### PR TITLE
libretro: Use gbWram[] for $C000 in CGB mode

### DIFF
--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -1282,7 +1282,7 @@ void gbWriteMemory(register uint16_t address, register uint8_t value)
         if ((gbHardware & 5)
             && (((!gbInt48Signal) && (gbLcdMode < 2) && (register_LCDC & 0x80))
             || (register_LY == register_LYC))) {
-            
+
             gbMemory[0xff0f] = register_IF |=2;
         }
 
@@ -2744,7 +2744,15 @@ void gbReset()
         gbMemoryMap[0x09] = &gbVram[0x1000];
         gbMemoryMap[0x0a] = &gbMemory[0xa000];
         gbMemoryMap[0x0b] = &gbMemory[0xb000];
+
+        // TODO: 2019/1/15
+        // Should we be using gbWram[] on $C000 as well
+        // for a continouos mem block?
+#ifndef __LIBRETRO__
         gbMemoryMap[0x0c] = &gbMemory[0xc000];
+#else
+        gbMemoryMap[0x0c] = &gbWram[0x0000];
+#endif
         gbMemoryMap[0x0d] = &gbWram[0x1000];
         gbMemoryMap[0x0e] = &gbMemory[0xe000];
         gbMemoryMap[0x0f] = &gbMemory[0xf000];
@@ -5662,6 +5670,7 @@ bool gbReadSaveState(const uint8_t* data, unsigned)
 
         gbMemoryMap[0x08] = &gbVram[register_VBK * 0x2000];
         gbMemoryMap[0x09] = &gbVram[register_VBK * 0x2000 + 0x1000];
+        gbMemoryMap[0x0c] = &gbWram[0x0000];
         gbMemoryMap[0x0d] = &gbWram[value * 0x1000];
     }
 

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -308,7 +308,7 @@ size_t retro_get_memory_size(unsigned id)
                 return gbRamSize;
             return 0;
         case RETRO_MEMORY_SYSTEM_RAM:
-            return gbCgbMode ? 0x1000 : 0x2000;
+            return 0x2000;
         case RETRO_MEMORY_VIDEO_RAM:
             return 0x2000;
         }


### PR DESCRIPTION
This uses full size of gbWram[] so we have a continouos memory block
for RAM addresses $C000 and $D000 in CGB mode. This helps with
retroachievements.