### PR TITLE
Fix remote gdb support

### DIFF
--- a/src/gba/remote.cpp
+++ b/src/gba/remote.cpp
@@ -3700,17 +3700,24 @@ void remoteMemoryRead(char* p)
 void remoteQuery(char* p)
 {
     if (!strncmp(p, "fThreadInfo", 11)) {
-        remotePutPacket("m-1");
+        remotePutPacket("m1");
     } else if (!strncmp(p, "sThreadInfo", 11)) {
         remotePutPacket("l");
     } else if (!strncmp(p, "Supported", 9)) {
         remotePutPacket("PacketSize=1000");
+    } else if (!strncmp(p, "C", 1)) {
+        remotePutPacket("QC1");
+    } else if (!strncmp(p, "Attached", 8)) {
+        remotePutPacket("1");
+    } else if (!strncmp(p, "Symbol", 6)) {
+        remotePutPacket("OK");
     } else if (!strncmp(p, "Rcmd,", 5)) {
         p += 5;
         std::string cmd = HexToString(p);
         dbgExecute(cmd);
         remotePutPacket("OK");
     } else {
+        fprintf(stderr, "Unknown packet %s\n", --p);
         remotePutPacket("");
     }
 }

--- a/src/gba/remote.cpp
+++ b/src/gba/remote.cpp
@@ -3612,7 +3612,7 @@ void remoteSendStatus()
     s += 12;
     CPUUpdateCPSR();
     v = reg[16].I;
-    sprintf(s, "10:%02x%02x%02x%02x;", (v & 255),
+    sprintf(s, "19:%02x%02x%02x%02x;", (v & 255),
         (v >> 8) & 255,
         (v >> 16) & 255,
         (v >> 24) & 255);


### PR DESCRIPTION
Fixes #181 

See the steps to reproduce on the original issue. This should get remote debugging working again with gdb 8.0 which comes in the latest devkitpro.

The remote query response packets needed to be formatted slightly different and the cpsr register number is changed.