### PR TITLE
GBA: Remove some magic numbers for main pointers and save types size

### DIFF
--- a/src/gba/EEprom.cpp
+++ b/src/gba/EEprom.cpp
@@ -11,11 +11,11 @@ int eepromByte = 0;
 int eepromBits = 0;
 int eepromAddress = 0;
 
-uint8_t eepromData[0x2000];
+uint8_t eepromData[SIZE_EEPROM_8K];
 
 uint8_t eepromBuffer[16];
 bool eepromInUse = false;
-int eepromSize = 512;
+int eepromSize = SIZE_EEPROM_512;
 
 variable_desc eepromSaveData[] = {
     { &eepromMode, sizeof(int) },
@@ -23,7 +23,7 @@ variable_desc eepromSaveData[] = {
     { &eepromBits, sizeof(int) },
     { &eepromAddress, sizeof(int) },
     { &eepromInUse, sizeof(bool) },
-    { &eepromData[0], 512 },
+    { &eepromData[0], SIZE_EEPROM_512 },
     { &eepromBuffer[0], 16 },
     { NULL, 0 }
 };
@@ -31,7 +31,7 @@ variable_desc eepromSaveData[] = {
 void eepromInit()
 {
     eepromInUse = false;
-    eepromSize = 512;
+    eepromSize = SIZE_EEPROM_512;
     memset(eepromData, 255, sizeof(eepromData));
 }
 
@@ -48,7 +48,7 @@ void eepromSaveGame(uint8_t*& data)
 {
     utilWriteDataMem(data, eepromSaveData);
     utilWriteIntMem(data, eepromSize);
-    utilWriteMem(data, eepromData, 0x2000);
+    utilWriteMem(data, eepromData, SIZE_EEPROM_8K);
 }
 
 void eepromReadGame(const uint8_t*& data, int version)
@@ -56,10 +56,10 @@ void eepromReadGame(const uint8_t*& data, int version)
     utilReadDataMem(data, eepromSaveData);
     if (version >= SAVE_GAME_VERSION_3) {
         eepromSize = utilReadIntMem(data);
-        utilReadMem(eepromData, data, 0x2000);
+        utilReadMem(eepromData, data, SIZE_EEPROM_8K);
     } else {
         // prior to 0.7.1, only 4K EEPROM was supported
-        eepromSize = 512;
+        eepromSize = SIZE_EEPROM_512;
     }
 }
 
@@ -69,7 +69,7 @@ void eepromSaveGame(gzFile gzFile)
 {
     utilWriteData(gzFile, eepromSaveData);
     utilWriteInt(gzFile, eepromSize);
-    utilGzWrite(gzFile, eepromData, 0x2000);
+    utilGzWrite(gzFile, eepromData, SIZE_EEPROM_8K);
 }
 
 void eepromReadGame(gzFile gzFile, int version)
@@ -77,10 +77,10 @@ void eepromReadGame(gzFile gzFile, int version)
     utilReadData(gzFile, eepromSaveData);
     if (version >= SAVE_GAME_VERSION_3) {
         eepromSize = utilReadInt(gzFile);
-        utilGzRead(gzFile, eepromData, 0x2000);
+        utilGzRead(gzFile, eepromData, SIZE_EEPROM_8K);
     } else {
         // prior to 0.7.1, only 4K EEPROM was supported
-        eepromSize = 512;
+        eepromSize = SIZE_EEPROM_512;
     }
 }
 
@@ -90,7 +90,7 @@ void eepromReadGameSkip(gzFile gzFile, int version)
     utilReadDataSkip(gzFile, eepromSaveData);
     if (version >= SAVE_GAME_VERSION_3) {
         utilGzSeek(gzFile, sizeof(int), SEEK_CUR);
-        utilGzSeek(gzFile, 0x2000, SEEK_CUR);
+        utilGzSeek(gzFile, SIZE_EEPROM_8K, SEEK_CUR);
     }
 }
 #endif
