### PR TITLE
improve OpenAL support on Mac and make it default

### DIFF
--- a/src/wx/openal.cpp
+++ b/src/wx/openal.cpp
@@ -350,7 +350,7 @@ bool OpenAL::LoadOAL()
 #else
 #ifdef __WXMAC__
         // on macosx, it's just plain OpenAL
-        !Lib.Load(wxT("OpenAL"), wxDL_NOW | wxDL_VERBATIM) &&
+        !Lib.Load(wxT("/System/Library/Frameworks/OpenAL.framework/Versions/A/OpenAL"), wxDL_NOW | wxDL_VERBATIM) &&
 #endif
 #endif
         // on linux, it's libopenal.so

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -273,6 +273,10 @@ opts_t::opts_t()
     frameSkip = -1;
 #ifdef __WXMSW__
     audio_api = AUD_DIRECTSOUND;
+#else
+#ifdef __WXMAC__
+    audio_api = AUD_OPENAL;
+#endif
 #endif
     video_scale = 3;
     retain_aspect = true;


### PR DESCRIPTION
Fix the dynamic library path for OpenAL to the framework included with
OS X.

Make option initialization set the AudioAPI to OpenAL on mac by default,
since SDL sound is currently completely broken.

There is a lot of stuttering, will have to look at that next.