### PR TITLE
msys2 build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,15 @@ option( ENABLE_ASM_CORE "Enable x86 ASM CPU cores" OFF )
 option( ENABLE_ASM_SCALERS "Enable x86 ASM graphic filters" OFF )
 option( ENABLE_LINK "Enable GBA linking functionality" ON )
 option( ENABLE_LIRC "Enable LIRC support" OFF )
-option( ENABLE_FFMPEG "Enable ffmpeg A/V recording" ON )
+
+SET(FFMPEG_DEFAULT ON)
+
+IF((WIN32 AND NOT (MINGW AND MSYS)) OR APPLE)
+    SET(FFMPEG_DEFAULT OFF)
+ENDIF()
+
+option(ENABLE_FFMPEG "Enable ffmpeg A/V recording" ${FFMPEG_DEFAULT})
+
 if(ENABLE_ASM_SCALERS)
     option( ENABLE_MMX "Enable MMX" OFF )
 endif(ENABLE_ASM_SCALERS)
@@ -133,9 +141,10 @@ FIND_PACKAGE(SDL2 REQUIRED)
 ADD_DEFINITIONS(${SDL2_DEFINITIONS})
 
 if( ENABLE_LINK )
-    if(WIN32)
+    # msys2 does not have static sfml libs atm
+    if(WIN32 AND NOT (MINGW AND MSYS))
         set(SFML_STATIC_LIBRARIES TRUE)
-    endif(WIN32)
+    endif()
     FIND_PACKAGE ( SFML 2 COMPONENTS network system REQUIRED )
 endif( ENABLE_LINK )
 
@@ -221,7 +230,7 @@ ENDIF( NOT ENABLE_ASM_CORE )
 if( ENABLE_NLS )
     SET( LOCALEDIR ${CMAKE_INSTALL_PREFIX}/share/locale )
     ADD_DEFINITIONS ( -DENABLE_NLS )
-    ADD_DEFINITIONS ( -DLOCALEDIR=\\\"${LOCALEDIR}\\\" )
+    ADD_DEFINITIONS ( -DLOCALEDIR='"${LOCALEDIR}"' )
     # for now, only GBALink.cpp uses gettext() directly
     IF(APPLE)
         # use Homebrew gettext if available

--- a/installdeps-msys2
+++ b/installdeps-msys2
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+cd "$(dirname $0)"
+
+MINGW_DEPS='SDL2 cairo ffmpeg openal sfml wxWidgets zlib binutils cmake crt-git extra-cmake-modules gcc gcc-libs gdb headers-git make pkg-config tools-git windows-default-manifest libmangle-git'
+MINGW64_DEPS=
+MINGW32_DEPS=
+
+for dep in $MINGW_DEPS; do
+    MINGW64_DEPS="$MINGW64_DEPS mingw-w64-x86_64-$dep"
+    MINGW32_DEPS="$MINGW32_DEPS mingw-w64-i686-$dep"
+done
+
+echo '[32mInstalling deps....[0m'
+echo
+
+pacman --noconfirm --needed -Syuu git make zip $MINGW64_DEPS $MINGW32_DEPS
+
+git submodule update --init --recursive
+
+cat <<'EOF'
+
+[32mDone! To build do:[0m
+
+mkdir build
+cd build
+cmake .. -G 'MSYS Makefiles'
+make -j10
+EOF

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -12,7 +12,16 @@ if( WIN32 )
   option( ENABLE_DIRECT3D "Enable Direct3D rendering for the wxWidgets port" ON )
   option( ENABLE_XAUDIO2 "Enable xaudio2 sound output for the wxWidgets port" ON )
 endif( WIN32 )
+
 option( ENABLE_OPENAL "Enable OpenAL for the wxWidgets port" ON )
+
+IF(WIN32 AND MINGW)
+    IF(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../dependencies")
+        MESSAGE(FATAL_ERROR "Please run: git submodule update --init --recursive")
+    ENDIF()
+
+    INCLUDE_DIRECTORIES("${CMAKE_CURRENT_SOURCE_DIR}/../../dependencies/mingw-xaudio/include")
+ENDIF()
 
 IF(APPLE)
     ADD_DEFINITIONS(-DwxMAC_USE_CORE_GRAPHICS)
@@ -202,8 +211,6 @@ IF( WIN32 )
     IF(ENABLE_DEBUGGER)
         SET(DIRECTX_LIBRARIES ${DIRECTX_LIBRARIES} -lwsock32)
     ENDIF(ENABLE_DEBUGGER)
-ELSE( WIN32 )
-    SET(DIRECTX_LIBRARIES )
 ENDIF( WIN32 )
 
 link_directories( ${CMAKE_BINARY_DIR} )

--- a/todo.md
+++ b/todo.md
@@ -23,6 +23,11 @@
 - [ ] see what code we can steal from other emu folks, e.g. filters etc.
 - [ ] update config handling, to switch to XDG on linux etc.
 - [ ] add simple 'mute audio' option for wx interface
+- [ ] HiDPI support on Windows
+- [ ] ./installdeps for more platforms
+- [ ] console-mode Wx app on Windows in debug mode
+- [ ] fix keyboard game input on msys2 builds
+- [ ] fix the -D\*DIR defines to have the correct paths on various platforms
 
 # Coding Guidelines (for those that want to help out and send a pull request.)
 


### PR DESCRIPTION
* Enable ffmpeg by default only on linux and msys2, it will be disabled
for normal windows builds and on mac.

* Set SFML_STATIC_LIBRARIES only for normal non-msys2 windows builds,
because msys2 does not currently have static versions of the SFML
sub-libraries, e.g. system, network, etc.. Dynamic linking works fine
for now.

* Fix quoting for -DLOCALEDIR, on windows spaces were causing errors in
make on msys2.

* Update to upstream FindSFML.cmake .

* Add an ./installdeps-msys2 script to install all necessary tools and
libraries on msys2 for building both 64 and 32 bit windows Wx binaries.

* Add the dependencies/mingw-xaudio/include directory to
INCLUDE_DIRECTORIES so that XAudio compiles on msys2, as mingw-w64 does
not currently have XAudio headers. Also check that the user pulled the
git submodule in the process (the ./installdeps-msys2 script does this
for you.)

TODO:

* Generalize ./installdeps to work on more platforms.

* Make console Wx app in debug mode so that debug prints will work.

* Fix game keyboard input for msys2 builds.

* Add HiDPI support for Windows.

* Fix the -D*DIR defines to have the correct paths on windows.