### PR TITLE
rebind toggle fullscreen on mac

### DIFF
--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -230,7 +230,8 @@
       <object class="wxMenuItem" name="ToggleFullscreen">
         <label>Toggle _full screen</label>
         <bitmap platform="unix" stock_id="gtk-fullscreen"/>
-        <accel>F11</accel>
+        <accel platform="win|unix">F11</accel>
+        <accel platform="mac">RawCtrl+Ctrl+F</accel>
       </object>
       <object class="separator"/>
       <object class="wxMenuItem" name="EmulatorSpeedupToggle">


### PR DESCRIPTION
On OS X, the F11 key is by default bound to "show desktop", so is a poor
choice for the "ToggleFullscreen" accelerator.

The default key combo to take apps fullscreen should be Ctrl+Cmd+F
according to:

https://support.apple.com/kb/PH18744?locale=en_US

Fortunately, this was very easy to fix by using the "platform" attribute
in MainMenu.xrc .

NOTE: this does not give us "real" OS X fullscreen yet, where the app is
on its own space, like native fullscreen apps. In the future it would be
nice to add an option to do this.