### PR TITLE
Libretro: Do not compile arm disassembly module

### DIFF
--- a/src/libretro/Makefile.common
+++ b/src/libretro/Makefile.common
@@ -6,7 +6,6 @@ SOURCES_CXX := $(CORE_DIR)/gba/GBA-thumb.cpp \
 	$(CORE_DIR)/gba/CheatSearch.cpp \
 	$(CORE_DIR)/gba/Globals.cpp \
 	$(CORE_DIR)/gba/agbprint.cpp \
-	$(CORE_DIR)/gba/armdis.cpp \
 	$(CORE_DIR)/gba/Mode4.cpp \
 	$(CORE_DIR)/gba/Mode3.cpp \
 	$(CORE_DIR)/gba/Mode5.cpp \


### PR DESCRIPTION
fix compile issue in windows