### PR TITLE
Mac OS X HiDPI fixes + other misc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,11 @@ IF( NOT VERSION )
     endif(EXISTS ${PROJECT_SOURCE_DIR}/.git)
 ENDIF( NOT VERSION )
 
-
+IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    ADD_DEFINITIONS(-DDEBUG)
+ELSE()
+    ADD_DEFINITIONS(-NDEBUG)
+ENDIF()
 
 # Fill in SDLMAIN_LIBRARY on OS X manually to avoid using SDLMain.m
 # OS X users will have to compile and install SDL from source.
@@ -68,18 +72,38 @@ if( APPLE AND ENABLE_SDL )
     SET(SDL2MAIN_LIBRARY "-lSDL2main")
 endif( APPLE AND ENABLE_SDL )
 
-# Add support for MacPorts and Homebrew on OS X
-# and ObjectiveC code
+# Add support for Homebrew, MacPorts and Fink on OS X
+# as well as for ObjectiveC code
 IF(APPLE)
-    SET(CMAKE_INCLUDE_PATH "${CMAKE_INCLUDE_PATH};/usr/local/include;/opt/local/include")
-    SET(CMAKE_LIBRARY_PATH "${CMAKE_LIBRARY_PATH};/usr/local/lib;/opt/local/lib")
-    SET(CMAKE_PROGRAM_PATH "${CMAKE_PROGRAM_PATH};/usr/local/bin;/opt/local/bin")
+    IF(EXISTS /usr/local/include)
+        SET(CMAKE_INCLUDE_PATH "${CMAKE_INCLUDE_PATH};/usr/local/include")
+        INCLUDE_DIRECTORIES("/usr/local/include")
+    ELSEIF(EXISTS /opt/local/include)
+        SET(CMAKE_INCLUDE_PATH "${CMAKE_INCLUDE_PATH};/opt/local/include")
+        INCLUDE_DIRECTORIES("/opt/local/include")
+    ELSEIF(EXISTS /sw/include)
+        SET(CMAKE_INCLUDE_PATH "${CMAKE_INCLUDE_PATH};/sw/include")
+        INCLUDE_DIRECTORIES("/sw/include")
+    ENDIF()
 
-    link_directories("/usr/local/lib")
-    include_directories("/usr/local/include")
+    IF(EXISTS /usr/local/lib)
+        SET(CMAKE_LIBRARY_PATH "${CMAKE_LIBRARY_PATH};/usr/local/lib")
+        LINK_DIRECTORIES("/usr/local/lib")
+    ELSEIF(EXISTS /opt/local/lib)
+        SET(CMAKE_LIBRARY_PATH "${CMAKE_LIBRARY_PATH};/opt/local/lib")
+        LINK_DIRECTORIES("/opt/local/lib")
+    ELSEIF(EXISTS /sw/lib)
+        SET(CMAKE_LIBRARY_PATH "${CMAKE_LIBRARY_PATH};/sw/lib")
+        LINK_DIRECTORIES("/sw/lib")
+    ENDIF()
 
-    link_directories("/opt/local/lib")
-    include_directories("/opt/local/include")
+    IF(EXISTS /usr/local/bin)
+        SET(CMAKE_PROGRAM_PATH "${CMAKE_PROGRAM_PATH};/usr/local/bin")
+    ELSEIF(EXISTS /opt/local/bin)
+        SET(CMAKE_PROGRAM_PATH "${CMAKE_PROGRAM_PATH};/opt/local/bin")
+    ELSEIF(EXISTS /sw/bin)
+        SET(CMAKE_PROGRAM_PATH "${CMAKE_PROGRAM_PATH};/sw/bin")
+    ENDIF()
 
     # and compile as Objective-C++ for ObjectiveC #ifdefs
     SET(CMAKE_CXX_COMPILE_OBJECT "<CMAKE_CXX_COMPILER> -x objective-c++ <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>")

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -29,10 +29,15 @@ else(ENABLE_OPENAL)
     ADD_DEFINITIONS (-DNO_OAL)
 endif(ENABLE_OPENAL)
 
+IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    SET(wxWidgets_USE_DEBUG ON) # noop if wx is compiled with --disable-debug, like in Mac Homebrew atm
 
-IF(CMAKE_BUILD_TYPE EQUAL "Debug")
-    SET(wxWidgets_USE_DEBUG ON)
+    # and if this is the case, we can't set debug level without link failing
+    IF(NOT wxWidgets_DEFINITIONS MATCHES "-DwxDEBUG_LEVEL=0")
+        ADD_DEFINITIONS(-DwxDEBUG_LEVEL=1)
+    ENDIF()
 ENDIF()
+
 SET(wxWidgets_USE_UNICODE ON)
 # adv is for wxAboutBox
 # xml, html is for xrc

--- a/src/wx/drawing.h
+++ b/src/wx/drawing.h
@@ -47,13 +47,11 @@ protected:
     {
         PaintEv(ev);
     }
