### PR TITLE
fix kbd controls on Mac + misc.

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -247,8 +247,12 @@ if(APPLE)
     SET(MACOSX_BUNDLE_ICON_FILE ${VBAM_ICON})
     SET_SOURCE_FILES_PROPERTIES(${VBAM_ICON_PATH} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
-    ADD_CUSTOM_COMMAND(TARGET visualboyadvance-m POST_BUILD
-        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/osx/third_party_libs_tool "$<TARGET_FILE_DIR:visualboyadvance-m>/../..")
+    # budle dylibs and relink them for releasing .app
+    # but only in Release mode
+    IF(CMAKE_BUILD_TYPE STREQUAL "Release")
+        ADD_CUSTOM_COMMAND(TARGET visualboyadvance-m POST_BUILD
+            COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/osx/third_party_libs_tool "$<TARGET_FILE_DIR:visualboyadvance-m>/../..")
+    ENDIF()
 endif(APPLE)
 
 SET(WX_EXE_NAME visualboyadvance-m-wx${CMAKE_EXECUTABLE_SUFFIX})

--- a/src/wx/drawing.h
+++ b/src/wx/drawing.h
@@ -8,14 +8,9 @@ public:
     BasicDrawingPanel(wxWindow* parent, int _width, int _height);
 
 protected:
-    void PaintEv2(wxPaintEvent& ev)
-    {
-        PaintEv(ev);
-    }
     void DrawArea(wxWindowDC& dc);
 
     DECLARE_CLASS()
-    DECLARE_EVENT_TABLE()
 };
 
 #ifndef NO_OGL
@@ -27,10 +22,6 @@ public:
     virtual ~GLDrawingPanel();
 
 protected:
-    void PaintEv2(wxPaintEvent& ev)
-    {
-        PaintEv(ev);
-    }
     void DrawArea(wxWindowDC& dc);
 #if wxCHECK_VERSION(2, 9, 0)
     wxGLContext* ctx;
@@ -40,7 +31,6 @@ protected:
     int texsize;
 
     DECLARE_CLASS()
-    DECLARE_EVENT_TABLE()
 };
 #endif
 
@@ -50,15 +40,10 @@ public:
     DXDrawingPanel(wxWindow* parent, int _width, int _height);
 
 protected:
-    void PaintEv2(wxPaintEvent& ev)
-    {
-        PaintEv(ev);
-    }
     void DrawArea(wxWindowDC&);
     void DrawingPanelInit();
 
     DECLARE_CLASS()
-    DECLARE_EVENT_TABLE()
 };
 #endif
 
@@ -71,15 +56,10 @@ public:
     ~CairoDrawingPanel();
 
 protected:
-    void PaintEv2(wxPaintEvent& ev)
-    {
-        PaintEv(ev);
-    }
     void DrawArea(wxWindowDC&);
     cairo_surface_t* conv_surf;
 
     DECLARE_CLASS()
-    DECLARE_EVENT_TABLE()
 };
 #endif
 

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -293,7 +293,10 @@ opts_t::opts_t()
     if (max_threads < 0)
         max_threads = 2;
 
-    audio_buffers = 5;
+    // 10 fixes stuttering on mac with openal, as opposed to 5
+    // also should be better for modern hardware in general
+    audio_buffers = 10;
+
     sound_en = 0x30f;
     sound_vol = 100;
     sound_qual = 1;

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -71,13 +71,19 @@ static void get_config_path(wxPathList& path, bool exists = true)
             path.Add(s);                                                                                     \
     } while (0)
 
