### PR TITLE
Appdata fixes

### DIFF
--- a/src/wx/wxvbam.appdata.xml
+++ b/src/wx/wxvbam.appdata.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2016 Jeremy Newton -->
 <component type="desktop">
  <id>wxvbam.desktop</id>
- <metadata_license>GPLv2</metadata_license>
- <project_license>GPLv2</project_license>
+ <metadata_license>CC-BY-SA-3.0</metadata_license>
+ <project_license>GPL-2.0</project_license>
  <name>VisualBoyAdvance-M</name>
- <summary>WX GUI for VBA-M, a high compatibility Gameboy Advance Emulator</summary>
+ <summary>WX GUI for VisualBoyAdvance-M, a high compatibility Gameboy Advance Emulator</summary>
  <description>
   <p>
    VisualBoyAdvance-M is a Nintendo Game Boy Emulator with high compatibility with
@@ -16,4 +17,5 @@
  </description>
  <url type="homepage">http://vba-m.com/</url>
  <url type="bugtracker">https://github.com/visualboyadvance-m/visualboyadvance-m/issues</url>
+ <update_contact>alexjnewt_at_hotmail.com</update_contact>
 </component>


### PR DESCRIPTION
Changing VBA-M to VisualBoyAdvance-M and fixing a bunch of warnings thrown by _appstream-util validate_. Still needs translations and screenshot(s), but it's good enough for now.

Note that metadata_license is the license for this specific file; apparently, it's not allowed to be GPL, so CC-BY-SA-3.0 is close enough.