### PR TITLE
[WIP] Add support for the XDG Base Dir Spec for Linux with legacy support.

### DIFF
--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -718,14 +718,7 @@ const char* FindConfigFile(const char *name)
 void LoadConfigFile()
 {
 #if !defined(_WIN32) && !defined(__APPLE__)
-	// Get home dir
-	char buf[1024];
-	struct stat s;
 	homeDir = getenv("HOME");
-	snprintf(buf, 1024, "%s/%s", homeDir, DOT_DIR);
-	// Make dot dir if not existent
-	if (stat(buf, &s) == -1 || !S_ISDIR(s.st_mode))
-		mkdir(buf, 0755);
 #else
 	homeDir = 0;
 #endif
@@ -746,14 +739,7 @@ void LoadConfigFile()
 void SaveConfigFile()
 {
 #if !defined(_WIN32) && !defined(__APPLE__)
-	// Get home dir
-	char buf[1024];
-	struct stat s;
 	homeDir = getenv("HOME");
-	snprintf(buf, 1024, "%s/%s", homeDir, DOT_DIR);
-	// Make dot dir if not existent
-	if (stat(buf, &s) == -1 || !S_ISDIR(s.st_mode))
-		mkdir(buf, 0755);
 #else
 	homeDir = 0;
 #endif


### PR DESCRIPTION
We check if `$HOME/.vbam` exists; if it does, then we use
`$HOME/.vbam/vbam.conf`; otherwise, use
`${XDG_CONFIG_HOME:-$HOME/.config}/visualboyadvance-m/vbam.conf`.

Fix for #94.

@rkitover Here it is a first code for this. I have some comments to do about it, so we could check for improvements:

1. I see the config file is `vbam.ini` (first try) or `vbam.cfg` for Windows and MacOS, but the name for Linux is `vbam.conf`. I kept this, since this is what we discussed previously, but maybe we could use the name for Win and Mac with Linux for the XDG Dir. I am not sure how hard this is right now, but with wxWidgets >= 3.1 it should be a piece of cake. 

2. I believe we could also use the time until wxWidgets >= 3.1 became stable as a "adaptation time" for users on Linux. I mean like only using the XDG dir when this happens. This would allow for a good refactoring of this part of the code.

3. Testing. Where do I code for automated testing? I did manually, using `wxWidgets 3.0` on my main and `wxWidgets 2.8` on Debian container. It worked as I expected, but there is never enough testing. I have a template for this, but would like further instructions.

As always, check if the code quality is good enough to be merged. There is always room for improvement! I have some free time right now, so I could take your feedback and code it (or try to, at least).