### PR TITLE
Fix a casting error in GCC 6

### DIFF
--- a/fex/fex/blargg_common.h
+++ b/fex/fex/blargg_common.h
@@ -12,7 +12,7 @@
 typedef const char *blargg_err_t; // 0 on success, otherwise error string
 
 // Success; no error
-int const blargg_ok = 0;
+#define blargg_ok NULL
 
 // BLARGG_RESTRICT: equivalent to C99's restrict, where supported
 #if __GNUC__ >= 3 || _MSC_VER >= 1100


### PR DESCRIPTION
This PR fixes several instances of a casting/conversion error in GCC6
`error: invalid conversion from 'int' to 'blargg_err_t {aka const char*}' [-fpermissive]`

Unrelated: I see you're working on changing all the instances of `u8` to `uint8_t` and such, but your last commit was on the 9th. If you'd like, I can take a shot at getting the master branch into a compilable state until you can resume work.