### PR TITLE
[WIP] Return non-error code for given command line parameters.

### DIFF
--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -421,6 +421,26 @@ bool wxvbamApp::OnInit()
     return true;
 }
 
+int wxvbamApp::OnRun()
+{
+    if (console_mode)
+    {
+	// we could check for our own error codes here...
+	return EXIT_SUCCESS;
+    }
+    else
+    {
+	return wxApp::OnRun();
+    }
+}
+
+bool wxvbamApp::OnCmdLineHelp(wxCmdLineParser& parser)
+{
+    wxApp::OnCmdLineHelp(parser);
+    console_mode = true;
+    return true;
+}
+
 void wxvbamApp::OnInitCmdLine(wxCmdLineParser& cl)
 {
     wxApp::OnInitCmdLine(cl);
@@ -505,7 +525,8 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
             s.mb_str());
         tack_full_path(lm);
         wxLogMessage(lm);
-        return false;
+        console_mode = true;
+        return true;
     }
 
     if (cl.Found(wxT("print-cfg-path"))) {
@@ -515,7 +536,8 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
         wxString lm(_("Configuration is read from, in order:"));
         tack_full_path(lm);
         wxLogMessage(lm);
-        return false;
+        console_mode = true;
+        return true;
     }
 
     if (cl.Found(wxT("save-over"), &s)) {
@@ -533,7 +555,8 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
         tack_full_path(lm, oi);
         lm.append(_("\n\tbuilt-in"));
         wxLogMessage(lm);
-        return false;
+        console_mode = true;
+        return true;
     }
 
     if (cl.Found(wxT("f"))) {
@@ -567,7 +590,8 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
         for (int i = 0; i < ncmds; i++)
             wxPrintf(wxT("%s (%s)\n"), cmdtab[i].cmd, cmdtab[i].name);
 
-        return false;
+        console_mode = true;
+        return true;
     }
 
 #if !defined(NO_LINK) && !defined(__WXMSW__)

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -83,6 +83,8 @@ public:
     {
     }
     virtual bool OnInit();
+    virtual int OnRun();
+    virtual bool OnCmdLineHelp(wxCmdLineParser&);
     virtual bool UsingWayland() { return using_wayland; }
     virtual void OnInitCmdLine(wxCmdLineParser&);
     virtual bool OnCmdLineParsed(wxCmdLineParser&);
@@ -140,6 +142,7 @@ public:
 
 protected:
     bool using_wayland;
+    bool console_mode = false;
 
 private:
     wxPathList config_path;


### PR DESCRIPTION
@rkitover I have an idea about how we could handle the return code `255`. But first, I will tell what I think it is happening, so you can check if we are on the same page.

When we run 
`./visualboyadvance-m --help; echo $?`
or 
`./visualboyadvance-m --print-cfg-path; echo $?`

we get the value `255`, which is a non-zero error code. For these 2 cases, we wish we got `0`, since it means the app ran successfully (only printing the asked info and then exiting).

According to my researches, the reason why we get `255` is because we returned `false` on the `OnInit()` function, causing it to exit the program immediately, but in the sense of failing to initialize. Sources [(1)](https://stackoverflow.com/questions/19255020/how-do-i-quit-a-wxwidget-application-when-no-window-was-opened) and [(2)](https://docs.wxwidgets.org/3.0/classwx_app_console.html#a99953775a2fd83fa2456e390779afe15).

Our function `wxvbamApp::OnCmdLineParsed` had several `return false` statements, all of them to parameters that print information (`--print-cfg-path`, for example). We wanted to print information and then exit the app successfully, because we only wanted to see the text from the options.

I searched the WxWidgets docs, and found some interesting stuff. The first one is to handle these parameters that we create; we could make a **console mode**, by overriding the `OnRun` method. The idea is to check if we are in this mode and return our own exit code; otherwise, return the parent function `wxApp::OnRun` [(3)](https://docs.wxwidgets.org/3.0/classwx_app_console.html#ac05a28c7cdb529f2cdfe77b3431c385c). This idea was coded here.

Now, for the `--help`, we have a more specific situation. This is handled by the function `OnCmdLineHelp`[(4)](https://docs.wxwidgets.org/3.0/classwx_app_console.html#ac05a28c7cdb529f2cdfe77b3431c385c). By the doc, this returns `false` for `OnInit()` and, again, in the sense of failing to initialize the app and exiting the application immediately; this is what generates the `255` for this param. If we don't want to consider this as a fail, we need to override `OnCmdLineHelp` and use the same logic that we did for the other params. The counter point to this, though, is that we get other info print alongside it. This is the output for the current code:

```
$ ./visualboyadvance-m -h; echo $?
VisualBoyAdvance-M

Usage: visualboyadvance-m [-h] [--verbose] [--save-xrc <str>] [--save-over <str>] [--print-cfg-path] [-f] [-s] [-o] [ROM file] [<config>=<value>...]
  -h, --help               	show this help message
  --verbose                	generate verbose log messages
  --save-xrc=<str>         	Save built-in XRC file and exit
  --save-over=<str>        	Save built-in vba-over.ini and exit
  --print-cfg-path         	Print configuration path and exit
  -f, --fullscreen         	Start in full-screen mode
  -s, --delete-shared-state	Delete shared link state first, if it exists
  -o, --list-options       	List all settable options and exit
04:37:07 PM: Debug: GetUserLocalDataDir(): /home/denisfa/.visualboyadvance-m
04:37:07 PM: Debug: GetUserDataDir(): /home/denisfa/.visualboyadvance-m
04:37:07 PM: Debug: GetLocalizedResourcesDir(wxGetApp().locale.GetCanonicalName()): /usr/local/share/visualboyadvance-m/en_US
04:37:07 PM: Debug: GetResourcesDir(): /usr/local/share/visualboyadvance-m
04:37:07 PM: Debug: GetDataDir(): /usr/local/share/visualboyadvance-m
04:37:07 PM: Debug: GetLocalDataDir(): /etc/visualboyadvance-m
04:37:07 PM: Debug: plugins_dir: /usr/local/lib/visualboyadvance-m
04:37:07 PM: Debug: XdgConfigDir: /home/denisfa/.config/visualboyadvance-m
0
```

Also, we have to consider wrong or misspelled parameters. Like this:
```
./visualboyadvance-m --print-cfg-paah; echo $?
Unknown long option 'print-cfg-paah'
VisualBoyAdvance-M

Usage: visualboyadvance-m [-h] [--verbose] [--save-xrc <str>] [--save-over <str>] [--print-cfg-path] [-f] [-s] [-o] [ROM file] [<config>=<value>...]
  -h, --help               	show this help message
  --verbose                	generate verbose log messages
  --save-xrc=<str>         	Save built-in XRC file and exit
  --save-over=<str>        	Save built-in vba-over.ini and exit
  --print-cfg-path         	Print configuration path and exit
  -f, --fullscreen         	Start in full-screen mode
  -s, --delete-shared-state	Delete shared link state first, if it exists
  -o, --list-options       	List all settable options and exit
255
```

We would need to define what we want from this. Maybe the message but a success return code? I am not sure... We can work it out by overriding `OnCmdLineError` [(5)](https://docs.wxwidgets.org/3.0/classwx_app_console.html#a1c8bf26b12a280fd03911caac70e3144).

It is really fun to search and learn how to use a library like WxWidgets, but on the other hand, since It is my first contact with it, I could be dropping the ball really hard here, considering you must have been working with it for a longer time and could have a better explanation for what it is happening. But hey, you miss 100% of the shots you don't take, right?