@@ -150,7 +150,7 @@ void eepromWrite(uint32_t /* address */, uint8_t value)
         if (cpuDmaCount == 0x11 || cpuDmaCount == 0x51) {
             if (eepromBits == 0x11) {
                 eepromInUse = true;
-                eepromSize = 0x2000;
+                eepromSize = SIZE_EEPROM_8K;
                 eepromAddress = ((eepromBuffer[0] & 0x3F) << 8) | ((eepromBuffer[1] & 0xFF));
                 if (!(eepromBuffer[0] & 0x40)) {
                     eepromBuffer[0] = bit;

--- a/src/gba/Flash.cpp
+++ b/src/gba/Flash.cpp
@@ -18,11 +18,11 @@
 #define FLASH_PROGRAM 8
 #define FLASH_SETBANK 9
 
-uint8_t flashSaveMemory[FLASH_128K_SZ];
+uint8_t flashSaveMemory[SIZE_FLASH1M];
 
 int flashState = FLASH_READ_ARRAY;
 int flashReadState = FLASH_READ_ARRAY;
-int flashSize = 0x10000;
+int flashSize = SIZE_FLASH512;
 int flashDeviceID = 0x1b;
 int flashManufacturerID = 0x32;
 int flashBank = 0;
@@ -30,7 +30,7 @@ int flashBank = 0;
 static variable_desc flashSaveData[] = {
     { &flashState, sizeof(int) },
     { &flashReadState, sizeof(int) },
-    { &flashSaveMemory[0], 0x10000 },
+    { &flashSaveMemory[0], SIZE_FLASH512 },
     { NULL, 0 }
 };
 
@@ -38,7 +38,7 @@ static variable_desc flashSaveData2[] = {
     { &flashState, sizeof(int) },
     { &flashReadState, sizeof(int) },
     { &flashSize, sizeof(int) },
-    { &flashSaveMemory[0], 0x20000 },
+    { &flashSaveMemory[0], SIZE_FLASH1M },
     { NULL, 0 }
 };
 
@@ -47,7 +47,7 @@ static variable_desc flashSaveData3[] = {
     { &flashReadState, sizeof(int) },
     { &flashSize, sizeof(int) },
     { &flashBank, sizeof(int) },
-    { &flashSaveMemory[0], 0x20000 },
+    { &flashSaveMemory[0], SIZE_FLASH1M },
     { NULL, 0 }
 };
 
@@ -109,7 +109,7 @@ void flashReadGameSkip(gzFile gzFile, int version)
 void flashSetSize(int size)
 {
     //  log("Setting flash size to %d\n", size);
-    if (size == 0x10000) {
+    if (size == SIZE_FLASH512) {
         flashDeviceID = 0x1b;
         flashManufacturerID = 0x32;
     } else {
@@ -118,8 +118,8 @@ void flashSetSize(int size)
     }
     // Added to make 64k saves compatible with 128k ones
     // (allow wrongfuly set 64k saves to work for Pokemon games)
-    if ((size == 0x20000) && (flashSize == 0x10000))
-        memcpy((uint8_t*)(flashSaveMemory + 0x10000), (uint8_t*)(flashSaveMemory), 0x10000);
+    if ((size == SIZE_FLASH1M) && (flashSize == SIZE_FLASH512))
+        memcpy((uint8_t*)(flashSaveMemory + SIZE_FLASH512), (uint8_t*)(flashSaveMemory), SIZE_FLASH512);
     flashSize = size;
 }
 
@@ -208,7 +208,7 @@ void flashWrite(uint32_t address, uint8_t byte)
                 flashReadState = FLASH_READ_ARRAY;
             } else if (byte == 0xA0) {
                 flashState = FLASH_PROGRAM;
-            } else if (byte == 0xB0 && flashSize == 0x20000) {
+            } else if (byte == 0xB0 && flashSize == SIZE_FLASH1M) {
                 flashState = FLASH_SETBANK;
             } else {
                 flashState = FLASH_READ_ARRAY;

--- a/src/gba/GBA.cpp
+++ b/src/gba/GBA.cpp
@@ -75,11 +75,11 @@ static profile_segment* profilSegment = NULL;
 #endif
 
 #ifdef BKPT_SUPPORT
-uint8_t freezeWorkRAM[WORK_RAM_SIZE];
-uint8_t freezeInternalRAM[0x8000];
+uint8_t freezeWorkRAM[SIZE_WRAM];
+uint8_t freezeInternalRAM[SIZE_IRAM];
 uint8_t freezeVRAM[0x18000];
-uint8_t freezePRAM[0x400];
-uint8_t freezeOAM[0x400];
+uint8_t freezePRAM[SIZE_PRAM];
+uint8_t freezeOAM[SIZE_OAM];
 bool debugger_last;
 #endif
 
@@ -458,7 +458,7 @@ variable_desc saveGameStruct[] = {
     { NULL, 0 }
 };
 
-static int romSize = ROM_SIZE;
+static int romSize = SIZE_ROM;
 
 #ifdef PROFILING
 void cpuProfil(profile_segment* seg)
@@ -593,13 +593,13 @@ unsigned int CPUWriteState(uint8_t* data, unsigned size)
     utilWriteIntMem(data, stopState);
     utilWriteIntMem(data, IRQTicks);
 
-    utilWriteMem(data, internalRAM, 0x8000);
-    utilWriteMem(data, paletteRAM, 0x400);
-    utilWriteMem(data, workRAM, WORK_RAM_SIZE);
-    utilWriteMem(data, vram, 0x20000);
-    utilWriteMem(data, oam, 0x400);
-    utilWriteMem(data, pix, 4 * 240 * 160);
-    utilWriteMem(data, ioMem, 0x400);
+    utilWriteMem(data, internalRAM, SIZE_IRAM);
+    utilWriteMem(data, paletteRAM, SIZE_PRAM);
+    utilWriteMem(data, workRAM, SIZE_WRAM);
+    utilWriteMem(data, vram, SIZE_VRAM);
+    utilWriteMem(data, oam, SIZE_OAM);
+    utilWriteMem(data, pix, SIZE_PIX);
+    utilWriteMem(data, ioMem, SIZE_IOMEM);
 
     eepromSaveGame(data);
     flashSaveGame(data);
@@ -643,13 +643,13 @@ bool CPUReadState(const uint8_t* data, unsigned size)
         IRQTicks = 0;
     }
 
-    utilReadMem(internalRAM, data, 0x8000);
-    utilReadMem(paletteRAM, data, 0x400);
-    utilReadMem(workRAM, data, WORK_RAM_SIZE);
-    utilReadMem(vram, data, 0x20000);
-    utilReadMem(oam, data, 0x400);
-    utilReadMem(pix, data, 4 * 240 * 160);
-    utilReadMem(ioMem, data, 0x400);
+    utilReadMem(internalRAM, data, SIZE_IRAM);
+    utilReadMem(paletteRAM, data, SIZE_PRAM);
+    utilReadMem(workRAM, data, SIZE_WRAM);
+    utilReadMem(vram, data, SIZE_VRAM);
+    utilReadMem(oam, data, SIZE_OAM);
+    utilReadMem(pix, data, SIZE_PIX);
+    utilReadMem(ioMem, data, SIZE_IOMEM);
 
     eepromReadGame(data, version);
     flashReadGame(data, version);
@@ -705,13 +705,13 @@ static bool CPUWriteState(gzFile gzFile)
     // new to version 0.8
     utilWriteInt(gzFile, IRQTicks);
 
-    utilGzWrite(gzFile, internalRAM, 0x8000);
-    utilGzWrite(gzFile, paletteRAM, 0x400);
-    utilGzWrite(gzFile, workRAM, WORK_RAM_SIZE);
-    utilGzWrite(gzFile, vram, 0x20000);
-    utilGzWrite(gzFile, oam, 0x400);
-    utilGzWrite(gzFile, pix, 4 * 241 * 162);
-    utilGzWrite(gzFile, ioMem, 0x400);
+    utilGzWrite(gzFile, internalRAM, SIZE_IRAM);
+    utilGzWrite(gzFile, paletteRAM, SIZE_PRAM);
+    utilGzWrite(gzFile, workRAM, SIZE_WRAM);
+    utilGzWrite(gzFile, vram, SIZE_VRAM);
+    utilGzWrite(gzFile, oam, SIZE_OAM);
+    utilGzWrite(gzFile, pix, SIZE_PIX);
+    utilGzWrite(gzFile, ioMem, SIZE_IOMEM);
 
     eepromSaveGame(gzFile);
     flashSaveGame(gzFile);
@@ -819,16 +819,16 @@ static bool CPUReadState(gzFile gzFile)
         }
     }
 
-    utilGzRead(gzFile, internalRAM, 0x8000);
-    utilGzRead(gzFile, paletteRAM, 0x400);
-    utilGzRead(gzFile, workRAM, WORK_RAM_SIZE);
-    utilGzRead(gzFile, vram, 0x20000);
-    utilGzRead(gzFile, oam, 0x400);
+    utilGzRead(gzFile, internalRAM, SIZE_IRAM);
+    utilGzRead(gzFile, paletteRAM, SIZE_PRAM);
+    utilGzRead(gzFile, workRAM, SIZE_WRAM);
+    utilGzRead(gzFile, vram, SIZE_VRAM);
+    utilGzRead(gzFile, oam, SIZE_OAM);
     if (version < SAVE_GAME_VERSION_6)
         utilGzRead(gzFile, pix, 4 * 240 * 160);
     else
-        utilGzRead(gzFile, pix, 4 * 241 * 162);
-    utilGzRead(gzFile, ioMem, 0x400);
+        utilGzRead(gzFile, pix, SIZE_PIX);
+    utilGzRead(gzFile, ioMem, SIZE_IOMEM);
 
     if (skipSaveGameBattery) {
         // skip eeprom data
@@ -1448,20 +1448,20 @@ void SetMapMasks()
 
 int CPULoadRom(const char* szFile)
 {
-    romSize = ROM_SIZE;
+    romSize = SIZE_ROM;
     if (rom != NULL) {
         CPUCleanUp();
     }
 
     systemSaveUpdateCounter = SYSTEM_SAVE_NOT_UPDATED;
 
-    rom = (uint8_t*)malloc(romSize);
+    rom = (uint8_t*)malloc(SIZE_ROM);
     if (rom == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "ROM");
         return 0;
     }
-    workRAM = (uint8_t*)calloc(1, WORK_RAM_SIZE);
+    workRAM = (uint8_t*)calloc(1, SIZE_WRAM);
     if (workRAM == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "WRAM");
@@ -1513,35 +1513,35 @@ int CPULoadRom(const char* szFile)
         temp++;
     }
 
-    bios = (uint8_t*)calloc(1, 0x4000);
+    bios = (uint8_t*)calloc(1, SIZE_BIOS);
     if (bios == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "BIOS");
         CPUCleanUp();
         return 0;
     }
