### PR TITLE
cmake: Fix -DENABLE_FFMPEG=OFF

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -513,12 +513,14 @@ TARGET_LINK_LIBRARIES (
     ${OPENAL_LIBRARY}
 )
 
-join("${FFMPEG_LDFLAGS}" " " FFMPEG_LDFLAGS_STR)
+if(ENABLE_FFMPEG)
+    join("${FFMPEG_LDFLAGS}" " " FFMPEG_LDFLAGS_STR)
 
-set_target_properties(
-    visualboyadvance-m
-    PROPERTIES LINK_FLAGS ${FFMPEG_LDFLAGS_STR}
-)
+    set_target_properties(
+        visualboyadvance-m
+        PROPERTIES LINK_FLAGS ${FFMPEG_LDFLAGS_STR}
+    )
+endif(ENABLE_FFMPEG)
 
 # Build a console app in debug mode on Windows
 IF(WIN32 AND CMAKE_BUILD_TYPE STREQUAL Debug)


### PR DESCRIPTION
Fixes the cmake configure with `-DENABLE_FFMPEG=OFF` which was failing with this.
```
CMake Error at src/wx/CMakeLists.txt:518 (set_target_properties):
  set_target_properties called with incorrect number of arguments.


-- Configuring incomplete, errors occurred!
```
Related issue. https://github.com/visualboyadvance-m/visualboyadvance-m/issues/179