### PR TITLE
Overall cleanup.

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -66,62 +66,58 @@ bool FileExists(const char *filename)
 
 // Get user-specific config dir manually.
 // apple:   ~/Library/Application Support/
-// windows: %APPDATA%
-// unix:    ${XDG_CONFIG_HOME:-~/.config}
+// windows: %APPDATA%\
+// unix:    ${XDG_CONFIG_HOME:-~/.config}/
 std::string get_xdg_user_config_home()
 {
     std::string path;
 #ifdef __APPLE__
     std::string home(getenv("HOME"));
-    path = home + "/Library/Application Support/";
+    path = home + "/Library/Application Support";
 #elif _WIN32
     std::string app_data(getenv("LOCALAPPDATA"));
-    path = app_data + '\\';
+    path = app_data;
 #else // Unix
     char *xdg_var = getenv("XDG_CONFIG_HOME");
     if (!xdg_var || !*xdg_var)
     {
 	std::string xdg_default(getenv("HOME"));
-	xdg_default += "/.config";
-	path = xdg_default;
+	path = xdg_default + "/.config";
     }
     else
     {
 	path = xdg_var;
     }
-    path += '/';
 #endif
-    return path;
+    return path + FILE_SEP;
 }
 
 // Get user-specific data dir manually.
 // apple:   ~/Library/Application Support/
-// windows: %APPDATA%
-// unix:    ${XDG_DATA_HOME:-~/.local/share}
+// windows: %APPDATA%\
+// unix:    ${XDG_DATA_HOME:-~/.local/share}/
 std::string get_xdg_user_data_home()
 {
     std::string path;
 #ifdef __APPLE__
     std::string home(getenv("HOME"));
-    path = home + "/Library/Application Support/";
+    path = home + "/Library/Application Support";
 #elif _WIN32
     std::string app_data(getenv("LOCALAPPDATA"));
-    path = app_data + '\\';
+    path = app_data;
 #else // Unix
     char *xdg_var = getenv("XDG_DATA_HOME");
     if (!xdg_var || !*xdg_var)
     {
 	std::string xdg_default(getenv("HOME"));
-	xdg_default += "/.local/share";
-	path = xdg_default;
+	path = xdg_default + "/.local/share";
     }
     else
     {
 	path = xdg_var;
     }
-    path += '/';
 #endif
-    return path;
+    return path + FILE_SEP;
 }
 
 void utilReadScreenPixels(uint8_t *dest, int w, int h)

--- a/src/Util.h
+++ b/src/Util.h
@@ -4,6 +4,12 @@
 #include <string>
 #include "System.h"
 
+#ifdef _WIN32
+#define FILE_SEP '\\'
+#else // MacOS, Unix
+#define FILE_SEP '/'
+#endif
+
 enum IMAGE_TYPE { IMAGE_UNKNOWN = -1, IMAGE_GBA = 0, IMAGE_GB = 1 };
 
 // save game

--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -644,11 +644,9 @@ const char* FindConfigFile(const char *name)
 
 #ifdef _WIN32
 #define PATH_SEP ";"
-#define FILE_SEP '\\'
 #define EXE_NAME "vbam.exe"
 #else // ! _WIN32
 #define PATH_SEP ":"
-#define FILE_SEP '/'
 #define EXE_NAME "vbam"
 #endif // ! _WIN32
 
@@ -732,7 +730,7 @@ const char* FindConfigFile(const char *name)
 void LoadConfigFile()
 {
 	struct stat s;
-	std::string homeDirTmp = get_xdg_user_config_home() + FILE_SEP + DOT_DIR;
+	std::string homeDirTmp = get_xdg_user_config_home() + DOT_DIR;
 	homeDir = (char *)homeDirTmp.c_str();
 	if (stat(homeDir, &s) == -1 || !S_ISDIR(s.st_mode))
 		mkdir(homeDir, 0755);
@@ -742,28 +740,17 @@ void LoadConfigFile()
 		const char* configFile = FindConfigFile("vbam.ini");
 		OpenPreferences(configFile);
 	}
