### PR TITLE
Fix glibc crash: add log message on fopen failure

### DIFF
--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -758,6 +758,10 @@ void SaveConfigFile()
 	if (configFile != NULL)
 	{
 		FILE *f = fopen(configFile, "w");
+		if (f == NULL) {
+			log("Configuration file could not be opened %s\n", optarg);
+			return;
+		}
 		// Needs mixed case version of the option name to add new options into the ini
 		//for (int i = 0; i < (sizeof(argOptions) / sizeof(option)); i++)
 		//{


### PR DESCRIPTION
glibc's fclose implementation does not do a NULL check and will crash on "fclose(NULL)". A bunch of Fedora users have been sending in traces for this issue. I've added a log on failure case, likely if the user does not have permission to write to the file.