### PR TITLE
SFML is required for link support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ if( ENABLE_LINK )
     if(WIN32)
         set(SFML_STATIC_LIBRARIES TRUE)
     endif(WIN32)
-    FIND_PACKAGE ( SFML 2 COMPONENTS network system )
+    FIND_PACKAGE ( SFML 2 COMPONENTS network system REQUIRED )
 endif( ENABLE_LINK )
 
 # set the standard libraries all ports use


### PR DESCRIPTION
Without this change, if you don't have SFML, it'll try to build and then fail because it can't find the SFML headers.