### PR TITLE
Small change: make `.clang-format` use C++11 Standard

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -83,7 +83,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp03
+Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
 ...


### PR DESCRIPTION
I noticed this very small discrepancy, and so I changed it.  The `CMakeLists` is already using C++11 standard, but the `.clang-format` was not.