-    void OnSize(wxSizeEvent&);
     void DrawArea(wxWindowDC& dc);
-#if wxCHECK_VERSION(2, 9, 0) || !defined(__WXMAC__)
-    wxGLContext ctx;
+#if wxCHECK_VERSION(2, 9, 0)
+    wxGLContext* ctx;
 #endif
-    bool did_init;
-    void Init();
+    void DrawingPanelInit();
     GLuint texid, vlist;
     int texsize;
 
@@ -81,8 +79,7 @@ protected:
         PaintEv(ev);
     }
     void DrawArea(wxWindowDC&);
-    bool did_init;
-    void Init();
+    void DrawingPanelInit();
 
     DECLARE_CLASS()
     DECLARE_EVENT_TABLE()

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2522,6 +2522,8 @@ bool MainFrame::BindControls()
         return false;
     }
 
+    panel->SetMainFrame(this);
+
     panel->AdjustSize(false);
     // only the panel does idle events (the emulator loop)
     // however, do not enable until end of init, since errors will start

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -18,7 +18,7 @@ extern struct opts_t {
     wxVideoMode fs_mode;
     int max_threads;
     int render_method;
-    int video_scale;
+    double video_scale;
     bool retain_aspect;
     bool keep_on_top;
 
@@ -90,11 +90,13 @@ extern struct opt_desc {
     wxString* stropt;
     int* intopt;
     const wxChar* enumvals;
-    int min, max;
+    double min, max;
     bool* boolopt;
+    double* doubleopt;
     // current configured value
     wxString curstr;
     int curint;
+    double curdouble;
 #define curbool curint
 } opts[];
 extern const int num_opts;


### PR DESCRIPTION
Use a high-res surface on HiDPI (e.g. retina) Macs for the OpenGL
renderer, and scale window accordingly. Also fix fullscreen toggle not
working in HiDPI mode. And some other stuff.

Aside from the .app not being linked statically, the app is now fully
functional on Mac and ready to ship.

Full change details:

* add -DDEBUG or -DNDEBUG based on CMAKE_RELEASE_TYPE

* properly search for homebrew/macports/fink directories, and only add
  them if they exist

* fix building with wx debug support, when available

* use explicit OpenGL context on Mac too for new versions of wx

* add main_frame pointer in GameArea back to MainFrame, and a
  SetMainFrame(MainFrame* parent) public method to set it in guinit

* add full support for reading and writing double value config options
  (the GUI still needs to be updated for options that can take doubles,
  such as video_scale)

* change video_scale option (Display/Scale) to a double, putting a
  double value such as 3.6 in the config file works correctly

* add a HiDPIAware mixin class for GameArea and DrawingPanel, with the
  method HiDPIScaleFactor which returns the current window's
  backingScaleFactor

* change the GameArea sizing methods (DelBorder(), AdjustMinSize() and
  AdjustSize()) to divide the window size by the
  HiDPIAware::HiDPIScaleFactor so that the window is scaled properly

* change GameArea::ShowFullScreen to ignore fullscreen events for a
  maximized window on Mac, because maximized windows on OS X are
  actually native fullscreen windows

* change scale variables to double from int, and use std::ceil() to
  round scaled pixel or memory size values

* make a default base class DrawingPane::DrawingPanelInit() virtual
  method, call by all concrete class constructors based on the did_init
  flag

* call setWantsBestResolutionOpenGLSurface:YES on the view backing the
  wxGLCanvas for the OpenGL renderer (GLDrawingPanel) to get a high res
  OpenGL surface in HiDPI mode

* remove GLDrawingPanel::OnSize event, the OpenGL viewport resizes
  automatically without the need to call glViewport()

* do not hide the mouse pointer if the main frame has menus or dialogs
  open

* add variadic vbamDebug(const char* format, ...) function, active only
  #ifdef DEBUG, which sets the wx log target to STDERR and logs a
  message to it

* use full name of app "visualboyadvance-m" instead of "vbam" when
  getting configuration paths, this way the config is saved to
  ~/Library/Application Support/visualboyadvance-m rather than
  ~/Library/Application Support/vbam

* listen to the MENU_HIGHLIGHT_ALL event as well, as an extra way to
  check when the menus are open

* add public MainFrame::SetMenusOpened(bool state) method to force the
  main frame to change the internal menus_opened state, this is
  necessary because in HiDPI mode on Mac the keyboard accelerator for
  toggle fullscreen sends a menu open event, but not a menu close event,
  so on switch to fullscreen the state is changed to menus closed and
  the emu is unpaused

TODO:

* GUI option to change toggle fullscreen behavior between native and
  non-native fullscreen on Mac

* GUI support for double config values like Display/Scale

* add HiDPI support to simple renderer

* fix SDL sound, or disable the option

* fix Cairo suport on Mac, or disable the option

* use dynamic_cast<> to implement GetWindow() for DrawingPanel instead
  of pure virtual method, likewise for Delete()

* link .app statically by default so it can be shipped

* add Homebrew formula