### PR TITLE
fix backcompat on unix for config brkn in 7a7a72f

### DIFF
--- a/src/wx/drawing.h
+++ b/src/wx/drawing.h
@@ -6,14 +6,6 @@
 class BasicDrawingPanel : public DrawingPanel, public wxPanel {
 public:
     BasicDrawingPanel(wxWindow* parent, int _width, int _height);
-    wxWindow* GetWindow()
-    {
-        return this;
-    }
-    void Delete()
-    {
-        Destroy();
-    }
 
 protected:
     void PaintEv2(wxPaintEvent& ev)
@@ -33,14 +25,6 @@ class GLDrawingPanel : public DrawingPanel, public wxGLCanvas {
 public:
     GLDrawingPanel(wxWindow* parent, int _width, int _height);
     virtual ~GLDrawingPanel();
-    wxWindow* GetWindow()
-    {
-        return this;
-    }
-    void Delete()
-    {
-        Destroy();
-    }
 
 protected:
     void PaintEv2(wxPaintEvent& ev)
@@ -64,14 +48,6 @@ protected:
 class DXDrawingPanel : public DrawingPanel, public wxPanel {
 public:
     DXDrawingPanel(wxWindow* parent, int _width, int _height);
-    wxWindow* GetWindow()
-    {
-        return this;
-    }
-    void Delete()
-    {
-        Destroy();
-    }
 
 protected:
     void PaintEv2(wxPaintEvent& ev)
@@ -93,14 +69,6 @@ class CairoDrawingPanel : public DrawingPanel, public wxPanel {
 public:
     CairoDrawingPanel(wxWindow* parent, int _width, int _height);
     ~CairoDrawingPanel();
-    wxWindow* GetWindow()
-    {
-        return this;
-    }
-    void Delete()
-    {
-        Destroy();
-    }
 
 protected:
     void PaintEv2(wxPaintEvent& ev)

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -53,7 +53,11 @@ static void get_config_path(wxPathList& path, bool exists = true)
 {
     // we want paths with "visualboyadvance-m" not "vbam", so change appname temporarily
     wxString current_app_name = wxGetApp().GetAppName();
+
+    // keep config path as ~/.vbam on UNIX for now for backcompat
+#if defined(__WXMSW__) || defined(__WXMAC__)
     wxGetApp().SetAppName(_("visualboyadvance-m"));
+#endif
 
     //   local config dir first, then global
     //   locale-specific res first, then main

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -628,9 +628,11 @@ public:
     DrawingPanel(int _width, int _height);
     ~DrawingPanel();
     void DrawArea(uint8_t** pixels);
-    // the following wouldn't be necessary with virtual inheritance
-    virtual wxWindow* GetWindow() = 0;
-    virtual void Delete() = 0;
+
+    // using dynamic_cast<> to not force trivial reimplementation in concrete classes
+    // TODO: figure something out for PaintEv as well
+    virtual wxWindow* GetWindow() { return dynamic_cast<wxWindow*>(this); }
+    virtual void Delete() { (dynamic_cast<wxWindow*>(this))->Destroy(); }
 
 protected:
     virtual void DrawArea(wxWindowDC&) = 0;


### PR DESCRIPTION
Only load config files with the app name set to "visualboyadvance-m" on
Windows and Mac, on unix keep the default of "vbam" for now so that
users' ~/.vbam directories are found correctly.

TODO:

* migrate all of this properly to XDG paths on unix, giving users the
  option to move their config