### PR TITLE
Fix namespace issue, missing parenthesis, missing function

### DIFF
--- a/src/gtk/CMakeLists.txt
+++ b/src/gtk/CMakeLists.txt
@@ -47,7 +47,7 @@ SET(SRC_GTK
     soundconfig.cpp
     screenarea.cpp
     screenarea-cairo.cpp
-    #screenarea-opengl.cpp
+    screenarea-opengl.cpp
     tools.cpp
     window.cpp
     ../sdl/inputSDL.cpp

--- a/src/gtk/screenarea.cpp
+++ b/src/gtk/screenarea.cpp
@@ -49,7 +49,7 @@ ScreenArea::ScreenArea(int _iWidth, int _iHeight, int _iScale)
     pixbuf->fill(0);
 
 #if !GTK_CHECK_VERSION(3, 0, 0)
-    m_poEmptyCursor = new Gdk::Cursor(get_display, pixbuf, 0, 0);
+    m_poEmptyCursor = new Gdk::Cursor(get_display(), pixbuf, 0, 0);
 #else
     m_poEmptyCursor = Gdk::Cursor::create(get_display(), pixbuf, 0, 0);
 #endif

--- a/src/sdl/expr.cpp
+++ b/src/sdl/expr.cpp
@@ -85,14 +85,10 @@ enum yytokentype {
 /* Copy the first part of user declarations.  */
 #line 1 "expr.ypp"
 
-namespace std {
 #include <memory.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-}
-
-using namespace std;
+#include <cstdlib>
 
 #include "../System.h"
 #include "../gba/elf.h"

--- a/src/sdl/expr.ypp
+++ b/src/sdl/expr.ypp
@@ -1,13 +1,9 @@
 %{
-namespace std {  
 #include <stdio.h>
 #include <memory.h>
-#include <stdlib.h>
 #include <string.h>
-}
+#include <cstdlib>
 
-using namespace std;
- 
 #include "../System.h"
 #include "../gba/elf.h"
 #include "exprNode.h" 


### PR DESCRIPTION
Hello!

I was trying to compile visualboyadvance-m in arch linux from v2.0.0 tag and I was having some issues. This was what I had to change to be able to compile.

This is the commands I've been using:

```
$ CXXFLAGS+=' -std=c++11 -fpermissive'
$ cmake . -DCMAKE_BUILD_TYPE='Release' \
              -DCMAKE_INSTALL_PREFIX='/usr' \
              -DCMAKE_SKIP_RPATH='TRUE' \
              -DENABLE_GTK='TRUE' \
              -DENABLE_WX='TRUE' \
              -DENABLE_FFMPEG='FALSE' \
              -DENABLE_LINK='TRUE'
$ make
```

Also, my gcc version:

```
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/6.2.1/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++ --enable-shared --enable-threads=posix --enable-libmpx --with-system-zlib --with-isl --enable-__cxa_atexit --disable-libunwind-exceptions --enable-clocale=gnu --disable-libstdcxx-pch --disable-libssp --enable-gnu-unique-object --enable-linker-build-id --enable-lto --enable-plugin --enable-install-libiberty --with-linker-hash-style=gnu --enable-gnu-indirect-function --disable-multilib --disable-werror --enable-checking=release
Thread model: posix
gcc version 6.2.1 20160830 (GCC)
```

Since some of these changes were already done in master, I'm submitting this PR for your evaluation in order to see if these are the expected changes or if I should go another way.

