### PR TITLE
Map Viewer: Fix crash when running  a gb/gbc game,

### DIFF
--- a/src/wx/gfxviewers.cpp
+++ b/src/wx/gfxviewers.cpp
@@ -565,6 +565,8 @@ public:
     GBMapViewer()
         : GfxViewer(wxT("GBMapViewer"), 256, 256)
     {
+        charbase = 0x0000;
+        mapbase = 0x1800;
         getradio(, "CharBase0", charbase, 0x0000);
         getradio(, "CharBase1", charbase, 0x0800);
         getradio(, "MapBase0", mapbase, 0x1800);


### PR DESCRIPTION
...caused by invalid start address of mapbase.

Fix https://github.com/visualboyadvance-m/visualboyadvance-m/issues/372

Feel free to correct if necessary, since im unfamiliar with wx.