### PR TITLE
Tweaks

### DIFF
--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -43,7 +43,7 @@ const
     w->SetExtraStyle(w->GetExtraStyle() | wxWS_EX_VALIDATE_RECURSIVELY);
     wxWindowList l = w->GetChildren();
 
-    for (wxWindowList::iterator ch = l.begin(); ch != l.end(); ch++)
+    for (wxWindowList::iterator ch = l.begin(); ch != l.end(); ++ch)
         mark_recursive(*ch);
 }
 
@@ -2020,7 +2020,7 @@ public:
 
         // first drop from user accels, if applicable
         for (wxAcceleratorEntry_v::iterator i = user_accels.begin();
-             i < user_accels.end(); i++)
+             i < user_accels.end(); ++i)
             if (i->GetFlags() == selmod && i->GetKeyCode() == selkey) {
                 user_accels.erase(i);
                 break;
@@ -2037,7 +2037,7 @@ public:
 
         // finally, remove from accels instead of recomputing
         for (wxAcceleratorEntry_v::iterator i = accels.begin();
-             i < accels.end(); i++)
+             i < accels.end(); ++i)
             if (i->GetFlags() == selmod && i->GetKeyCode() == selkey) {
                 accels.erase(i);
                 break;
@@ -2081,7 +2081,7 @@ public:
 
         // first drop from user accels, if applicable
         for (wxAcceleratorEntry_v::iterator i = user_accels.begin();
-             i < user_accels.end(); i++)
+             i < user_accels.end(); ++i)
             if (i->GetFlags() == acmod && i->GetKeyCode() == ackey) {
                 user_accels.erase(i);
                 break;
@@ -2149,7 +2149,7 @@ void MainFrame::add_menu_accels(wxTreeCtrl* tc, wxTreeItemId& parent, wxMenu* me
 {
     wxMenuItemList mil = menu->GetMenuItems();
 
-    for (wxMenuItemList::iterator mi = mil.begin(); mi != mil.end(); mi++) {
+    for (wxMenuItemList::iterator mi = mil.begin(); mi != mil.end(); ++mi) {
         if ((*mi)->IsSeparator()) {
             tc->AppendItem(parent, wxT("-----"));
         } else if ((*mi)->IsSubMenu()) {
@@ -2374,7 +2374,7 @@ wxAcceleratorEntry_v MainFrame::get_accels(wxAcceleratorEntry_v user_accels)
     for (int i = 0; i < user_accels.size(); i++) {
         const wxAcceleratorEntry& ae = user_accels[i];
 
-        for (wxAcceleratorEntry_v::iterator e = accels.begin(); e < accels.end(); e++)
+        for (wxAcceleratorEntry_v::iterator e = accels.begin(); e < accels.end(); ++e)
             if (ae.GetFlags() == e->GetFlags() && ae.GetKeyCode() == e->GetKeyCode()) {
                 accels.erase(e);
                 break;
@@ -2636,7 +2636,7 @@ bool MainFrame::BindControls()
 
                     // only add it if not already there
                     for (wxAcceleratorEntry_v::iterator e = sys_accels.begin();
-                         e < sys_accels.end(); e++)
+                         e < sys_accels.end(); ++e)
                         if (a->GetFlags() == e->GetFlags() && a->GetKeyCode() == e->GetKeyCode()) {
                             if (e->GetMenuItem()) {
                                 wxLogInfo(_("Duplicate menu accelerator: %s for %s and %s; keeping first"),

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -749,7 +749,7 @@ void update_opts()
         cfg->SetPath(wxT("/Keyboard"));
 
     for (wxAcceleratorEntry_v::iterator i = gopts.accels.begin();
-         i < gopts.accels.end(); i++) {
+         i < gopts.accels.end(); ++i) {
         int cmd_id = i->GetCommand();
         int cmd;
 
@@ -759,7 +759,7 @@ void update_opts()
 
         wxAcceleratorEntry_v::iterator j;
 
-        for (j = i + 1; j < gopts.accels.end(); j++)
+        for (j = i + 1; j < gopts.accels.end(); ++j)
             if (j->GetCommand() != cmd_id)
                 break;
 
@@ -883,11 +883,11 @@ bool opt_set(const wxChar* name, const wxChar* val)
                 return false;
 
             for (wxAcceleratorEntry_v::iterator i = gopts.accels.begin();
-                 i < gopts.accels.end(); i++)
+                 i < gopts.accels.end(); ++i)
                 if (i->GetCommand() == cmd->cmd_id) {
                     wxAcceleratorEntry_v::iterator j;
 
-                    for (j = i; j < gopts.accels.end(); j++)
+                    for (j = i; j < gopts.accels.end(); ++j)
                         if (j->GetCommand() != cmd->cmd_id)
                             break;
 

--- a/src/wx/viewsupt.cpp
+++ b/src/wx/viewsupt.cpp
@@ -9,7 +9,7 @@ void Viewer::CloseDlg(wxCloseEvent& ev)
     MainFrame* f = wxGetApp().frame;
 
     for (dialog_list_t::iterator i = f->popups.begin();
-         i != f->popups.end(); i++)
+         i != f->popups.end(); ++i)
         if (*i == this) {
             f->popups.erase(i);
             break;
@@ -63,7 +63,7 @@ END_EVENT_TABLE()
 
 void MainFrame::UpdateViewers()
 {
-    for (dialog_list_t::iterator i = popups.begin(); i != popups.end(); i++) {
+    for (dialog_list_t::iterator i = popups.begin(); i != popups.end(); ++i) {
         Viewers::Viewer* d = static_cast<Viewers::Viewer*>(*i);
 
         if (d->auto_update)

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -703,7 +703,7 @@ void MainFrame::enable_menus()
 
 void MainFrame::SetRecentAccels()
 {
-    for (int i = 0; i <= 10; i++) {
+    for (int i = 0; i < 10; i++) {
         wxMenuItem* mi = recent->FindItem(i + wxID_FILE1);
 
         if (!mi)


### PR DESCRIPTION
First commit looks to be a typo, as the loop iterates one extra time. I would think the check and break should prevent unintentionally dereferencing recent_accel out of bounds (i.e. if i=10), but it could call recent->FindItem once redundantly.

Second commit is using the prefix ++ operator for non-primitive variables with unused return values, as this could yield better performance. Depending on how smart the compiler is, this may not do anything, as when the return value is unused, a smart compiler would optimise out the opt codes that store and return of the variables previous value in the case of a post ++ op.