### PR TITLE
Fix GCC warnings, incorrect c flag, wrong return type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
     ENDIF()
 
     # common flags
-    SET(MY_C_FLAGS -pipe -fPIC -Wformat -Wformat-security -fexceptions -D_FORTIFY_SOURCE=2 -feliminate-unused-debug-types)
+    SET(MY_C_FLAGS -pipe -fPIC -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -feliminate-unused-debug-types)
 
     # check if SSP flags are supported
     INCLUDE(CheckCXXCompilerFlag)
@@ -345,10 +345,10 @@ IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
         ADD_COMPILE_OPTIONS(${C_COMPILE_FLAG})
     ENDFOREACH()
 
-    # This one must be set for C++ only, and we can't use generator expressions
-    # in ADD_COMPILE_OPTIONS because that's a cmake 3.3 feature and we need
-    # 2.8.12 compat for Ubuntu 14.
-    SET(CMAKE_CXX_COMPILE_OBJECT "${CMAKE_CXX_COMPILE_OBJECT} -std=gnu++11")
+    # These must be set for C++ only, and we can't use generator expressions in
+    # ADD_COMPILE_OPTIONS because that's a cmake 3.3 feature and we need 2.8.12
+    # compat for Ubuntu 14.
+    STRING(REGEX REPLACE "<FLAGS>" "<FLAGS> -std=gnu++11 -fpermissive -fexceptions " CMAKE_CXX_COMPILE_OBJECT ${CMAKE_CXX_COMPILE_OBJECT})
 
     # make a string of compile options to add to link flags
     UNSET(C_COMPILE_FLAGS_STR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
     ENDIF()
 
     # common flags
-    SET(MY_C_FLAGS -pipe -fPIC -fpermissive -Wformat -Wformat-security -fexceptions -D_FORTIFY_SOURCE=2 -feliminate-unused-debug-types)
+    SET(MY_C_FLAGS -pipe -fPIC -Wformat -Wformat-security -fexceptions -D_FORTIFY_SOURCE=2 -feliminate-unused-debug-types)
 
     # check if SSP flags are supported
     INCLUDE(CheckCXXCompilerFlag)

--- a/src/common/Patch.cpp
+++ b/src/common/Patch.cpp
@@ -356,8 +356,8 @@ static bool patchApplyPPF2(FILE* f, uint8_t** rom, int* size)
     uint8_t* mem = *rom;
 
     uint8_t block[1024];
-    fread(&block, 1, 1024, f);
-    if (memcmp(&mem[0x9320], &block, 1024) != 0)
+    if (fread(&block, 1, 1024, f) == 0 ||
+            memcmp(&mem[0x9320], &block, 1024) != 0)
         return false;
 
     int idlen = ppfFileIdLen(f, 2);
@@ -402,8 +402,8 @@ static bool patchApplyPPF3(FILE* f, uint8_t** rom, int* size)
 
     if (blockcheck) {
         uint8_t block[1024];
-        fread(&block, 1, 1024, f);
-        if (memcmp(&mem[(imagetype == 0) ? 0x9320 : 0x80A0], &block, 1024) != 0)
+        if (fread(&block, 1, 1024, f) == 0 ||
+                memcmp(&mem[(imagetype == 0) ? 0x9320 : 0x80A0], &block, 1024) != 0)
             return false;
         count -= 1024;
     }

--- a/src/gb/gbCheats.cpp
+++ b/src/gb/gbCheats.cpp
@@ -403,7 +403,11 @@ bool gbCheatReadGSCodeFile(const char* fileName)
 
     fseek(file, 0x18, SEEK_SET);
     int count = 0;
-    fread(&count, 1, 2, file);
+    if(fread(&count, 1, 2, file) == 0 ) {
+        fclose(file);
+        return false;
+    }
+
     int dummy = 0;
     gbCheatRemoveAll();
     char desc[13];

--- a/src/gba/Cheats.cpp
+++ b/src/gba/Cheats.cpp
@@ -2094,7 +2094,7 @@ bool cheatsImportGSACodeFile(const char* name, int game, bool v3)
         }
     }
     fclose(f);
-    return false;
+    return true;
 }
 
 void cheatsCBAReverseArray(uint8_t* array, uint8_t* dest)

--- a/src/gba/Cheats.cpp
+++ b/src/gba/Cheats.cpp
@@ -2040,9 +2040,14 @@ bool cheatsImportGSACodeFile(const char* name, int game, bool v3)
         return false;
 
     int games = 0;
-    int len = 0;
     fseek(f, 0x1e, SEEK_CUR);
-    fread(&games, 1, 4, f);
+    if(fread(&games, 1, 4, f) == 0)
+    {
+        fclose(f);
+        return false;
+    }
+
+    int len = 0;
     bool found = false;
     int g = 0;
     while (games > 0) {

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2449,6 +2449,7 @@ EVT_HANDLER(wxID_ABOUT, "About...")
     ai.AddDeveloper(wxT("skidau"));
     ai.AddDeveloper(wxT("TheCanadianBacon"));
     ai.AddDeveloper(wxT("rkitover"));
+    ai.AddDeveloper(wxT("Mystro256"));
     ai.AddDeveloper(wxT("Orig. VBA team"));
     ai.AddDeveloper(wxT("... many contributors who send us patches/PRs"));
     wxAboutBox(ai);


### PR DESCRIPTION
Some misc fixes:

- Fix some GCC warnings and added some error cases/checking
- fpermissive is not a C flag, only a c++ flag. I've removed it to silence a warning.
- cheatsImportGSACodeFile incorrectly returns false in non-error case, should be true for success (see src/wx/cmdevents.cpp). Caused an incorrect error code to print.