-    internalRAM = (uint8_t*)calloc(1, 0x8000);
+    internalRAM = (uint8_t*)calloc(1, SIZE_IRAM);
     if (internalRAM == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "IRAM");
         CPUCleanUp();
         return 0;
     }
-    paletteRAM = (uint8_t*)calloc(1, 0x400);
+    paletteRAM = (uint8_t*)calloc(1, SIZE_PRAM);
     if (paletteRAM == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "PRAM");
         CPUCleanUp();
         return 0;
     }
-    vram = (uint8_t*)calloc(1, 0x20000);
+    vram = (uint8_t*)calloc(1, SIZE_VRAM);
     if (vram == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "VRAM");
         CPUCleanUp();
         return 0;
     }
-    oam = (uint8_t*)calloc(1, 0x400);
+    oam = (uint8_t*)calloc(1, SIZE_OAM);
     if (oam == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "OAM");
@@ -1556,7 +1556,7 @@ int CPULoadRom(const char* szFile)
         CPUCleanUp();
         return 0;
     }
-    ioMem = (uint8_t*)calloc(1, 0x400);
+    ioMem = (uint8_t*)calloc(1, SIZE_IOMEM);
     if (ioMem == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "IO");
@@ -1574,20 +1574,20 @@ int CPULoadRom(const char* szFile)
 
 int CPULoadRomData(const char* data, int size)
 {
-    romSize = ROM_SIZE;
+    romSize = SIZE_ROM;
     if (rom != NULL) {
         CPUCleanUp();
     }
 
     systemSaveUpdateCounter = SYSTEM_SAVE_NOT_UPDATED;
 
-    rom = (uint8_t*)malloc(romSize);
+    rom = (uint8_t*)malloc(SIZE_ROM);
     if (rom == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "ROM");
         return 0;
     }
