### PR TITLE
GB: Fix SIO related issue

### DIFF
--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -992,7 +992,9 @@ void gbWriteMemory(register uint16_t address, register uint8_t value)
         }
         EmuReseted = false;
         gbMemory[0xff02] = value;
-        if (gbSerialOn && (GetLinkMode() == LINK_GAMEBOY_IPC || GetLinkMode() == LINK_GAMEBOY_SOCKET || winGbPrinterEnabled)) {
+        if (gbSerialOn && (GetLinkMode() == LINK_GAMEBOY_IPC || GetLinkMode() == LINK_GAMEBOY_SOCKET
+        || GetLinkMode() == LINK_DISCONNECTED || winGbPrinterEnabled)) {
+
             gbSerialTicks = GBSERIAL_CLOCK_TICKS;
 
             LinkIsWaiting = true;


### PR DESCRIPTION
Try to fix this https://github.com/visualboyadvance-m/visualboyadvance-m/issues/274

The game Alleyway requires some serial IO stuff in order to run properly. The current implementation is only allowing serial IO when a gameboy compatible link is being used. (original PR here: https://github.com/visualboyadvance-m/visualboyadvance-m/commit/0d306b67babd7290d2c3daec872905aeec03a3a6#diff-f970b1434f44444711bd095d494a3ddf)

This PR tries to remedy this by allowing access  SIO when no link is detected. Not sure if there are other games that uses SIO without using any link methods like this.

The game though still goes back to being unplayable when a gbPrinter is connected, until vbam is closed.