### PR TITLE
Mac OS X 10.7 (Lion) build and runtime support

### DIFF
--- a/src/System.h
+++ b/src/System.h
@@ -1,7 +1,7 @@
 #ifndef SYSTEM_H
 #define SYSTEM_H
 
-#include <cstdint>
+#include "common/cstdint.h"
 
 #ifndef __LIBRETRO__
 #include <zlib.h>

--- a/src/common/Patch.h
+++ b/src/common/Patch.h
@@ -1,7 +1,7 @@
 #ifndef PATCH_H
 #define PATCH_H
 
-#include <cstdint>
+#include "cstdint.h"
 
 bool applyPatch(const char *patchname, uint8_t **rom, int *size);
 

--- a/src/common/Port.h
+++ b/src/common/Port.h
@@ -1,7 +1,7 @@
 #ifndef PORT_H
 #define PORT_H
 
-#include <cstdint>
+#include "cstdint.h"
 
 #ifdef __CELLOS_LV2__
 /* PlayStation3 */

--- a/src/common/cstdint.h
+++ b/src/common/cstdint.h
@@ -1,0 +1,13 @@
+#if defined(__has_include)
+#   if __has_include(<cstdint>)
+#       include <cstdint>
+// necessary on Mac OS X Lion 10.7 or any clang <= 3.0
+#   elif __has_include(<tr1/cstdint>)
+#       include <tr1/cstdint>
+#   else
+//      throw error
+#       include <cstdint>
+#   endif
+#else
+#   include <cstdint>
+#endif

--- a/src/gb/gbGlobals.cpp
+++ b/src/gb/gbGlobals.cpp
@@ -1,5 +1,5 @@
 #include <cstddef>
-#include <cstdint>
+#include "../common/cstdint.h"
 
 uint8_t* gbMemoryMap[16];
 

--- a/src/gb/gbGlobals.h
+++ b/src/gb/gbGlobals.h
@@ -1,7 +1,7 @@
 #ifndef GBGLOBALS_H
 #define GBGLOBALS_H
 
-#include <cstdint>
+#include "../common/cstdint.h"
 
 extern int gbRomSizeMask;
 extern int gbRomSize;

--- a/src/gb/gbMemory.h
+++ b/src/gb/gbMemory.h
@@ -1,7 +1,7 @@
 #ifndef GBMEMORY_H
 #define GBMEMORY_H
 
