### PR TITLE
fix configuration directory on OSX

### DIFF
--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -706,7 +706,7 @@ char* FindConfigFile(char *name)
 
 void LoadConfigFile()
 {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
 	// Get home dir
 	char buf[1024];
 	struct stat s;
@@ -734,7 +734,7 @@ void LoadConfigFile()
 
 void SaveConfigFile()
 {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
 	// Get home dir
 	char buf[1024];
 	struct stat s;


### PR DESCRIPTION
I'm probably going to push more commits to this PR soon, in particular to fix the Esc key, maybe other stuff.

Write vbam.ini to ~/Library/Application Support/vbam on OSX.

Do not create ~/.vbam on OSX in common/ConfigManager.cpp .

Make get_config_path and wxvbamApp::GetConfigurationPath return
directories with a writable parent in reverse search order when no
writable directories in the current search order are available since the
directory is created in OnInit.

This prefers to create the user-local directory and write the vbam.ini
there.