### PR TITLE
fix wx kbd accels that are game key + modifier

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1214,12 +1214,12 @@ static bool process_key_press(bool down, int key, int mod, int joy = 0)
 
 void GameArea::OnKeyDown(wxKeyEvent& ev)
 {
-    ev.Skip(!process_key_press(true, ev.GetKeyCode(), 0 /* ev.GetModifiers() */));
+    ev.Skip(!process_key_press(true, ev.GetKeyCode(), ev.GetModifiers()));
 }
 
 void GameArea::OnKeyUp(wxKeyEvent& ev)
 {
-    ev.Skip(!process_key_press(false, ev.GetKeyCode(), 0 /* ev.GetModifiers() */));
+    ev.Skip(!process_key_press(false, ev.GetKeyCode(), ev.GetModifiers()));
 }
 
 void GameArea::OnSDLJoy(wxSDLJoyEvent& ev)

--- a/todo.md
+++ b/todo.md
@@ -5,7 +5,7 @@
 - [ ] Fix the libretro interface
 - [ ] Next will be removing the majority of the interface code and going straight libretro (Will make it easier to maintain one interface that's platform independent.
 - [ ] add OnSize handler for GLDrawingPanel in wx back to reset the GL viewport, and set viewport on init as well
-- [ ] fix wx accels that are a game key with a modifier, e.g. ALT+ENTER when ENTER is a game key 
+- [x] fix wx accels that are a game key with a modifier, e.g. ALT+ENTER when ENTER is a game key 
 - [ ] add an option to the video config dialog to choose native or non-native fullscreen for Mac (and check if the OS supports it)
 - [ ] fix SFML cmake stuff to detect brew SFML on Mac
 - [ ] update FindSDL2.cmake to use sdl2-config if available and pkg-config is not, get PR merged upstream


### PR DESCRIPTION
Pass the keyboard modifiers to process_key_press so that it only
registers a game key if the modifiers match. That is, if e.g. ENTER is a
game key, then ALT+ENTER gets passed to other Wx controls and does not
register as a game key.