-    workRAM = (uint8_t*)calloc(1, WORK_RAM_SIZE);
+    workRAM = (uint8_t*)calloc(1, SIZE_WRAM);
     if (workRAM == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "WRAM");
@@ -1606,35 +1606,35 @@ int CPULoadRomData(const char* data, int size)
         temp++;
     }
 
-    bios = (uint8_t*)calloc(1, 0x4000);
+    bios = (uint8_t*)calloc(1, SIZE_BIOS);
     if (bios == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "BIOS");
         CPUCleanUp();
         return 0;
     }
-    internalRAM = (uint8_t*)calloc(1, 0x8000);
+    internalRAM = (uint8_t*)calloc(1, SIZE_IRAM);
     if (internalRAM == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "IRAM");
         CPUCleanUp();
         return 0;
     }
-    paletteRAM = (uint8_t*)calloc(1, 0x400);
+    paletteRAM = (uint8_t*)calloc(1, SIZE_PRAM);
     if (paletteRAM == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "PRAM");
         CPUCleanUp();
         return 0;
     }
-    vram = (uint8_t*)calloc(1, 0x20000);
+    vram = (uint8_t*)calloc(1, SIZE_VRAM);
     if (vram == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "VRAM");
         CPUCleanUp();
         return 0;
     }
