### PR TITLE
fix DisplayConfig panel brkn in 7a7a72f

### DIFF
--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2899,6 +2899,11 @@ bool MainFrame::BindControls()
         tc = SafeXRCCTRL<wxTextCtrl>(d, n);                   \
         tc->SetValidator(wxTextValidator(wxFILTER_NONE, &o)); \
     } while (0)
+#define getgtc(n, o)                                          \
+    do {                                                      \
+        tc = SafeXRCCTRL<wxTextCtrl>(d, n);                   \
+        tc->SetValidator(wxGenericValidator(&o));             \
+    } while (0)
 #ifndef NO_LINK
         {
             net_link_handler.dlg = d;
@@ -3294,7 +3299,7 @@ bool MainFrame::BindControls()
             /// Zoom
             // this was a choice, but I'd rather not have to make an off-by-one
             // validator just for this, and spinctrl is good enough.
-            getsc("DefaultScale", gopts.video_scale);
+            getgtc("DefaultScale", gopts.video_scale);
             getsc("MaxScale", maxScale);
             /// Advanced
             getrbi("OutputSimple", gopts.render_method, RND_SIMPLE);

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1041,6 +1041,10 @@ void GameArea::OnIdle(wxIdleEvent& event)
 
         if (pointer_blanked)
             w->SetCursor(wxCursor(wxCURSOR_BLANK));
+
+        // if user changed Display/Scale config, this needs to run
+        AdjustMinSize();
+        AdjustSize(false);
     }
 
     if (!paused && (!pauseWhenInactive || wxGetApp().frame->HasFocus())) {

--- a/src/wx/xrc/DisplayConfig.xrc
+++ b/src/wx/xrc/DisplayConfig.xrc
@@ -106,9 +106,7 @@
                 <border>5</border>
               </object>
               <object class="sizeritem">
-                <object class="wxSpinCtrl" name="DefaultScale">
-                  <min>1</min>
-                  <max>6</max>
+                <object class="wxTextCtrl" name="DefaultScale">
                 </object>
                 <option>1</option>
                 <flag>wxALL|wxEXPAND</flag>


### PR DESCRIPTION
Change the Scale control in the DisplayConfig dialog from a SpinCtrl to
a TextCtrl (for a simple text field) because GenericValidator does not
support using a double* with a SpinCtrl.

Also force adjustment on minimum size and resize the window when
necessary on panel creation, so that when the user sets the value
higher, the window size automatically adjusts.