### PR TITLE
XDG followup work.

### DIFF
--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -64,6 +64,9 @@
 #include "inputSDL.h"
 #include "text.h"
 
+// from: https://stackoverflow.com/questions/7608714/why-is-my-pointer-not-null-after-free
+#define freeSafe(ptr) free(ptr); ptr = NULL;
+
 #ifndef _WIN32
 #include <unistd.h>
 #define GETCWD getcwd
@@ -222,15 +225,6 @@ uint32_t screenMessageTime = 0;
 #define SOUND_MAX_VOLUME 2.0
 #define SOUND_ECHO 0.2
 #define SOUND_STEREO 0.15
-
-void freeSafe(void *ptr)
-{
-    if (ptr != NULL)
-    {
-	free(ptr);
-	ptr = NULL;
-    }
-}
 
 static void sdlChangeVolume(float d)
 {

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -462,7 +462,7 @@ void GameArea::recompute_dirs()
     }
 
     if (!wxIsWritable(batdir)) {
-        batdir = wxGetApp().GetAbsolutePath(get_xdg_user_data_home() + DOT_DIR);
+        batdir = wxGetApp().GetDataDir();
     }
 
     statedir = gopts.state_dir;
@@ -474,7 +474,7 @@ void GameArea::recompute_dirs()
     }
 
     if (!wxIsWritable(statedir)) {
-        statedir = wxGetApp().GetAbsolutePath(get_xdg_user_data_home() + DOT_DIR);
+        statedir = wxGetApp().GetDataDir();
     }
 }
 

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -461,6 +461,10 @@ void GameArea::recompute_dirs()
         batdir = wxGetApp().GetAbsolutePath(gopts.battery_dir);
     }
 
+    if (!wxIsWritable(batdir)) {
+        batdir = wxGetApp().GetAbsolutePath(get_xdg_user_data_home() + DOT_DIR);
+    }
+
     statedir = gopts.state_dir;
 
     if (!statedir.size()) {
@@ -469,11 +473,9 @@ void GameArea::recompute_dirs()
         statedir = wxGetApp().GetAbsolutePath(gopts.state_dir);
     }
 
-    if (!wxIsWritable(batdir))
-        batdir = wxGetApp().GetConfigurationPath();
-
-    if (!wxIsWritable(statedir))
-        statedir = wxGetApp().GetConfigurationPath();
+    if (!wxIsWritable(statedir)) {
+        statedir = wxGetApp().GetAbsolutePath(get_xdg_user_data_home() + DOT_DIR);
+    }
 }
 
 void GameArea::UnloadGame(bool destruct)

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -612,6 +612,16 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
     return true;
 }
 
+wxString wxvbamApp::GetConfigDir()
+{
+    return GetAbsolutePath(get_xdg_user_config_home() + DOT_DIR);
+}
+
+wxString wxvbamApp::GetDataDir()
+{
+    return GetAbsolutePath(get_xdg_user_data_home() + DOT_DIR);
+}
+
 wxvbamApp::~wxvbamApp() {
     if (home != NULL)
     {

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -750,7 +750,10 @@ wxString MainFrame::GetGamePath(wxString path)
         game_path = wxFileName::GetCwd();
 
     if (!wxIsWritable(game_path))
-        game_path = wxGetApp().GetConfigurationPath();
+    {
+	game_path = wxGetApp().GetAbsolutePath(get_xdg_user_data_home() + DOT_DIR);
+	wxFileName::Mkdir(game_path, 0777, wxPATH_MKDIR_FULL);
+    }
 
     return game_path;
 }

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -86,6 +86,8 @@ public:
     virtual bool UsingWayland() { return using_wayland; }
     virtual void OnInitCmdLine(wxCmdLineParser&);
     virtual bool OnCmdLineParsed(wxCmdLineParser&);
+    virtual wxString GetConfigDir();
+    virtual wxString GetDataDir();
     wxString GetConfigurationPath();
     const wxString GetPluginsDir();
     wxString GetAbsolutePath(wxString path);


### PR DESCRIPTION
@rkitover This is another followup work I had to do after #94. There was some stuff bugging me at that time, like whatever option to save file I had on GUI (screenshot, recording etc) was having the default option the same path from the configuration file, where `vbam.conf` was. 

This is not an issue for Windows and MacOS, but for Linux the appropriate path would be the `$XDG_DATA_HOME/visualboyadvance-m`, hence what I am doing here.

Another thing that I had to do was to sync these location with the ones from the SDL port. I am 99% sure that these type of `else` (example) were unreachable:
```
if (batteryDir)
...
else if (homeDir)
...
else // <- useless, it would never reach here
```

Now, all these locations are synced with the ones from the WX. The order is:
1. StateDir / BatteryDir / configuration file specific dir;
2. The path of the current loaded game;
3. XDG Base Dir (or equivalent) fallback.

I tested everything on Linux. I will update this if I find any issues on other platforms. My testing was like this: I had the same game on two places: `/opt/loz.zip` and `~/Downloads/loz.zip`.

1. Used `/opt/loz.zip`, with my regular user, on GUI and SDL port. I expected to save stuff on `${XDG_DATA_HOME}/visualboyadvance-m` (OK) and the default option for the gui when asking where to save files to be this location (OK).

2. Used `~/Downloads/loz.zip`, with my regular user, on GUI and SDL port. I expected to save stuff on `~/Downloads/` (OK) and the default option for the gui when asking where to save files to be this location (OK).

So it was very straightforward. Check If I still need to do something and, if I need, do not merge this and let's continue what is missing here before merging.