-#include <cstdint>
+#include "../common/cstdint.h"
 #include <time.h>
 
 struct mapperMBC1 {

--- a/src/gba/BreakpointStructures.h
+++ b/src/gba/BreakpointStructures.h
@@ -1,7 +1,7 @@
 #ifndef VBA_BKS_H
 #define VBA_BKS_H
 
-#include <cstdint>
+#include "../common/cstdint.h"
 
 #define readWord(addr) \
     ((map[(addr) >> 24].address[(addr)&map[(addr) >> 24].mask]) + ((map[(addr + 1) >> 24].address[(addr + 1) & map[(addr + 1) >> 24].mask]) << 8) + ((map[(addr + 2) >> 24].address[(addr + 2) & map[(addr + 2) >> 24].mask]) << 16) + ((map[(addr + 3) >> 24].address[(addr + 3) & map[(addr + 3) >> 24].mask]) << 24))

--- a/src/gba/EEprom.h
+++ b/src/gba/EEprom.h
@@ -1,7 +1,7 @@
 #ifndef EEPROM_H
 #define EEPROM_H
 
-#include <cstdint>
+#include "../common/cstdint.h"
 #include <zlib.h>
 
 #ifdef __LIBRETRO__

--- a/src/gba/Flash.h
+++ b/src/gba/Flash.h
@@ -1,7 +1,7 @@
 #ifndef FLASH_H
 #define FLASH_H
 
-#include <cstdint>
+#include "../common/cstdint.h"
 #include <zlib.h>
 
 #define FLASH_128K_SZ 0x20000

--- a/src/gba/GBA.h
+++ b/src/gba/GBA.h
@@ -1,7 +1,7 @@
 #ifndef GBA_H
 #define GBA_H
 
-#include <cstdint>
+#include "../common/cstdint.h"
 
 #include "../System.h"
 

--- a/src/gba/GBASockClient.h
+++ b/src/gba/GBASockClient.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include "../common/cstdint.h"
 #include <SFML/Network.hpp>
 
 class GBASockClient {

--- a/src/gba/Sram.h
+++ b/src/gba/Sram.h
@@ -1,7 +1,7 @@
 #ifndef SRAM_H
 #define SRAM_H
 
-#include <cstdint>
+#include "../common/cstdint.h"
 
 uint8_t sramRead(uint32_t address);
 void sramWrite(uint32_t address, uint8_t byte);

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -1,4 +1,4 @@
-#include <cstdint>
+#include "../common/cstdint.h"
 #include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #ifdef __APPLE__
+#include <OpenGL/OpenGL.h>
 #include <OpenGL/glext.h>
 #include <OpenGL/glu.h>
 #else

--- a/src/sdl/filters.h
+++ b/src/sdl/filters.h
@@ -19,7 +19,7 @@
 #ifndef VBA_SDL_FILTERS_H
 #define VBA_SDL_FILTERS_H
 
-#include <cstdint>
+#include "../common/cstdint.h"
 
 #include "../System.h"
 

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -22,7 +22,14 @@ double HiDPIAware::HiDPIScaleFactor()
 {
     if (hidpi_scale_factor == 0) {
 #ifdef __WXMAC__
-        hidpi_scale_factor = [[(NSView*)GetWindow()->GetHandle() window] backingScaleFactor];
+        NSWindow* window = [(NSView*)GetWindow()->GetHandle() window];
+
+        if ([window respondsToSelector:@selector(backingScaleFactor)]) {
+            hidpi_scale_factor = [window backingScaleFactor];
+        }
+        else {
+            hidpi_scale_factor = 1.0;
+        }
 #else
         hidpi_scale_factor = 1.0;
 #endif
@@ -2017,7 +2024,11 @@ GLDrawingPanel::GLDrawingPanel(wxWindow* parent, int _width, int _height)
     , DrawingPanel(_width, _height)
 {
 #ifdef __WXMAC__
-    [(NSView *)GetHandle() setWantsBestResolutionOpenGLSurface:YES];
+    NSView* view = (NSView*)GetHandle();
+
+    if ([view respondsToSelector:@selector(setWantsBestResolutionOpenGLSurface:)]) {
+        [view setWantsBestResolutionOpenGLSurface:YES];
+    }
 #endif
 #if wxCHECK_VERSION(2, 9, 0)
     ctx = new wxGLContext(this);

--- a/src/wx/tools/osx/third_party_libs_tool
+++ b/src/wx/tools/osx/third_party_libs_tool
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-version=0.1
+version=0.6
 
 main() {
     # parse options
@@ -32,7 +32,7 @@ main() {
 
     mktmp
 
-    app_bundle=$(echo "$1" | fully_resolve_links | sed 's,/*$,,')
+    app_bundle=$(echo "$1" | fully_resolve_links)
 
     case "$app_bundle" in
         *.app|*.APP)
@@ -146,10 +146,14 @@ lib_scan() {
 
 fully_resolve_links() {
     while read -r file; do
+        # get initial part for non-absolute path, or blank for absolute
+        path=${file%%/*}
+        # and set $file to the rest
+        file=${file#*/}
+
         OLDIFS=$IFS
         IFS='
 '
-        path=
         for part in $(echo "$file" | sed 's,^/*,,; s,/*$,,; s,//*,\
 ,g'); do
             path=$(resolve_link "$path/$part")
@@ -168,6 +172,9 @@ fully_resolve_links() {
             esac
         done
 
+        # remove trailing /s
+        path=$(echo "$path" | sed 's,/*$,,')
+
         echo "$path"
     done
 }
@@ -176,7 +183,7 @@ resolve_link() {
     file="$1"
 
     while [ -h "$file" ]; do
-        ls0=`ls -l "$file"`
+        ls0=`ls -ld "$file"`
         new_link=`expr "$ls0" : '.* -> \(.*\)$'`
         if expr "$new_link" : '/.*' > /dev/null; then
             file="$new_link"
@@ -234,9 +241,28 @@ relink() {
         head -1
     )
 
-    if [ -n "$lib_link_path" ]; then
-        install_name_tool -change "$lib_link_path" "@rpath/$lib_basename" "$target"
+    [ -z "$lib_link_path" ] && return 0
+
+    # check that the shorter basename is the prefix of the longer basename
+    # that is, the lib versions match
+    lib1=${lib_basename%.dylib}
+    lib2=${lib_link_path##*/}
+    lib2=${lib2%.dylib}
+
+    if [ "${#lib1}" -le "${#lib2}" ]; then
+        shorter=$lib1
+        longer=$lib2
+    else
+        shorter=$lib2
+        longer=$lib1
     fi
+
+    case "$longer" in
+        "$shorter"*)
+            # and if so, relink target to the lib
+            install_name_tool -change "$lib_link_path" "@rpath/$lib_basename" "$target"
+            ;;
+    esac
 }
 
 # try with sudo in case it fails,

--- a/src/wx/viewers.cpp
+++ b/src/wx/viewers.cpp
@@ -2,7 +2,7 @@
 // these are all the viewer dialogs except for the ones with graphical areas
 // they can be instantiated multiple times
 
-#include <cstdint>
+#include "../common/cstdint.h"
 
 #include "../gba/armdis.h"
 #include "viewsupt.h"


### PR DESCRIPTION
Make a custom cstdint.h header file that includes <tr1/cstdint> if
<cstdint> is not available, because the clang 3.x used on Lion does not
have it. Change all references to <cstdint> to use it instead.

Add missing OpenGL header for older OS X in sdl/SDL.cpp .

When calling HiDPI methods, use respondsToSelector: to check if the
methods are available first.

Fix the bundling/linking script to support multiple copies of the same
dylib with different versions. Necessary to include both the Lion system
libpng and the brew libpng. Including the system libpng is necessary
because it is removed in later versions of OS X.