### PR TITLE
Revert to a default audio api (SDL) when config is invalid

### DIFF
--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -254,10 +254,18 @@ opt_desc opts[] = {
     INTOPT("preferences/vsync", "VSync", wxTRANSLATE("Wait for vertical sync"), vsync, 0, 1),
 
 /// Sound
-#ifdef __WXMSW__
-    ENUMOPT("Sound/AudioAPI", "", wxTRANSLATE("Sound API; if unsupported, default API will be used"), gopts.audio_api, wxTRANSLATE("sdl|openal|directsound|xaudio2")),
+#ifdef NO_OAL
+ #ifdef __WXMSW__
+    ENUMOPT("Sound/AudioAPI", "", wxTRANSLATE("Sound API; if unsupported, default API will be used"), gopts.audio_api, wxTRANSLATE("sdldirectsound|xaudio2")),
+ #else
+    ENUMOPT("Sound/AudioAPI", "", wxTRANSLATE("Sound API; if unsupported, default API will be used"), gopts.audio_api, wxTRANSLATE("sdl")),
+ #endif
 #else
+ #ifdef __WXMSW__
+    ENUMOPT("Sound/AudioAPI", "", wxTRANSLATE("Sound API; if unsupported, default API will be used"), gopts.audio_api, wxTRANSLATE("sdl|openal|directsound|xaudio2")),
+ #else
     ENUMOPT("Sound/AudioAPI", "", wxTRANSLATE("Sound API; if unsupported, default API will be used"), gopts.audio_api, wxTRANSLATE("sdl|openal")),
+ #endif
 #endif
     INTOPT("Sound/Buffers", "", wxTRANSLATE("Number of sound buffers"), gopts.audio_buffers, 2, 10),
     INTOPT("Sound/Enable", "", wxTRANSLATE("Bit mask of sound channels to enable"), gopts.sound_en, 0, 0x30f),


### PR DESCRIPTION
Prevents crash when an invalid or a non existing api is used in
vbam.conf