### PR TITLE
Fix forbidden conversion in remote.cpp

### DIFF
--- a/src/gba/remote.cpp
+++ b/src/gba/remote.cpp
@@ -1526,7 +1526,7 @@ void debuggerReadCharTable(int n, char** args)
                 } else
                     wordSymbol[slot] = character;
             } else
-                wordSymbol[slot] = " ";
+                wordSymbol[slot] = ' ';
 
             if (largestSymbol < strlen(character))
                 largestSymbol = strlen(character);


### PR DESCRIPTION
Conversion from std::string to char* is forbidden in ISO C++.