-    vbamDebug("GetUserLocalDataDir(): %s", static_cast<const char*>(stdp.GetUserLocalDataDir().utf8_str()));
-    vbamDebug("GetUserDataDir(): %s", static_cast<const char*>(stdp.GetUserDataDir().utf8_str()));
-    vbamDebug("GetLocalizedResourcesDir(wxGetApp().locale.GetCanonicalName()): %s", static_cast<const char*>(stdp.GetLocalizedResourcesDir(wxGetApp().locale.GetCanonicalName()).utf8_str()));
-    vbamDebug("GetResourcesDir(): %s", static_cast<const char*>(stdp.GetResourcesDir().utf8_str()));
-    vbamDebug("GetDataDir(): %s", static_cast<const char*>(stdp.GetDataDir().utf8_str()));
-    vbamDebug("GetLocalDataDir(): %s", static_cast<const char*>(stdp.GetLocalDataDir().utf8_str()));
-    vbamDebug("GetPluginsDir(): %s", static_cast<const char*>(stdp.GetPluginsDir().utf8_str()));
+    static bool debug_dumped = false;
+
+    if (!debug_dumped) {
+        vbamDebug("GetUserLocalDataDir(): %s", static_cast<const char*>(stdp.GetUserLocalDataDir().utf8_str()));
+        vbamDebug("GetUserDataDir(): %s", static_cast<const char*>(stdp.GetUserDataDir().utf8_str()));
+        vbamDebug("GetLocalizedResourcesDir(wxGetApp().locale.GetCanonicalName()): %s", static_cast<const char*>(stdp.GetLocalizedResourcesDir(wxGetApp().locale.GetCanonicalName()).utf8_str()));
+        vbamDebug("GetResourcesDir(): %s", static_cast<const char*>(stdp.GetResourcesDir().utf8_str()));
+        vbamDebug("GetDataDir(): %s", static_cast<const char*>(stdp.GetDataDir().utf8_str()));
+        vbamDebug("GetLocalDataDir(): %s", static_cast<const char*>(stdp.GetLocalDataDir().utf8_str()));
+        vbamDebug("GetPluginsDir(): %s", static_cast<const char*>(stdp.GetPluginsDir().utf8_str()));
+        
+        debug_dumped = true;
+    }
 
     // NOTE: this does not support XDG (freedesktop.org) paths
     add_path(GetUserLocalDataDir());
@@ -591,10 +597,16 @@ EVT_CONTEXT_MENU(MainFrame::OnMenu)
 EVT_ACTIVATE(MainFrame::OnActivate)
 // requires DragAcceptFiles(true); even then may not do anything
 EVT_DROP_FILES(MainFrame::OnDropFile)
+
 // pause game if menu pops up
+//
+// this causes problems with keyboard game keys on mac, disable for now
+#ifndef __WXMAC__
 EVT_MENU_OPEN(MainFrame::MenuPopped)
 EVT_MENU_CLOSE(MainFrame::MenuPopped)
 EVT_MENU_HIGHLIGHT_ALL(MainFrame::MenuPopped)
+#endif
+
 END_EVENT_TABLE()
 
 void MainFrame::OnActivate(wxActivateEvent& event)

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -630,10 +630,10 @@ public:
     void DrawArea(uint8_t** pixels);
 
     // using dynamic_cast<> to not force trivial reimplementation in concrete classes
-    // TODO: figure something out for PaintEv as well
     virtual wxWindow* GetWindow() { return dynamic_cast<wxWindow*>(this); }
     virtual void Delete() { (dynamic_cast<wxWindow*>(this))->Destroy(); }
 
+    void PaintEv(wxPaintEvent& ev);
 protected:
     virtual void DrawArea(wxWindowDC&) = 0;
     virtual void DrawOSD(wxWindowDC&);
@@ -650,13 +650,6 @@ protected:
     const RENDER_PLUGIN_INFO* rpi; // also flag indicating plugin loaded
     // largest buffer required is 32-bit * (max width + 1) * (max height + 2)
     uint8_t delta[257 * 4 * 226];
-
-    // following can't work in 2.8 as intended
-    // inheriting from wxEvtHandler is required, but also breaks subclasses
-    // due to lack of virtual inheritance (2.9 drops wxEvtHandler req)
-    // so each child must have a paint event handler (not override of this,
-    // but it's not virtual anyway, so that won't happen) that calls this
-    void PaintEv(wxPaintEvent& ev);
 
     DECLARE_ABSTRACT_CLASS()
 };


### PR DESCRIPTION
After creating the drawing panel, call SetFocus() on it and use
Connect() to bind keyboard events from it. Add the wxWANTS_CHARS flag to
all DrawingArea subclasses so that wxEVT_CHAR_HOOK can be used instead
of wxEVT_KEY_DOWN, because it is more general and catches more keys.

Change the process_key_press function to return a bool indicating
whether a game control is currently pressed or not, this is used in the
key events to determine whether the event should be propagated or not.
If in a game key, do not propagate the event, otherwise it hits one of
the other controls and generates a beep sound.

The menu open/closed/highlighted events had to be turned off for Mac,
because the menubar is catching all keyboard events for some reason even
before they reach the drawing panel event handler. So on Mac the game
will not be paused when the menu is being used, this is not really a big
deal and can be fixed later.

Other improvements:

* do not bundle and link dylibs when CMAKE_BUILD_TYPE is not "Release",
  this makes for quicker debug builds

* finally make a generic PaintEv for the DrawingPanel abstract base
  class using dynamic_cast<> and Bind(), unfortunately this is not wx
  2.8 compatible

* set the default audio_buffers to 10 instead of 5, this completely or
  almost completely fixes sound stuttering during normal game play on
  Mac with OpenAL

* spew path info on startup only once