### PR TITLE
Queue refresh after drawing (required for wayland)

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1424,6 +1424,10 @@ void DrawingPanelBase::PaintEv(wxPaintEvent& ev)
 
     DrawArea(dc);
     DrawOSD(dc);
+#ifndef NO_CAIRO
+    if (!paused)
+        GetWindow()->Refresh();
+#endif
 }
 
 void DrawingPanelBase::EraseBackground(wxEraseEvent& ev)


### PR DESCRIPTION
Recreation of Pull Request #68:

Original description:

> I noticed that compiling and running on Wayland (an alternative to XOrg/X11 for BSD and Linux), the screen would never refresh automatically unless the window is resized. Requesting a Refresh() following DrawArea() and DrawOSD() does the trick.
> 
> Although with that said, Wayland seems to require drawing with Cairo, as the GUI will segfault without it, so I've wrapped this in #ifndef NO_CAIRO to avoid any unintended issues with other systems.
> 
> Side note, I noticed a comment in CairoDrawingPanel::DrawArea() about drawing with cairo being very slow for WXMSW. Perhaps this also fixes that issue, which could be required for cairo to work correctly, but I'm not sure.

Quote from last relevant comment:
@rkitover said:
> So according to the docs here:
> 
> http://docs.wxwidgets.org/2.8/wx_wxwindow.html#wxwindowrefresh
> 
> this queues a repaint event for the window, so what your change does is, in effect, make a loop that sends another paint event after every paint event. This may be OK if we can't find a more elegant solution.
> 
> What we would ideally like to do is check in OnIdle() if the emulator system has a frame ready to be drawn that is different from the previous frame, and only then send a Refresh() to the panel.