-
-	if (preferences == NULL)
-	{
-		const char* configFile = FindConfigFile("vbam.cfg");
-		OpenPreferences(configFile);
-	}
 }
 
 void SaveConfigFile()
 {
 	struct stat s;
-	std::string homeDirTmp = get_xdg_user_config_home() + FILE_SEP + DOT_DIR;
+	std::string homeDirTmp = get_xdg_user_config_home() + DOT_DIR;
 	homeDir = (char *)homeDirTmp.c_str();
 	if (stat(homeDir, &s) == -1 || !S_ISDIR(s.st_mode))
 		mkdir(homeDir, 0755);
 
 	const char* configFile = FindConfigFile("vbam.ini");
-
-	if (configFile == NULL)
-	{
-		configFile = FindConfigFile("vbam.cfg");
-	}
 
 	if (configFile != NULL)
 	{

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -76,7 +76,7 @@ static void get_config_path(wxPathList& path, bool exists = true)
 #if defined(__WXGTK__)
     // XDG spec manual support
     // ${XDG_CONFIG_HOME:-$HOME/.config}/`appname`
-    wxString old_config = wxString(getenv("HOME")) + "/.vbam";
+    wxString old_config = wxString(getenv("HOME")) + FILE_SEP + ".vbam";
     wxString new_config(get_xdg_user_config_home());
     if (!wxDirExists(old_config) && wxIsWritable(new_config))
     {
@@ -88,7 +88,7 @@ static void get_config_path(wxPathList& path, bool exists = true)
     }
     else
     {
-	// config is in $HOME/.vbam/vbam.conf
+	// config is in $HOME/.vbam/
 	add_nonstandard_path(old_config);
     }
 #endif
@@ -120,11 +120,7 @@ const wxString wxvbamApp::GetPluginsDir()
 
 wxString wxvbamApp::GetConfigurationPath()
 {
-#if defined(__WXMSW__) || defined(__APPLE__)
     wxString config("vbam.ini");
-#else
-    wxString config("vbam.conf");
-#endif
     // first check if config files exists in reverse order
     // (from system paths to more local paths.)
     if (data_path.empty()) {
@@ -251,16 +247,18 @@ bool wxvbamApp::OnInit()
     wxString confname("vbam.ini");
     wxFileName vbamconf(GetConfigurationPath(), confname);
 // /MIGRATION
-// migrate from 'vbam.conf' to 'vbam.ini' to manage a single config
+// migrate from 'vbam.{cfg,conf}' to 'vbam.ini' to manage a single config
 // file for all platforms.
 #if !defined(__WXMSW__) && !defined(__APPLE__)
-    wxString oldConf(GetConfigurationPath() + "/vbam.conf");
-    wxString newConf(GetConfigurationPath() + "/vbam.ini");
+    wxString oldConf(GetConfigurationPath() + FILE_SEP + "vbam.conf");
+#else
+    wxString oldConf(GetConfigurationPath() + FILE_SEP + "vbam.cfg");
+#endif
+    wxString newConf(GetConfigurationPath() + FILE_SEP + "vbam.ini");
     if (wxFileExists(oldConf))
     {
 	wxRenameFile(oldConf, newConf, false);
     }
-#endif
 // /END_MIGRATION
     cfg = new wxFileConfig(wxT("vbam"), wxEmptyString,
         vbamconf.GetFullPath(),

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -614,7 +614,10 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
 
 wxvbamApp::~wxvbamApp() {
     if (home != NULL)
+    {
 	free(home);
+	home = NULL;
+    }
 }
 
 MainFrame::MainFrame()


### PR DESCRIPTION
@rkitover This is a little bit of cleanup. On #94 we discussed about managing a single config file for all platforms (`vbam.ini`), so we needed to also include a migration path for `vbam.cfg` on MacOS and Windows.

We also had some stuff duplicated the `FILE_SEP`, like `${XDG_CONFIG_HOME}//visualboyadvance-m` from the xdg functions. Although it has no problem, since all platforms understand the duplicate `FILE_SEP`, it was a quick fix, so why not?

Finally, it is always a good practice to set a pointer to NULL after deallocating it.  This was missing from the variable `home` that was the cause of that segfault command line issue.