### PR TITLE
Reduce input delay by 1 frame and audio timing fix

### DIFF
--- a/src/gba/Sound.cpp
+++ b/src/gba/Sound.cpp
@@ -96,9 +96,9 @@ static Stereo_Buffer* stereo_buffer;
 
 static Blip_Synth<blip_best_quality, 1> pcm_synth[3]; // 32 kHz, 16 kHz, 8 kHz
 
-static inline blip_time_t blip_time()
+static inline blip_time_t blip_time(void)
 {
-    return SOUND_CLOCK_TICKS - soundTicks;
+    return soundTicks;
 }
 
 void Gba_Pcm::init()
@@ -390,7 +390,7 @@ void psoundTickfn()
 {
     if (gb_apu && stereo_buffer) {
         // Run sound hardware to present
-        end_frame(SOUND_CLOCK_TICKS);
+        end_frame(soundTicks);
 
         flush_samples(stereo_buffer);
 
@@ -400,6 +400,8 @@ void psoundTickfn()
         if (soundVolume_ != soundVolume)
             apply_volume();
     }
+
+    soundTicks = 0;
 }
 
 static void apply_muting()
@@ -429,7 +431,7 @@ static void reset_apu()
     if (stereo_buffer)
         stereo_buffer->clear();
 
-    soundTicks = SOUND_CLOCK_TICKS;
+    soundTicks = 0;
 }
 
 static void remake_stereo_buffer()
@@ -524,8 +526,7 @@ void soundReset()
     reset_apu();
 
     soundPaused = true;
-    SOUND_CLOCK_TICKS = SOUND_CLOCK_TICKS_;
-    soundTicks = SOUND_CLOCK_TICKS_;
+    soundTicks = 0;
 
     soundEvent(NR52, (uint8_t)0x80);
 }

--- a/src/gba/Sound.h
+++ b/src/gba/Sound.h
@@ -70,7 +70,9 @@ void interp_rate();
 // Notifies emulator that SOUND_CLOCK_TICKS clocks have passed
 void psoundTickfn();
 extern int SOUND_CLOCK_TICKS; // Number of 16.8 MHz clocks between calls to soundTick()
-extern int soundTicks; // Number of 16.8 MHz clocks until soundTick() will be called
+
+// 2018-12-10 - counts up from 0 since last psoundTickfn() was called
+extern int soundTicks;
 
 // Saves/loads emulator state
 #ifdef __LIBRETRO__


### PR DESCRIPTION
- This PR adjusts timing for input, video and sound. This reduces input delay by reading and pre-process input before the main loop (CPULoop) this way makes the data already available during the loop instead of waiting for vblank to read the input.

- Sound timings and video timings are also adjust, including the number of clock ticks required so that CPULoop will have enough ticks reach finish till vblank  which takes about 280896 cycles. This makes it possible that video and sound can both be processed during vblank period which then ends the loop. 

This has been tested under linux and appears to have not caused any problems during normal gameplay.

This does not take into account though the functions that calls directly CPULoop() like viewer.cpp and remote.cpp debugging stuff, which means those will have no input and have to be added. I was thinking of using another parameter to CPULoop() like when its call from the debugger, and if so would read the input where it used to. But im not well versed maximizing those debugging stuff to create a correct or better implementation.

