### PR TITLE
Buildfix

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -80,7 +80,7 @@ set(wxWidgets_USE_LIBS xrc xml html adv net core base)
 # wx-config utility for these packages to e.g. wx-config-gtk3
 #
 # Do not do the check if the WX_CONFIG env var is set.
-if($ENV{WX_CONFIG} STREQUAL "")
+if("$ENV{WX_CONFIG}" STREQUAL "")
     foreach(gtk_ver 4 3)
         set(wxWidgets_CONFIG_EXECUTABLE wx-config-gtk${gtk_ver})
         find_package(wxWidgets QUIET)


### PR DESCRIPTION
fix this error during cmake when WX_CONFIG has not been set or available

```
CMake Error at src/wx/CMakeLists.txt:83 (if):
  if given arguments:

    "STREQUAL" ""

  Unknown arguments specified


-- Configuring incomplete, errors occurred!
```