-    oam = (uint8_t*)calloc(1, 0x400);
+    oam = (uint8_t*)calloc(1, SIZE_OAM);
     if (oam == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "OAM");
@@ -1649,7 +1649,7 @@ int CPULoadRomData(const char* data, int size)
         CPUCleanUp();
         return 0;
     }
-    ioMem = (uint8_t*)calloc(1, 0x400);
+    ioMem = (uint8_t*)calloc(1, SIZE_IOMEM);
     if (ioMem == NULL) {
         systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
             "IO");
@@ -3381,15 +3381,15 @@ void CPUReset()
     // clean registers
     memset(&reg[0], 0, sizeof(reg));
     // clean OAM
-    memset(oam, 0, 0x400);
+    memset(oam, 0, SIZE_OAM);
     // clean palette
-    memset(paletteRAM, 0, 0x400);
+    memset(paletteRAM, 0, SIZE_PRAM);
     // clean picture
-    memset(pix, 0, 4 * 160 * 240);
+    memset(pix, 0, SIZE_PIX);
     // clean vram
-    memset(vram, 0, 0x20000);
+    memset(vram, 0, SIZE_VRAM);
     // clean io memory
-    memset(ioMem, 0, 0x400);
+    memset(ioMem, 0, SIZE_IOMEM);
 
     DISPCNT = 0x0080;
     DISPSTAT = 0x0000;

--- a/src/gba/GBA.h
+++ b/src/gba/GBA.h
@@ -27,6 +27,30 @@ enum {
     GBA_SAVE_NONE
 };
 
+enum {
+    SIZE_SRAM      = 32768,
+    SIZE_FLASH512   = 65536,
+    SIZE_FLASH1M   = 131072,
+    SIZE_EEPROM_512 = 512,
+    SIZE_EEPROM_8K = 8192
+};
+
+enum {
+    SIZE_ROM   = 0x2000000,
+    SIZE_BIOS  = 0x0004000,
+    SIZE_IRAM  = 0x0008000,
+    SIZE_WRAM  = 0x0040000,
+    SIZE_PRAM  = 0x0000400,
+    SIZE_VRAM  = 0x0020000,
+    SIZE_OAM   = 0x0000400,
+    SIZE_IOMEM = 0x0000400,
+#ifndef __LIBRETRO__
+    SIZE_PIX   = (4 * 241 * 162)
+#else
+    SIZE_PIX   = (4 * 240 * 160)
+#endif
+};
+
 typedef struct {
     uint8_t* address;
     uint32_t mask;
@@ -161,9 +185,6 @@ extern struct EmulatedSystem GBASystem;
 #define R13_FIQ 42
 #define R14_FIQ 43
 #define SPSR_FIQ 44
-
-#define WORK_RAM_SIZE 0x40000
-#define ROM_SIZE      0x2000000
 
 #include "Cheats.h"
 #include "EEprom.h"

--- a/src/gba/bios.cpp
+++ b/src/gba/bios.cpp
@@ -852,7 +852,7 @@ void BIOS_RegisterRamReset(uint32_t flags)
     if (flags) {
         if (flags & 0x01) {
             // clear work RAM
-            memset(workRAM, 0, WORK_RAM_SIZE);
+            memset(workRAM, 0, SIZE_WRAM);
         }
         if (flags & 0x02) {
             // clear internal RAM

--- a/src/gba/elf.cpp
+++ b/src/gba/elf.cpp
@@ -2575,14 +2575,14 @@ bool elfReadProgram(ELFHeader* eh, uint8_t* data, unsigned long data_size, int& 
         if (cpuIsMultiBoot) {
             unsigned effective_address = address - 0x2000000;
 
-            if (effective_address + section_size < WORK_RAM_SIZE) {
+            if (effective_address + section_size < SIZE_WRAM) {
                 memcpy(&workRAM[effective_address], source, section_size);
                 size += section_size;
             }
         } else {
             unsigned effective_address = address - 0x8000000;
 
-            if (effective_address + section_size < ROM_SIZE) {
+            if (effective_address + section_size < SIZE_ROM) {
                 memcpy(&rom[effective_address], source, section_size);
                 size += section_size;
             }


### PR DESCRIPTION
- use labels instead of magic number for known sizes for pointers and save types

feel free to change any labels or if its better to use #define or const <variable type>