### PR TITLE
Set mirroringEnable to false

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -269,7 +269,7 @@ void GameArea::LoadGame(const wxString& name)
             else
                 saveType = cpuSaveType;
 
-            mirroringEnable = true;
+            mirroringEnable = false;
         }
 
         doMirroring(mirroringEnable);


### PR DESCRIPTION
Set mirroring to false when rom loaded is not found in database. Making this true all the time causes some issue, for one with soft-patching some games.

Fix this https://github.com/visualboyadvance-m/visualboyadvance-m/issues/182