### PR TITLE
Fix segmentation fault issue when using WX port command line on Linux and MacOS.

### DIFF
--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -590,7 +590,8 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
 }
 
 wxvbamApp::~wxvbamApp() {
-    free(home);
+    if (home != NULL)
+	free(home);
 }
 
 MainFrame::MainFrame()

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -142,7 +142,7 @@ protected:
 
 private:
     wxPathList config_path;
-    char* home;
+    char* home = NULL;
 };
 
 DECLARE_APP(wxvbamApp);


### PR DESCRIPTION
@rkitover 

I think I found the error for the `segmentation fault` on Linux.

The function `bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)` on `wxvbam.cpp` has this
scope at its end:
```
home = strdup(wxString(wxApp::argv[0]).char_str());
SetHome(home);
LoadConfig(); // Parse command line arguments (overrides ini)
ReadOpts(argc, (char**)argv);
```

On the other hand, this function returns `false` before this when you use the command line
with any option (`--help`, `--print-cfg-path` etc). The variable `home` is declared
as a private variable `char *` on `wxvbam.h`.

On the destructor in `wxvbam.h`, we have
```
wxvbamApp::~wxvbamApp() {
    free(home);
}
```

This variable is supposed to be initialized with the `strdup`, but it does not
reach the code with any command line param. This is the cause of the
`segmentation fault` on Linux. Windows is more "relaxed" regarding this type
of stuff, so this was not spotted there. MacOS should also be affected.

If you try to start the interface via command line with `--verbose` (ignored when without args), the app crashes on exit for the same reason.