### PR TITLE
Edit sdlStateName, fixing SDL states on a Mac

### DIFF
--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -641,7 +641,7 @@ static char * sdlStateName(int num)
 {
   static char stateName[2048];
 
-  if(saveDir)
+  if(saveDir && strlen(saveDir))
     sprintf(stateName, "%s/%s%d.sgm", saveDir, sdlGetFilename(filename),
             num+1);
   else if (homeDir)


### PR DESCRIPTION
Previously this function returned true for `if(saveDir)` when `saveDir` was simply a zero length string following a branch that returned `/<savepath>` which doesn't work when the user isn't a root user.