### PR TITLE
Fix problems of command line parameters.

### DIFF
--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -206,6 +206,9 @@ bool wxvbamApp::OnInit()
     if (!wxApp::OnInit())
         return false;
 
+    if (console_mode)
+	return true;
+
     // prepare for loading xrc files
     wxXmlResource* xr = wxXmlResource::Get();
     // note: if linking statically, next 2 pull in lot of unused code
@@ -437,6 +440,13 @@ int wxvbamApp::OnRun()
 bool wxvbamApp::OnCmdLineHelp(wxCmdLineParser& parser)
 {
     wxApp::OnCmdLineHelp(parser);
+    console_mode = true;
+    return true;
+}
+
+bool wxvbamApp::OnCmdLineError(wxCmdLineParser& parser)
+{
+    wxApp::OnCmdLineError(parser);
     console_mode = true;
     return true;
 }

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -429,7 +429,7 @@ int wxvbamApp::OnRun()
     if (console_mode)
     {
 	// we could check for our own error codes here...
-	return EXIT_SUCCESS;
+	return console_status;
     }
     else
     {
@@ -448,6 +448,7 @@ bool wxvbamApp::OnCmdLineError(wxCmdLineParser& parser)
 {
     wxApp::OnCmdLineError(parser);
     console_mode = true;
+    console_status = 1;
     return true;
 }
 

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -85,6 +85,7 @@ public:
     virtual bool OnInit();
     virtual int OnRun();
     virtual bool OnCmdLineHelp(wxCmdLineParser&);
+    virtual bool OnCmdLineError(wxCmdLineParser&);
     virtual bool UsingWayland() { return using_wayland; }
     virtual void OnInitCmdLine(wxCmdLineParser&);
     virtual bool OnCmdLineParsed(wxCmdLineParser&);

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -144,6 +144,7 @@ public:
 protected:
     bool using_wayland;
     bool console_mode = false;
+    int console_status = 0;
 
 private:
     wxPathList config_path;


### PR DESCRIPTION
@rkitover I believe this fixes the sanity check problems that we are having. I did some quick testing here, and I think that at least with `xvfb-run` it should work. Also, this includes returning code `0` for wrong params, like we discussed in #388.

If you can, try to test this before merging as well. Here I tried to solve the delay when running `--help`. There is an even quicker way, but requires some more dancing in the code. I will try to bring a solution. It move this code to the very top of the `OnInit`:
```
if (!wxApp::OnInit())
        return false;

if (console_mode)
       return true;
```

Check if you like it.