### PR TITLE
Set requirement to C++11 in cmake 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # The project's name is VBA-M it uses C and C++ code
 PROJECT(VBA-M C CXX)
 
-cmake_minimum_required( VERSION 2.6.0 )
+cmake_minimum_required( VERSION 3.1.0 )
 if( COMMAND cmake_policy )
     cmake_policy( SET CMP0003 NEW )
     cmake_policy( SET CMP0005 OLD )
@@ -491,6 +491,8 @@ ADD_LIBRARY (
     ${SRC_DEBUGGER}
     ${HDR_DEBUGGER}
 )
+set_property(TARGET vbamcore PROPERTY CXX_STANDARD 11)
+set_property(TARGET vbamcore PROPERTY CXX_STANDARD_REQUIRED ON)
 
 IF( ENABLE_SDL )
     ADD_EXECUTABLE (
@@ -499,6 +501,8 @@ IF( ENABLE_SDL )
         ${SRC_SDL}
         ${HDR_SDL}
     )
+    set_property(TARGET vbam PROPERTY CXX_STANDARD 11)
+    set_property(TARGET vbam PROPERTY CXX_STANDARD_REQUIRED ON)
 
     IF( WIN32 )
         SET( WIN32_LIBRARIES wsock32 )


### PR DESCRIPTION
Currently, the build is broken on Linux as fixed width integers (for example uint32) are used via <cstdint> without a namespace. This is officially only allowed in C++11 and later.

See http://en.cppreference.com/w/cpp/types/integer for details.

Without the commit, I am currently forced to set my CXX_FLAGS to include "-std=c++11" if I don't want to get those errors:

```
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/include/g++-v4/cstdint:35:0,
                 from /workspace/visualboyadvance-m/src/System.h:4,
                 from /workspace/visualboyadvance-m/src/Util.cpp:23:
/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.3/include/g++-v4/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
In file included from /workspace/visualboyadvance-m/src/Util.cpp:23:0:
/workspace/visualboyadvance-m/src/System.h:54:27: error: variable or field ‘systemGbPrint’ declared void
 extern void systemGbPrint(uint8_t *, int, int, int, int, int);
                           ^
/workspace/visualboyadvance-m/src/System.h:54:27: error: ‘uint8_t’ was not declared in this scope
/workspace/visualboyadvance-m/src/System.h:54:36: error: expected primary-expression before ‘,’ token
 extern void systemGbPrint(uint8_t *, int, int, int, int, int);
                                    ^
/workspace/visualboyadvance-m/src/System.h:54:38: error: expected primary-expression before ‘int’
 extern void systemGbPrint(uint8_t *, int, int, int, int, int);
                                      ^
/workspace/visualboyadvance-m/src/System.h:54:43: error: expected primary-expression before ‘int’
 extern void systemGbPrint(uint8_t *, int, int, int, int, int);
                                           ^
/workspace/visualboyadvance-m/src/System.h:54:48: error: expected primary-expression before ‘int’
 extern void systemGbPrint(uint8_t *, int, int, int, int, int);
                                                ^
/workspace/visualboyadvance-m/src/System.h:54:53: error: expected primary-expression before ‘int’
 extern void systemGbPrint(uint8_t *, int, int, int, int, int);
                                                     ^
/workspace/visualboyadvance-m/src/System.h:54:58: error: expected primary-expression before ‘int’
 extern void systemGbPrint(uint8_t *, int, int, int, int, int);
                                                          ^
```