### PR TITLE
Fix compilation warnings.

### DIFF
--- a/fex/7z_C/7zAlloc.c
+++ b/fex/7z_C/7zAlloc.c
@@ -20,6 +20,7 @@ int g_allocCountTemp = 0;
 
 void* SzAlloc(void* p, size_t size)
 {
+    (void)p; // unused param
     if (size == 0)
         return 0;
 #ifdef _SZ_ALLOC_DEBUG
@@ -31,6 +32,7 @@ void* SzAlloc(void* p, size_t size)
 
 void SzFree(void* p, void* address)
 {
+    (void)p; // unused param
 #ifdef _SZ_ALLOC_DEBUG
     if (address != 0) {
         g_allocCount--;
@@ -42,6 +44,7 @@ void SzFree(void* p, void* address)
 
 void* SzAllocTemp(void* p, size_t size)
 {
+    (void)p; // unused param
     if (size == 0)
         return 0;
 #ifdef _SZ_ALLOC_DEBUG
@@ -56,6 +59,7 @@ void* SzAllocTemp(void* p, size_t size)
 
 void SzFreeTemp(void* p, void* address)
 {
+    (void)p; // unused param
 #ifdef _SZ_ALLOC_DEBUG
     if (address != 0) {
         g_allocCountTemp--;

--- a/fex/fex/Data_Reader.cpp
+++ b/fex/fex/Data_Reader.cpp
@@ -325,24 +325,30 @@ size_t utf8_encode_char( unsigned wide, char * target )
 		target[5] = 0x80 | ( wide & 0x3F );
 		wide = wide >> 6;
 		wide |= 0x4000000;
+		break;
     case 5:
 		target[4] = 0x80 | ( wide & 0x3F );
 		wide = wide >> 6;
 		wide |= 0x200000;
+		break;
     case 4:
 		target[3] = 0x80 | ( wide & 0x3F );
 		wide = wide >> 6;
 		wide |= 0x10000;
+		break;
     case 3:
 		target[2] = 0x80 | ( wide & 0x3F );
 		wide = wide >> 6;
 		wide |= 0x800;
+		break;
     case 2:
 		target[1] = 0x80 | ( wide & 0x3F );
 		wide = wide >> 6;
 		wide |= 0xC0;
-	case 1:
+		break;
+    case 1:
 		target[0] = wide;
+		break;
 	}
 
 	return count;

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -66,7 +66,7 @@ bool FileExists(const char *filename)
 
 // Get user-specific config dir manually.
 // apple:   ~/Library/Application Support/
-// windows: %APPDATA%\
+// windows: %APPDATA%/
 // unix:    ${XDG_CONFIG_HOME:-~/.config}/
 std::string get_xdg_user_config_home()
 {
@@ -94,7 +94,7 @@ std::string get_xdg_user_config_home()
 
 // Get user-specific data dir manually.
 // apple:   ~/Library/Application Support/
-// windows: %APPDATA%\
+// windows: %APPDATA%/
 // unix:    ${XDG_DATA_HOME:-~/.local/share}/
 std::string get_xdg_user_data_home()
 {

--- a/src/Util.h
+++ b/src/Util.h
@@ -10,6 +10,8 @@
 #define FILE_SEP '/'
 #endif
 
+#define FREAD_UNCHECKED(A,B,C,D) (void)(fread(A,B,C,D) + 1)
+
 enum IMAGE_TYPE { IMAGE_UNKNOWN = -1, IMAGE_GBA = 0, IMAGE_GB = 1 };
 
 // save game

--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -264,7 +264,7 @@ IFBFilterFunc ifbFunction = 0;
 
 // allow up to 100 IPS/UPS/PPF patches given on commandline
 int	patchNum = 0;
-char *(patchNames[PATCH_MAX_NUM]) = { NULL }; // and so on
+char *patchNames[PATCH_MAX_NUM] = { NULL }; // and so on
 
 void(*dbgMain)() = remoteStubMain;
 void(*dbgSignal)(int, int) = remoteStubSignal;

--- a/src/common/SoundDriver.h
+++ b/src/common/SoundDriver.h
@@ -58,7 +58,7 @@ class SoundDriver
          */
         virtual void write(uint16_t *finalWave, int length) = 0;
 
-        virtual void setThrottle(unsigned short throttle){};
+        virtual void setThrottle(unsigned short throttle) = 0;
 };
 
 #endif // __VBA_SOUND_DRIVER_H__

--- a/src/common/SoundSDL.cpp
+++ b/src/common/SoundSDL.cpp
@@ -61,10 +61,12 @@ void SoundSDL::read(uint16_t* stream, int length) {
         return;
 
     if (!buffer_size())
+    {
         if (should_wait())
             SDL_SemWait(data_available);
         else
             return;
+    }
 
     SDL_LockMutex(mutex);
 
@@ -136,7 +138,7 @@ bool SoundSDL::init(long sampleRate) {
 
     sound_device = SDL_OpenAudioDevice(NULL, 0, &audio, &audio_spec, SDL_AUDIO_ALLOW_ANY_CHANGE);
 
-    if(sound_device < 0) {
+    if(sound_device == 0) {
         std::cerr << "Failed to open audio: " << SDL_GetError() << std::endl;
         return false;
     }

--- a/src/common/SoundSDL.h
+++ b/src/common/SoundSDL.h
@@ -45,7 +45,7 @@ protected:
 private:
         RingBuffer<uint16_t> samples_buf;
 
-        SDL_AudioDeviceID sound_device = -1;
+        SDL_AudioDeviceID sound_device = 0;
 
         SDL_mutex* mutex;
         SDL_sem* data_available;

--- a/src/common/iniparser.c
+++ b/src/common/iniparser.c
@@ -643,7 +643,7 @@ dictionary *iniparser_load(const char *ininame)
         char line[ASCIILINESZ + 1];
         char section[ASCIILINESZ + 1];
         char key[ASCIILINESZ + 1];
-        char tmp[ASCIILINESZ + 1];
+        char tmp[2 * ASCIILINESZ + 3];
         char val[ASCIILINESZ + 1];
 
         int last = 0;

--- a/src/filters/interframe.cpp
+++ b/src/filters/interframe.cpp
@@ -20,7 +20,7 @@ static uint8_t *frm3 = NULL;
 
 extern uint32_t qRGB_COLOR_MASK[2];
 
-static void Init()
+void InterframeFilterInit()
 {
   frm1 = (uint8_t *)calloc(322*242,4);
   // 1 frame ago
@@ -163,8 +163,9 @@ static void SmartIB_MMX(uint8_t *srcPtr, uint32_t srcPitch, int width, int start
 
 void SmartIB(uint8_t *srcPtr, uint32_t srcPitch, int width, int starty, int height)
 {
+  (void)width; // unused param
   if(frm1 == NULL) {
-    Init();
+    InterframeFilterInit();
   }
 #ifdef MMX
   if(cpu_mmx) {
@@ -329,8 +330,9 @@ static void SmartIB32_MMX(uint8_t *srcPtr, uint32_t srcPitch, int width, int sta
 
 void SmartIB32(uint8_t *srcPtr, uint32_t srcPitch, int width, int starty, int height)
 {
+  (void)width; // unused param
   if(frm1 == NULL) {
-    Init();
+    InterframeFilterInit();
   }
 #ifdef MMX
   if(cpu_mmx) {
@@ -445,8 +447,9 @@ static void MotionBlurIB_MMX(uint8_t *srcPtr, uint32_t srcPitch, int width, int 
 
 void MotionBlurIB(uint8_t *srcPtr, uint32_t srcPitch, int width, int starty, int height)
 {
+  (void)width; // unused param
   if(frm1 == NULL) {
-    Init();
+    InterframeFilterInit();
   }
 
 #ifdef MMX
@@ -550,8 +553,9 @@ static void MotionBlurIB32_MMX(uint8_t *srcPtr, uint32_t srcPitch, int width, in
 
 void MotionBlurIB32(uint8_t *srcPtr, uint32_t srcPitch, int width, int starty, int height)
 {
+  (void)width; // unused param
   if(frm1 == NULL) {
-    Init();
+    InterframeFilterInit();
   }
 
 #ifdef MMX
@@ -569,7 +573,7 @@ void MotionBlurIB32(uint8_t *srcPtr, uint32_t srcPitch, int width, int starty, i
   int sPitch = srcPitch >> 2;
   int pos = 0;
 
-  for (int j = 0; j < height;  j++)
+  for (int j = 0; j < height; j++)
     for (int i = 0; i < sPitch; i++) {
       uint32_t color = src0[pos];
       src0[pos] = (((color & colorMask) >> 1) +

--- a/src/filters/interframe.hpp
+++ b/src/filters/interframe.hpp
@@ -5,7 +5,7 @@
 
 extern int RGB_LOW_BITS_MASK;
 
-static void Init();
+void InterframeFilterInit();
 
 // call ifc to ignore previous frame / when starting new
 void InterframeCleanup();

--- a/src/filters/xBRZ/xbrz.cpp
+++ b/src/filters/xBRZ/xbrz.cpp
@@ -1031,6 +1031,7 @@ struct ColorDistanceRGB
 {
     static double dist(uint32_t pix1, uint32_t pix2, double luminanceWeight)
     {
+        (void)luminanceWeight; // unused param
         return distYCbCrBuffer.dist(pix1, pix2);
 
         //if (pix1 == pix2) //about 4% perf boost
@@ -1043,6 +1044,7 @@ struct ColorDistanceARGB
 {
     static double dist(uint32_t pix1, uint32_t pix2, double luminanceWeight)
     {
+        (void)luminanceWeight; // unused param
         const double a1 = getAlpha(pix1) / 255.0 ;
         const double a2 = getAlpha(pix2) / 255.0 ;
         /*

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -3443,8 +3443,6 @@ bool gbReadGSASnapshot(const char* fileName)
         return false;
     }
     fseek(file, 0x13, SEEK_SET);
-    //size_t read = 0;
-    //int toRead = 0;
     switch (gbRomType) {
     case 0x03:
     case 0x0f:
@@ -3453,15 +3451,11 @@ bool gbReadGSASnapshot(const char* fileName)
     case 0x1b:
     case 0x1e:
     case 0xff:
-        //read = fread(gbRam, 1, (gbRamSizeMask + 1), file);
         FREAD_UNCHECKED(gbRam, 1, (gbRamSizeMask + 1), file);
-        //toRead = (gbRamSizeMask + 1);
         break;
     case 0x06:
     case 0x22:
-        //read = fread(&gbMemory[0xa000], 1, 256, file);
         FREAD_UNCHECKED(&gbMemory[0xa000], 1, 256, file);
-        //toRead = 256;
         break;
     default:
         systemMessage(MSG_UNSUPPORTED_SNAPSHOT_FILE,

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -2189,7 +2189,7 @@ static void gbSelectColorizationPalette()
         }
 
         // Check if the checksum is in the list.
-        int idx;
+        size_t idx;
         for (idx = 0; idx < sizeof(gbColorizationChecksums); idx++) {
             if (gbColorizationChecksums[idx] == checksum) {
                 break;
@@ -2201,7 +2201,7 @@ static void gbSelectColorizationPalette()
             // Indexes above 0x40 have to be disambiguated.
             if (idx > 0x40) {
                 // No idea how that works. But it works.
-                for (int i = idx - 0x41, j = 0; i < sizeof(gbColorizationDisambigChars); i += 14, j += 14) {
+                for (size_t i = idx - 0x41, j = 0; i < sizeof(gbColorizationDisambigChars); i += 14, j += 14) {
                     if (gbRom[0x0137] == gbColorizationDisambigChars[i]) {
                         infoIdx = idx + j;
                         break;
@@ -3430,7 +3430,7 @@ bool gbReadGSASnapshot(const char* fileName)
     fseek(file, 0x4, SEEK_SET);
     char buffer[16];
     char buffer2[16];
-    fread(buffer, 1, 15, file);
+    FREAD_UNCHECKED(buffer, 1, 15, file);
     buffer[15] = 0;
     memcpy(buffer2, &gbRom[0x134], 15);
     buffer2[15] = 0;
@@ -3443,8 +3443,8 @@ bool gbReadGSASnapshot(const char* fileName)
         return false;
     }
     fseek(file, 0x13, SEEK_SET);
-    size_t read = 0;
-    int toRead = 0;
+    //size_t read = 0;
+    //int toRead = 0;
     switch (gbRomType) {
     case 0x03:
     case 0x0f:
@@ -3453,13 +3453,15 @@ bool gbReadGSASnapshot(const char* fileName)
     case 0x1b:
     case 0x1e:
     case 0xff:
-        read = fread(gbRam, 1, (gbRamSizeMask + 1), file);
-        toRead = (gbRamSizeMask + 1);
+        //read = fread(gbRam, 1, (gbRamSizeMask + 1), file);
+        FREAD_UNCHECKED(gbRam, 1, (gbRamSizeMask + 1), file);
+        //toRead = (gbRamSizeMask + 1);
         break;
     case 0x06:
     case 0x22:
-        read = fread(&gbMemory[0xa000], 1, 256, file);
-        toRead = 256;
+        //read = fread(&gbMemory[0xa000], 1, 256, file);
+        FREAD_UNCHECKED(&gbMemory[0xa000], 1, 256, file);
+        //toRead = 256;
         break;
     default:
         systemMessage(MSG_UNSUPPORTED_SNAPSHOT_FILE,

--- a/src/gb/gbCheats.cpp
+++ b/src/gb/gbCheats.cpp
@@ -416,10 +416,10 @@ bool gbCheatReadGSCodeFile(const char* fileName)
     char code[9];
     int i;
     for (i = 0; i < count; i++) {
-        fread(&dummy, 1, 2, file);
-        fread(desc, 1, 12, file);
+        FREAD_UNCHECKED(&dummy, 1, 2, file);
+        FREAD_UNCHECKED(desc, 1, 12, file);
         desc[12] = 0;
-        fread(code, 1, 8, file);
+        FREAD_UNCHECKED(code, 1, 8, file);
         code[8] = 0;
         gbAddGsCheat(code, desc);
     }

--- a/src/gb/gbMemory.cpp
+++ b/src/gb/gbMemory.cpp
@@ -991,8 +991,17 @@ mapperHuC3 gbDataHuC3 = {
     1, // ROM bank
     0, // RAM bank
     0, // RAM address
+    0, // Address
     0, // RAM flag
-    0 // RAM read value
+    0, // RAM read value
+    0, // Register 1
+    0, // Register 2
+    0, // Register 3
+    0, // Register 4
+    0, // Register 5
+    0, // Register 6
+    0, // Register 7
+    0  // Register 8
 };
 
 // HuC3 ROM write registers

--- a/src/gb/gbSGB.cpp
+++ b/src/gb/gbSGB.cpp
@@ -67,7 +67,7 @@ void gbSgbReset()
     gbSgbNextController = 0x0f;
     gbSgbReadingController = 0;
 
-    //memset(gbSgbSCPPalette, 0, 512 * 4 * sizeof(uint16_t));
+    memset(gbSgbSCPPalette, 0, 512 * 4 * sizeof(uint16_t));
     memset(gbSgbATF, 0, 20 * 18);
     memset(gbSgbATFList, 0, 45 * 20 * 18);
     memset(gbSgbPacket, 0, 16 * 7);

--- a/src/gb/gbSGB.cpp
+++ b/src/gb/gbSGB.cpp
@@ -67,7 +67,7 @@ void gbSgbReset()
     gbSgbNextController = 0x0f;
     gbSgbReadingController = 0;
 
-    memset(gbSgbSCPPalette, 0, 512 * 4);
+    //memset(gbSgbSCPPalette, 0, 512 * 4 * sizeof(uint16_t));
     memset(gbSgbATF, 0, 20 * 18);
     memset(gbSgbATFList, 0, 45 * 20 * 18);
     memset(gbSgbPacket, 0, 16 * 7);

--- a/src/gba/BreakpointStructures.cpp
+++ b/src/gba/BreakpointStructures.cpp
@@ -774,16 +774,19 @@ uint8_t parseConditionOperand(char* type)
             return flag | 0x3;
         if (tolower(type[1]) == 't')
             return flag | 0x2;
+	break;
 
     case 'e':
         if (tolower(type[1]) == 'q')
             return flag | 0x1;
         if (type[1] == '\0')
             return flag | 0x1;
+	break;
     case 'n':
         if (tolower(type[1]) == 'e')
             return flag | 0x6;
-    default:;
+    default:
+	break;
     }
     return flag;
 }

--- a/src/gba/Cheats.cpp
+++ b/src/gba/Cheats.cpp
@@ -2055,15 +2055,15 @@ bool cheatsImportGSACodeFile(const char* name, int game, bool v3)
             found = true;
             break;
         }
-        fread(&len, 1, 4, f);
+        FREAD_UNCHECKED(&len, 1, 4, f);
         fseek(f, len, SEEK_CUR);
         int codes = 0;
-        fread(&codes, 1, 4, f);
+        FREAD_UNCHECKED(&codes, 1, 4, f);
         while (codes > 0) {
-            fread(&len, 1, 4, f);
+            FREAD_UNCHECKED(&len, 1, 4, f);
             fseek(f, len, SEEK_CUR);
             fseek(f, 8, SEEK_CUR);
-            fread(&len, 1, 4, f);
+            FREAD_UNCHECKED(&len, 1, 4, f);
             fseek(f, len * 12, SEEK_CUR);
             codes--;
         }
@@ -2073,26 +2073,26 @@ bool cheatsImportGSACodeFile(const char* name, int game, bool v3)
     if (found) {
         char desc[256];
         char code[17];
-        fread(&len, 1, 4, f);
+        FREAD_UNCHECKED(&len, 1, 4, f);
         fseek(f, len, SEEK_CUR);
         int codes = 0;
-        fread(&codes, 1, 4, f);
+        FREAD_UNCHECKED(&codes, 1, 4, f);
         while (codes > 0) {
-            fread(&len, 1, 4, f);
+            FREAD_UNCHECKED(&len, 1, 4, f);
 	    if (len > 255)
 		    goto evil_gsa_code_file;	//XXX: this functione needs a rewrite in general, so for the short this is better than nothing
-            fread(desc, 1, len, f);
+            FREAD_UNCHECKED(desc, 1, len, f);
             desc[len] = 0;
             desc[31] = 0;
-            fread(&len, 1, 4, f);
+            FREAD_UNCHECKED(&len, 1, 4, f);
             fseek(f, len, SEEK_CUR);
             fseek(f, 4, SEEK_CUR);
-            fread(&len, 1, 4, f);
+            FREAD_UNCHECKED(&len, 1, 4, f);
             while (len) {
                 fseek(f, 4, SEEK_CUR);
-                fread(code, 1, 8, f);
+                FREAD_UNCHECKED(code, 1, 8, f);
                 fseek(f, 4, SEEK_CUR);
-                fread(&code[8], 1, 8, f);
+                FREAD_UNCHECKED(&code[8], 1, 8, f);
                 code[16] = 0;
                 cheatsAddGSACode(code, desc, v3);
                 len -= 2;
@@ -2734,16 +2734,16 @@ bool cheatsLoadCheatList(const char* file)
         }
     } else if (type == 0) {
         for (int i = 0; i < count; i++) {
-            fread(&cheatsList[i].code, 1, sizeof(int), f);
-            fread(&cheatsList[i].size, 1, sizeof(int), f);
-            fread(&cheatsList[i].status, 1, sizeof(int), f);
-            fread(&cheatsList[i].enabled, 1, sizeof(int), f);
+            FREAD_UNCHECKED(&cheatsList[i].code, 1, sizeof(int), f);
+            FREAD_UNCHECKED(&cheatsList[i].size, 1, sizeof(int), f);
+            FREAD_UNCHECKED(&cheatsList[i].status, 1, sizeof(int), f);
+            FREAD_UNCHECKED(&cheatsList[i].enabled, 1, sizeof(int), f);
             cheatsList[i].enabled = cheatsList[i].enabled ? true : false;
-            fread(&cheatsList[i].address, 1, sizeof(uint32_t), f);
+            FREAD_UNCHECKED(&cheatsList[i].address, 1, sizeof(uint32_t), f);
             cheatsList[i].rawaddress = cheatsList[i].address;
-            fread(&cheatsList[i].value, 1, sizeof(uint32_t), f);
-            fread(&cheatsList[i].oldValue, 1, sizeof(uint32_t), f);
-            fread(&cheatsList[i].codestring, 1, 20 * sizeof(char), f);
+            FREAD_UNCHECKED(&cheatsList[i].value, 1, sizeof(uint32_t), f);
+            FREAD_UNCHECKED(&cheatsList[i].oldValue, 1, sizeof(uint32_t), f);
+            FREAD_UNCHECKED(&cheatsList[i].codestring, 1, 20 * sizeof(char), f);
             if (fread(&cheatsList[i].desc, 1, 32 * sizeof(char), f) != 32 * sizeof(char)) {
                 fclose(f);
                 return false;

--- a/src/gba/GBA.cpp
+++ b/src/gba/GBA.cpp
@@ -1007,21 +1007,21 @@ bool CPUReadGSASnapshot(const char* fileName)
 
     // long size = ftell(file);
     fseek(file, 0x0, SEEK_SET);
-    fread(&i, 1, 4, file);
+    FREAD_UNCHECKED(&i, 1, 4, file);
     fseek(file, i, SEEK_CUR); // Skip SharkPortSave
     fseek(file, 4, SEEK_CUR); // skip some sort of flag
-    fread(&i, 1, 4, file); // name length
+    FREAD_UNCHECKED(&i, 1, 4, file); // name length
     fseek(file, i, SEEK_CUR); // skip name
-    fread(&i, 1, 4, file); // desc length
+    FREAD_UNCHECKED(&i, 1, 4, file); // desc length
     fseek(file, i, SEEK_CUR); // skip desc
-    fread(&i, 1, 4, file); // notes length
+    FREAD_UNCHECKED(&i, 1, 4, file); // notes length
     fseek(file, i, SEEK_CUR); // skip notes
     int saveSize;
-    fread(&saveSize, 1, 4, file); // read length
+    FREAD_UNCHECKED(&saveSize, 1, 4, file); // read length
     saveSize -= 0x1c; // remove header size
     char buffer[17];
     char buffer2[17];
-    fread(buffer, 1, 16, file);
+    FREAD_UNCHECKED(buffer, 1, 16, file);
     buffer[16] = 0;
     for (i = 0; i < 16; i++)
         if (buffer[i] < 32)
@@ -1074,7 +1074,7 @@ bool CPUReadGSASPSnapshot(const char* fileName)
 
     // read save name
     fseek(file, namepos, SEEK_SET);
-    fread(savename, 1, namesz, file);
+    FREAD_UNCHECKED(savename, 1, namesz, file);
     savename[namesz] = 0;
 
     memcpy(romname, &rom[0xa0], namesz);
@@ -1091,7 +1091,7 @@ bool CPUReadGSASPSnapshot(const char* fileName)
 
     // read footer tag
     fseek(file, footerpos, SEEK_SET);
-    fread(footer, 1, footersz, file);
+    FREAD_UNCHECKED(footer, 1, footersz, file);
     footer[footersz] = 0;
 
     if (memcmp(footer, gsvfooter, footersz)) {
@@ -1106,7 +1106,7 @@ bool CPUReadGSASPSnapshot(const char* fileName)
     }
 
     // Read up to 128k save
-    fread(flashSaveMemory, 1, FLASH_128K_SZ, file);
+    FREAD_UNCHECKED(flashSaveMemory, 1, FLASH_128K_SZ, file);
 
     fclose(file);
     CPUReset();

--- a/src/gba/GBA.h
+++ b/src/gba/GBA.h
@@ -3,6 +3,7 @@
 
 #include "../common/Types.h"
 #include "../System.h"
+#include "../Util.h"
 
 const uint64_t TICKS_PER_SECOND = 16777216;
 

--- a/src/gba/GBALink.cpp
+++ b/src/gba/GBALink.cpp
@@ -609,6 +609,7 @@ void EnableSpeedHacks(bool enable)
 
 void BootLink(int m_type, const char* hostAddr, int timeout, bool m_hacks, int m_numplayers)
 {
+    (void)m_numplayers; // unused param
     if (linkDriver) {
         // Connection has already been established
         return;
@@ -888,7 +889,7 @@ bool CableServer::RecvGB(void)
     if (counter == 1)
         return false;
 
-    int numbytes;
+    int numbytes = 0;
     if (lanlink.type == 0) { // TCP
         fdset.clear();
 
@@ -1230,6 +1231,7 @@ void StartCableSocket(uint16_t value)
 
 static void UpdateCableSocket(int ticks)
 {
+    (void)ticks; // unused param
     if (linkid && transfer_direction == SENDING && lc.transferring && linktime >= transfer_start_time_from_master) {
         cable_data[linkid] = READ16LE(&ioMem[COMM_SIODATA8]);
 
@@ -2199,7 +2201,8 @@ static void StartRFUSocket(uint16_t value)
                         case 0x24: // send [non-important] data (used by server often)
                             rfu_data.rfu_linktime[linkid] = linktime; //save the ticks before reseted to zero
 
-                            if (rfu_cansend && rfu_qsend2 >= 0) {
+			    // rfu_qsend2 >= 0 due to being `uint8_t`
+                            if (rfu_cansend) {
                                 if (rfu_ishost) {
                                     for (int j = 0; j < rfu_data.numgbas; j++)
                                         if (j != linkid) {
@@ -2560,7 +2563,7 @@ uint16_t gbLinkUpdate(uint8_t b, int gbSerialOn) //used on external clock
     rfu_enabled = false;
 
     if (gbSerialOn) {
-        if (gba_link_enabled)
+        if (gba_link_enabled) {
             //Single Computer
             if (GetLinkMode() == LINK_GAMEBOY_IPC) {
 #if (defined __WIN32__ || defined _WIN32)
@@ -2595,7 +2598,7 @@ uint16_t gbLinkUpdate(uint8_t b, int gbSerialOn) //used on external clock
                     }
                 }
             }
-
+	}
         if (dat == 0xff /*||dat==0x00||b==0x00*/) //dat==0xff||dat==0x00
             LinkFirstTime = true;
     }

--- a/src/gba/GBASockClient.cpp
+++ b/src/gba/GBASockClient.cpp
@@ -59,6 +59,7 @@ char GBASockClient::ReceiveCmd(char* data_in, bool block)
 
 void GBASockClient::ReceiveClock(bool block)
 {
+    (void)block; // unused param
     if (IsDisconnected())
         return;
 

--- a/src/gba/GBAinline.h
+++ b/src/gba/GBAinline.h
@@ -56,7 +56,7 @@ static inline uint32_t CPUReadMemory(uint32_t address)
         }
     }
 #endif
-    uint32_t value;
+    uint32_t value = 0;
     uint32_t oldAddress = address;
 
     if (address & 3) {

--- a/src/gba/debugger-expr-yacc.cpp
+++ b/src/gba/debugger-expr-yacc.cpp
@@ -1141,7 +1141,7 @@ int yyparse()
 #if YYERROR_VERBOSE
     /* Buffer for error messages, and its allocated size.  */
     char yymsgbuf[128];
-    char* yymsg = yymsgbuf;
+    char* yymsg = (char *)yymsgbuf;
     YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
 #endif
 
@@ -1518,7 +1518,7 @@ yyerrlab:
     if (!yyerrstatus) {
         ++yynerrs;
 #if !YYERROR_VERBOSE
-        yyerror(YY_("syntax error"));
+        yyerror((char *)YY_("syntax error"));
 #else
         {
             YYSIZE_T yysize = yysyntax_error(0, yystate, yychar);
@@ -1541,7 +1541,7 @@ yyerrlab:
                 (void)yysyntax_error(yymsg, yystate, yychar);
                 yyerror(yymsg);
             } else {
-                yyerror(YY_("syntax error"));
+                yyerror((char *)YY_("syntax error"));
                 if (yysize != 0)
                     goto yyexhaustedlab;
             }
@@ -1645,7 +1645,7 @@ yyabortlab:
 | yyexhaustedlab -- memory exhaustion comes here.  |
 `-------------------------------------------------*/
 yyexhaustedlab:
-    yyerror(YY_("memory exhausted"));
+    yyerror((char *)YY_("memory exhausted"));
     yyresult = 2;
 /* Fall through.  */
 #endif

--- a/src/gba/ereader.cpp
+++ b/src/gba/ereader.cpp
@@ -222,6 +222,7 @@ void BIOS_EReader_ScanCard(int swi_num)
 
     FILE* f;
 
+    i = j = k = 0;
     //Open dotcode bin/raw
 
     if (swi_num == 0xE0) {
@@ -259,7 +260,7 @@ void BIOS_EReader_ScanCard(int swi_num)
             reg[0].I = 0x303;
             return;
         }
-        fread(DotCodeData, 1, i, f);
+        FREAD_UNCHECKED(DotCodeData, 1, i, f);
         fclose(f);
 
         if (dotcodetype == 0) {

--- a/src/gba/remote.cpp
+++ b/src/gba/remote.cpp
@@ -349,6 +349,7 @@ void debuggerDontBreak(int n, char** args)
 
 void debuggerDontBreakClear(int n, char** args)
 {
+    (void)args; // unused params
     if (n == 1) {
         debuggerNumOfDontBreak = 0;
         {
@@ -782,7 +783,7 @@ unsigned int AddressToGBA(uint8_t* mem)
 
 void debuggerDoSearch()
 {
-    int count = 0;
+    unsigned int count = 0;
 
     while (true) {
         unsigned int final = SearchStart + SearchLength - 1;
@@ -1882,6 +1883,8 @@ void debuggerSymbols(int argc, char** argv)
 
 void debuggerWhere(int n, char** args)
 {
+    (void)n; // unused params
+    (void)args; // unused params
     void elfPrintCallChain(uint32_t);
     elfPrintCallChain(armNextPC);
 }
@@ -1958,6 +1961,7 @@ void debuggerVar(int n, char** args)
 
 bool debuggerBreakOnExecution(uint32_t address, uint8_t state)
 {
+    (void)state; // unused params
     if (dontBreakNow)
         return false;
     if (debuggerInDB(address))
@@ -1975,6 +1979,7 @@ bool debuggerBreakOnExecution(uint32_t address, uint8_t state)
 
 bool debuggerBreakOnRead(uint32_t address, int size)
 {
+    (void)size; // unused params
     if (dontBreakNow)
         return false;
     if (debuggerInDB(armState ? reg[15].I - 4 : reg[15].I - 2))
@@ -1996,6 +2001,8 @@ bool debuggerBreakOnRead(uint32_t address, int size)
 
 bool debuggerBreakOnWrite(uint32_t address, uint32_t value, int size)
 {
+    (void)value; // unused params
+    (void)size; // unused params
     if (dontBreakNow)
         return false;
     if (debuggerInDB(armState ? reg[15].I - 4 : reg[15].I - 2))
@@ -2019,6 +2026,8 @@ bool debuggerBreakOnWrite(uint32_t address, uint32_t value, int size)
 
 void debuggerBreakOnWrite(uint32_t address, uint32_t oldvalue, uint32_t value, int size, int t)
 {
+    (void)oldvalue; // unused params
+    (void)t; // unused params
     debuggerBreakOnWrite(address, value, size);
     //uint32_t lastValue;
     //dexp_eval("old_value", &lastValue);
@@ -2677,6 +2686,8 @@ void deleteBreak(uint32_t address, uint8_t flags, char** expression, int howToDe
 }
 void clearBreaks(uint32_t address, uint8_t flags, char** expression, int howToClear)
 {
+    (void)address; // unused params
+    (void)expression; // unused params
     if (howToClear == 2) {
         removeConditionalWithFlag(flags, true);
         removeConditionalWithFlag(flags << 4, true);
@@ -2692,6 +2703,7 @@ void clearBreaks(uint32_t address, uint8_t flags, char** expression, int howToCl
 
 void listBreaks(uint32_t address, uint8_t flags, char** expression, int howToList)
 {
+    (void)expression; // unused params
     flags |= (flags << 4);
     if (howToList) {
         printAllFlagConditionalsWithAddress(address, flags, true);
@@ -2896,8 +2908,7 @@ void executeBreakCommands(int n, char** cmd)
         operation(address, flag, cmd + 1, n - 1);
         return;
     }
-
-brkcmd_special_register:
+//brkcmd_special_register:
     switch (command[4]) {
     case 'l':
         debuggerBreakRegisterList((n > 0) && (tolower(cmd[0][0]) == 'v'));
@@ -3779,7 +3790,7 @@ void remoteSetBreakPoint(char* p)
 
 void remoteClearBreakPoint(char* p)
 {
-    int result;
+    int result = 0;
     uint32_t address;
     int count;
     sscanf(p, ",%x,%x#", &address, &count);
@@ -3968,6 +3979,7 @@ void remoteReadRegister(char* p)
 
 void remoteReadRegisters(char* p)
 {
+    (void)p; // unused params
     char buffer[1024];
 
     char* s = buffer;
@@ -4226,6 +4238,7 @@ void remoteStubMain()
 
 void remoteStubSignal(int sig, int number)
 {
+    (void)number; // unused params
     remoteSignal = sig;
     remoteResumed = false;
     remoteSendStatus();

--- a/src/libretro/SoundRetro.cpp
+++ b/src/libretro/SoundRetro.cpp
@@ -33,6 +33,7 @@ void SoundRetro::write(uint16_t* finalWave, int length)
 
 bool SoundRetro::init(long sampleRate)
 {
+    (void)sampleRate; // unused param
     return true;
 }
 
@@ -50,4 +51,9 @@ void SoundRetro::resume()
 
 void SoundRetro::reset()
 {
+}
+
+void setThrottle(unsigned short throttle)
+{
+    (void)throttle; // unused param
 }

--- a/src/libretro/SoundRetro.cpp
+++ b/src/libretro/SoundRetro.cpp
@@ -53,7 +53,7 @@ void SoundRetro::reset()
 {
 }
 
-void setThrottle(unsigned short throttle)
+void SoundRetro::setThrottle(unsigned short throttle)
 {
     (void)throttle; // unused param
 }

--- a/src/libretro/SoundRetro.h
+++ b/src/libretro/SoundRetro.h
@@ -30,6 +30,7 @@ public:
     virtual void reset();
     virtual void resume();
     virtual void write(uint16_t* finalWave, int length);
+    virtual void setThrottle(unsigned short throttle);
 };
 
 #endif // __VBA_SOUND_RETRO_H__

--- a/src/libretro/UtilRetro.cpp
+++ b/src/libretro/UtilRetro.cpp
@@ -192,7 +192,7 @@ uint8_t *utilLoad(const char *file, bool (*accept)(const char *), uint8_t *data,
 		}
 	}
 
-   fread(image, 1, size, fp); // read into buffer
+        FREAD_UNCHECKED(image, 1, size, fp); // read into buffer
 	fclose(fp);
 	return image;
 }

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -492,7 +492,8 @@ static void sdlOpenGLVideoResize()
 
 void sdlOpenGLInit(int w, int h)
 {
-
+    (void)w; // unused params
+    (void)h; // unused params
 #if 0
   float screenAspect = (float) sizeX / sizeY,
         windowAspect = (float) w / h;
@@ -2058,6 +2059,7 @@ int main(int argc, char** argv)
 
 void systemMessage(int num, const char* msg, ...)
 {
+    (void)num; // unused params
     va_list valist;
 
     va_start(valist, msg);
@@ -2290,6 +2292,12 @@ uint32_t systemGetClock()
 
 void systemGbPrint(uint8_t* data, int len, int pages, int feed, int palette, int contrast)
 {
+    (void)data; // unused params
+    (void)len; // unused params
+    (void)pages; // unused params
+    (void)feed; // unused params
+    (void)palette; // unused params
+    (void)contrast; // unused params
 }
 
 /* xKiv: added timestamp */
@@ -2412,6 +2420,8 @@ void systemOnSoundShutdown()
 
 void systemOnWriteDataToSoundBuffer(const uint16_t* finalWave, int length)
 {
+    (void)finalWave; // unused params
+    (void)length; // unused params
 }
 
 void log(const char* defaultMsg, ...)

--- a/src/sdl/expr.cpp
+++ b/src/sdl/expr.cpp
@@ -1530,6 +1530,7 @@ yyreturn:
 
 int yyerror(const char* s)
 {
+    (void)s; // unused params
     return 0;
 }
 

--- a/src/sdl/exprNode.cpp
+++ b/src/sdl/exprNode.cpp
@@ -97,6 +97,9 @@ Node* exprNodeNumber()
 
 bool exprNodeNumberResolve(Node* n, Function* f, CompileUnit* u)
 {
+    (void)n; // unused params
+    (void)f; // unused params
+    (void)u; // unused params
     return true;
 }
 

--- a/src/sdl/filters.cpp
+++ b/src/sdl/filters.cpp
@@ -605,6 +605,7 @@ void (*sdlStretcher24[4])(uint8_t*, uint8_t*, int) = {
 
 bool sdlStretchInit(int colorDepth, int sizeMultiplier, int srcWidth)
 {
+    (void)srcWidth; // unused params
 #ifndef C_CORE
     sdlMakeStretcher(srcWidth, sizeMultiplier);
 #else

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -50,7 +50,7 @@ void MainFrame::GetMenuOptionBool(const char* menuName, bool& field)
     field = !field;
     int id = wxXmlResource::GetXRCID(wxString(menuName, wxConvUTF8));
 
-    for (int i = 0; i < checkable_mi.size(); i++) {
+    for (size_t i = 0; i < checkable_mi.size(); i++) {
         if (checkable_mi[i].cmd != id)
             continue;
 
@@ -65,7 +65,7 @@ void MainFrame::GetMenuOptionInt(const char* menuName, int& field, int mask)
     bool is_checked = ((field) & (mask)) != (value);
     int id = wxXmlResource::GetXRCID(wxString(menuName, wxConvUTF8));
 
-    for (int i = 0; i < checkable_mi.size(); i++) {
+    for (size_t i = 0; i < checkable_mi.size(); i++) {
         if (checkable_mi[i].cmd != id)
             continue;
 
@@ -80,7 +80,7 @@ void MainFrame::SetMenuOption(const char* menuName, int value)
 {
     int id = wxXmlResource::GetXRCID(wxString(menuName, wxConvUTF8));
 
-    for (int i = 0; i < checkable_mi.size(); i++) {
+    for (size_t i = 0; i < checkable_mi.size(); i++) {
         if (checkable_mi[i].cmd != id)
             continue;
 
@@ -506,6 +506,7 @@ static bool maker_lt(const rom_maker& r1, const rom_maker& r2)
 
 void SetDialogLabel(wxDialog* dlg, const wxString& id, wxString ts, size_t l)
 {
+    (void)l; // unused params
     ts.Replace(wxT("&"), wxT("&&"), true);
     (dynamic_cast<wxControl*>((*dlg).FindWindow(wxXmlResource::GetXRCID(id))))->SetLabel(ts);
 }
@@ -548,7 +549,7 @@ EVT_HANDLER_MASK(RomInformation, "ROM information...", CMDEN_GB | CMDEN_GBA)
             s.Printf(wxT("%02x"), gbRom[0x14b]);
 
         setlab("MakerCode");
-        const rom_maker m = { s }, *rm;
+        const rom_maker m = { s, wxString() }, *rm;
         rm = std::lower_bound(&makers[0], &makers[num_makers], m, maker_lt);
 
         if (rm < &makers[num_makers] && !wxStrcmp(m.code, rm->code))
@@ -776,7 +777,7 @@ EVT_HANDLER_MASK(RomInformation, "ROM information...", CMDEN_GB | CMDEN_GBA)
         SetDialogLabel(dlg, wxT("CRC32"), rom_crc32, 8);
         setlabs("GameCode", rom[0xac], 4);
         setlabs("MakerCode", rom[0xb0], 2);
-        const rom_maker m = { s }, *rm;
+        const rom_maker m = { s, wxString() }, *rm;
         rm = std::lower_bound(&makers[0], &makers[num_makers], m, maker_lt);
 
         if (rm < &makers[num_makers] && !wxStrcmp(m.code, rm->code))
@@ -804,6 +805,9 @@ EVT_HANDLER_MASK(RomInformation, "ROM information...", CMDEN_GB | CMDEN_GBA)
         dlg->Fit();
         ShowModal(dlg);
     } break;
+
+    default:
+	break;
     }
 }
 
@@ -971,7 +975,7 @@ EVT_HANDLER_MASK(ImportGamesharkCodeFile, "Import GameShark code file...", CMDEN
 
                 game = lst->GetSelection();
 
-                if (game == wxNOT_FOUND)
+                if ((int)game == wxNOT_FOUND)
                     game = 0;
             }
 
@@ -1606,7 +1610,7 @@ EVT_HANDLER_MASK(Rewind, "Rewind", CMDEN_REWIND)
     // if within 5 seconds of last one, and > 1 state, delete last state & move back
     // FIXME: 5 should actually be user-configurable
     // maybe instead of 5, 10% of rewind_interval
-    if (panel->num_rewind_states > 1 && (gopts.rewind_interval <= 5 || panel->rewind_time / 6 > gopts.rewind_interval - 5)) {
+    if (panel->num_rewind_states > 1 && (gopts.rewind_interval <= 5 || (int)panel->rewind_time / 6 > gopts.rewind_interval - 5)) {
         --panel->num_rewind_states;
         panel->next_rewind_state = rew_st;
 
@@ -1713,7 +1717,7 @@ EVT_HANDLER_MASK(VideoLayersReset, "Show all video layers", CMDEN_GB | CMDEN_GBA
 #define set_vl(s)                                     \
     do {                                              \
         int id = XRCID(s);                            \
-        for (int i = 0; i < checkable_mi.size(); i++) \
+        for (size_t i = 0; i < checkable_mi.size(); i++) \
             if (checkable_mi[i].cmd == id) {          \
                 checkable_mi[i].mi->Check(true);      \
                 break;                                \
@@ -2291,7 +2295,7 @@ EVT_HANDLER_MASK(ChangeFilter, "Change Pixel Filter", CMDEN_NREC_ANY)
 {
     int filt = gopts.filter;
 
-    if (filt == FF_PLUGIN || ++gopts.filter == FF_PLUGIN && gopts.filter_plugin.empty()) {
+    if ((filt == FF_PLUGIN || ++gopts.filter == FF_PLUGIN) && gopts.filter_plugin.empty()) {
         gopts.filter = 0;
     }
 

--- a/src/wx/copy-events.cmake
+++ b/src/wx/copy-events.cmake
@@ -18,7 +18,7 @@ SET(EVLINES )
 FOREACH(EV ${MW})
     # stripping the wxID_ makes it look better, but it's still all-caps
     STRING(REGEX REPLACE "^[^\"]*\\((wxID_|)([^,]*),[^\"]*(\"[^\"]*\")[^,)]*(,[^)]*|).*"
-                         "    {wxT(\"\\2\"), wxTRANSLATE(\\3), XRCID(\"\\1\\2\")\\4 }"
+                         "    new_cmditem(wxT(\"\\2\"), wxTRANSLATE(\\3), XRCID(\"\\1\\2\")\\4 )"
 			 EV "${EV}")
     STRING(REGEX REPLACE "XRCID\\(\"(wxID_[^\"]*)\"\\)" "\\1" EV ${EV})
     LIST(APPEND EVLINES "${EV},\n")

--- a/src/wx/gfxviewers.cpp
+++ b/src/wx/gfxviewers.cpp
@@ -229,7 +229,7 @@ public:
             s.Printf(wxT("0x%08X"), address);
             addr->SetLabel(s);
 
-            if (!mode || (mode < 3 || mode > 5) && bg < 2) {
+            if ((!mode || (mode < 3 || mode > 5)) && bg < 2) {
                 uint16_t value = *((uint16_t*)&vram[address - 0x6000000]);
                 s.Printf(wxT("%d"), value & 1023);
                 tile->SetLabel(s);
@@ -738,6 +738,10 @@ void MainFrame::MapViewer()
     case IMAGE_GB:
         LoadXRCViewer(GBMap);
         break;
+
+    case IMAGE_UNKNOWN:
+	// do nothing
+	break;
     }
 }
 
@@ -1113,6 +1117,10 @@ void MainFrame::OAMViewer()
     case IMAGE_GB:
         LoadXRCViewer(GBOAM);
         break;
+
+    case IMAGE_UNKNOWN:
+	// do nothing
+	break;
     }
 }
 
@@ -1233,11 +1241,13 @@ public:
     }
     void SelBG(wxMouseEvent& ev)
     {
+	(void)ev; // unused params
         spv->SetSel(-1, -1, false);
         ShowSel();
     }
     void SelSprite(wxMouseEvent& ev)
     {
+	(void)ev; // unused params
         bpv->SetSel(-1, -1, false);
         ShowSel();
     }
@@ -1273,14 +1283,17 @@ public:
     }
     void SaveBG(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         savepal(this, colbmp, 16 * 16, wxT("bg"));
     }
     void SaveOBJ(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         savepal(this, colbmp + 16 * 16 * 3, 16 * 16, wxT("obj"));
     }
     void ChangeBackdrop(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         // FIXME: this should really be a preference
         // should also have some way of indicating selection
         // perhaps replace w/ checkbox + colorpickerctrl
@@ -1294,7 +1307,7 @@ public:
             *cd = dlg.GetColourData();
             wxColour c = cd->GetColour();
             //Binary or the upper 5 bits of each color choice
-            customBackdropColor = (c.Red() >> 3) || ((c.Green() >> 3) << 5) || ((c.Blue() >> 3) << 10);
+            customBackdropColor = ((c.Red() >> 3) != 0) || (((c.Green() >> 3) << 5) != 0) || (((c.Blue() >> 3) << 10) != 0);
         } else
             // kind of an unintuitive way to turn it off...
             customBackdropColor = -1;
@@ -1347,11 +1360,13 @@ public:
     }
     void SelBG(wxMouseEvent& ev)
     {
+	(void)ev; // unused params
         spv->SetSel(-1, -1, false);
         ShowSel();
     }
     void SelSprite(wxMouseEvent& ev)
     {
+	(void)ev; // unused params
         bpv->SetSel(-1, -1, false);
         ShowSel();
     }
@@ -1386,10 +1401,12 @@ public:
     }
     void SaveBG(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         savepal(this, colbmp, 4 * 8, wxT("bg"));
     }
     void SaveOBJ(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         savepal(this, colbmp + 4 * 8 * 3, 4 * 8, wxT("obj"));
     }
 
@@ -1419,6 +1436,10 @@ void MainFrame::PaletteViewer()
     case IMAGE_GB:
         LoadXRCViewer(GBPalette);
         break;
+
+    case IMAGE_UNKNOWN:
+	// do nothing
+	break;
     }
 }
 
@@ -1687,5 +1708,9 @@ void MainFrame::TileViewer()
     case IMAGE_GB:
         LoadXRCViewer(GBTile);
         break;
+
+    case IMAGE_UNKNOWN:
+	// do nothing
+	break;
     }
 }

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -73,10 +73,12 @@ public:
     wxButton* okb;
     void ServerOKButton(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         okb->SetLabel(_("Start!"));
     }
     void ClientOKButton(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         okb->SetLabel(_("Connect"));
     }
     // attached to OK, so skip when OK
@@ -306,7 +308,7 @@ public:
         } break;
 
         case wxID_REMOVE: {
-            bool asked = false, restore;
+            bool asked = false, restore = false;
 
             for (int i = list->GetItemCount() - 1; i >= 0; i--)
                 if (list->GetItemState(i, wxLIST_STATE_SELECTED)) {
@@ -705,10 +707,14 @@ public:
     CheatListFill(const CheatListFill& e)
         : wxValidator()
     {
+	(void)e; // unused params
     }
     wxObject* Clone() const { return new CheatListFill(*this); }
     bool TransferFromWindow() { return true; }
-    bool Validate(wxWindow* p) { return true; }
+    bool Validate(wxWindow* p) {
+	(void)p; // unused params
+	return true;
+    }
     bool TransferToWindow()
     {
         CheatList_t& clh = cheat_list_handler;
@@ -886,6 +892,7 @@ public:
 
     void UpdateVals(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         if (cheatSearchData.count) {
             cheatSearchUpdateValues(&cheatSearchData);
 
@@ -898,6 +905,7 @@ public:
 
     void ResetSearch(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         if (!cheatSearchData.count) {
             CheatSearchBlock* block = cheatSearchData.blocks;
 
@@ -989,6 +997,7 @@ public:
 
     void AddCheatB(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         int idx = list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 
         if (idx >= 0)
@@ -1195,6 +1204,7 @@ public:
 
     void UpdateView(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         dlg->TransferDataFromWindow();
 
         if (ofmt != fmt && !val_s.empty()) {
@@ -1283,10 +1293,14 @@ public:
     CheatFindFill(const CheatFindFill& e)
         : wxValidator()
     {
+	(void)e; // unused params
     }
     wxObject* Clone() const { return new CheatFindFill(*this); }
     bool TransferFromWindow() { return true; }
-    bool Validate(wxWindow* p) { return true; }
+    bool Validate(wxWindow* p) {
+	(void)p; // unused params
+	return true;
+    }
     bool TransferToWindow()
     {
         CheatFind_t& cfh = cheat_find_handler;
@@ -1314,7 +1328,7 @@ wxString CheatListCtrl::OnGetItemText(long item, long column) const
         off = (item & ((1 << (cap_size - size)) - 1)) << size;
         item >>= cap_size - size;
     } else if (cap_size < size) {
-        for (int i = 0; i < addrs.size(); i++) {
+        for (size_t i = 0; i < addrs.size(); i++) {
             if (!(addrs[i] & ((1 << size) - 1)) && !item--) {
                 item = i;
                 break;
@@ -1419,6 +1433,7 @@ public:
     }
     void ColorReset(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         const uint16_t* color = &systemGbPalette[pno * 8];
 
         for (int i = 0; i < 8; i++, color++)
@@ -1429,6 +1444,7 @@ public:
 
     void ColorButton(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         c->SetSelection(0);
     }
 } GBColorConfigHandler[3];
@@ -1443,10 +1459,14 @@ public:
     GBACtrlEnabler(const GBACtrlEnabler& e)
         : wxValidator()
     {
+	(void)e; // unused params
     }
     wxObject* Clone() const { return new GBACtrlEnabler(*this); }
     bool TransferFromWindow() { return true; }
-    bool Validate(wxWindow* p) { return true; }
+    bool Validate(wxWindow* p) {
+	(void)p; // unused params
+	return true;
+    }
     bool TransferToWindow()
     {
         GetWindow()->Enable(wxGetApp().frame->GetPanel()->game_type() == IMAGE_GBA);
@@ -1465,6 +1485,7 @@ public:
     }
     void Detect(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         uint32_t sz = wxGetApp().frame->GetPanel()->game_size();
         utilGBAFindSave(sz);
         type->SetSelection(saveType);
@@ -1490,6 +1511,7 @@ public:
 
     void FullVol(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         vol->SetValue(100);
     }
     void AdjustFrames(int count)
@@ -1500,6 +1522,7 @@ public:
     }
     void AdjustFramesEv(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         AdjustFrames(bufs->GetValue());
     }
 
@@ -1549,7 +1572,7 @@ public:
 
         dev->SetSelection(0);
 
-        for (int i = 0; i < names.size(); i++) {
+        for (size_t i = 0; i < names.size(); i++) {
             dev->Append(names[i]);
 
             if (api == gopts.audio_api && gopts.audio_dev == dev_ids[i])
@@ -1587,9 +1610,13 @@ public:
     SoundConfigLoad(const SoundConfigLoad& e)
         : wxValidator()
     {
+	(void)e; // unused params
     }
     wxObject* Clone() const { return new SoundConfigLoad(*this); }
-    bool Validate(wxWindow* p) { return true; }
+    bool Validate(wxWindow* p) {
+	(void)p; // unused params
+	return true;
+    }
     bool TransferToWindow()
     {
         SoundConfig_t& sch = sound_config_handler;
@@ -1650,9 +1677,13 @@ public:
     ScreenModeList(const ScreenModeList& e)
         : wxValidator()
     {
+	(void)e; // unused params
     }
     wxObject* Clone() const { return new ScreenModeList(*this); }
-    bool Validate(wxWindow* p) { return true; }
+    bool Validate(wxWindow* p) {
+	(void)p; // unused params
+	return true;
+    }
     bool TransferToWindow()
     {
         wxChoice* c = wxStaticCast(GetWindow(), wxChoice);
@@ -1666,7 +1697,7 @@ public:
         vm = d.GetModes();
         wxString s;
 
-        for (int i = 0; i < vm.size(); i++) {
+        for (size_t i = 0; i < vm.size(); i++) {
             s.Printf(_("%d x %d - %dbpp @ %dHz"), vm[i].w, vm[i].h, vm[i].bpp, vm[i].refresh);
             c->Append(s);
 
@@ -1724,10 +1755,14 @@ public:
     PluginEnabler(const PluginEnabler& e)
         : wxValidator()
     {
+	(void)e; // unused params
     }
     wxObject* Clone() const { return new PluginEnabler(*this); }
     bool TransferFromWindow() { return true; }
-    bool Validate(wxWindow* p) { return true; }
+    bool Validate(wxWindow* p) {
+	(void)p; // unused params
+	return true;
+    }
     bool TransferToWindow()
     {
         GetWindow()->Enable(gopts.filter == FF_PLUGIN);
@@ -1752,22 +1787,25 @@ class PluginListFiller : public PluginEnabler {
 public:
     PluginListFiller(wxDialog* parent, wxControl* lab, wxChoice* ch)
         : PluginEnabler()
+	, dlg(parent)
         , txt(lab)
-        , dlg(parent)
-        , plugins()
         , filtch(ch)
+        , plugins()
     {
     }
     PluginListFiller(const PluginListFiller& e)
         : PluginEnabler()
+	, dlg(e.dlg)
         , txt(e.txt)
-        , dlg(e.dlg)
-        , plugins(e.plugins)
         , filtch(e.filtch)
+        , plugins(e.plugins)
     {
     }
     wxObject* Clone() const { return new PluginListFiller(*this); }
-    bool Validate(wxWindow* p) { return true; }
+    bool Validate(wxWindow* p) {
+	(void)p; // unused params
+	return true;
+    }
     bool TransferToWindow()
     {
         PluginEnabler::TransferToWindow();
@@ -1778,10 +1816,10 @@ public:
         const wxString plpath = wxGetApp().GetPluginsDir();
         wxDir::GetAllFiles(plpath, &plugins, wxT("*.rpi"), wxDIR_FILES | wxDIR_DIRS);
 
-        for (int i = 0; i < plugins.size(); i++) {
+        for (size_t i = 0; i < plugins.size(); i++) {
             wxDynamicLibrary dl(plugins[i], wxDL_VERBATIM | wxDL_NOW);
             RENDPLUG_GetInfo GetInfo;
-            const RENDER_PLUGIN_INFO* rpi;
+            const RENDER_PLUGIN_INFO* rpi = NULL;
 
             if (dl.IsLoaded() && (GetInfo = (RENDPLUG_GetInfo)dl.GetSymbol(wxT("RenderPluginGetInfo"))) &&
                 // note that in actual kega fusion plugins, rpi->Output is
@@ -1803,8 +1841,10 @@ public:
 
                 if (plugins[i] == gopts.filter_plugin)
                     ch->SetSelection(i + 1);
-            } else
+            }
+	    else {
                 plugins.RemoveAt(i--);
+	    }
         }
 
         if (ch->GetCount() == 1) {
@@ -1994,7 +2034,7 @@ public:
         asb->Enable(!key->GetValue().empty());
         int cmd = id->val;
 
-        for (int i = 0; i < accels.size(); i++)
+        for (size_t i = 0; i < accels.size(); i++)
             if (accels[i].GetCommand() == cmdtab[cmd].cmd_id)
                 lb->Append(wxKeyTextCtrl::ToString(accels[i].GetFlags(),
                     accels[i].GetKeyCode()));
@@ -2003,12 +2043,14 @@ public:
     // after selecting a key in key list, enable Remove button
     void KeySel(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         remb->Enable(lb->GetSelection() != wxNOT_FOUND);
     }
 
     // remove selected binding
     void Remove(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         int lsel = lb->GetSelection();
 
         if (lsel == wxNOT_FOUND)
@@ -2039,7 +2081,7 @@ public:
         // if it's a system accel, disable by assigning to NOOP
         wxAcceleratorEntry_v& sys_accels = wxGetApp().frame->sys_accels;
 
-        for (int i = 0; i < sys_accels.size(); i++)
+        for (size_t i = 0; i < sys_accels.size(); i++)
             if (sys_accels[i].GetFlags() == selmod && sys_accels[i].GetKeyCode() == selkey) {
                 wxAcceleratorEntry ne(selmod, selkey, XRCID("NOOP"));
                 user_accels.push_back(ne);
@@ -2057,6 +2099,7 @@ public:
     // wipe out all user bindings
     void ResetAll(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         if (user_accels.empty() || wxMessageBox(_("This will clear all user-defined accelerators.  Are you sure?"), _("Confirm"), wxYES_NO) != wxYES)
             return;
 
@@ -2072,6 +2115,7 @@ public:
     // remove old key binding, add new key binding, and update GUI
     void Assign(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         wxTreeItemId csel = tc->GetSelection();
         wxString accel = key->GetValue();
 
@@ -2083,7 +2127,7 @@ public:
         if (!wxKeyTextCtrl::FromString(accel, acmod, ackey))
             return; // this should never happen
 
-        for (int i = 0; i < lb->GetCount(); i++)
+        for (unsigned int i = 0; i < lb->GetCount(); i++)
             if (lb->GetString(i) == accel)
                 return; // ignore attempts to add twice
 
@@ -2112,6 +2156,7 @@ public:
     // update curas and maybe enable asb
     void CheckKey(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         wxString nkey = key->GetValue();
 
         if (nkey.empty()) {
@@ -2132,7 +2177,7 @@ public:
         asb->Enable(tc->GetSelection().IsOk());
         int cmd = -1;
 
-        for (int i = 0; i < accels.size(); i++)
+        for (size_t i = 0; i < accels.size(); i++)
             if (accels[i].GetFlags() == acmod && accels[i].GetKeyCode() == ackey) {
                 int cmdid = accels[i].GetCommand();
 
@@ -2219,6 +2264,7 @@ public:
     // set thrsel from thr
     void SetThrottleSel(wxSpinEvent& evt)
     {
+	(void)evt; // unused params
         DoSetThrottleSel(thr->GetValue());
     }
 
@@ -2233,6 +2279,7 @@ public:
     // set thr from thrsel
     void SetThrottle(wxCommandEvent& evt)
     {
+	(void)evt; // unused params
         uint32_t val = thrsel->GetSelection() * 25;
 
         if (val <= 600)
@@ -2272,6 +2319,7 @@ public:
     // set speedup_throttle_sel from speedup_throttle
     void SetSpeedupThrottleSel(wxSpinEvent& evt)
     {
+	(void)evt; // unused params
         DoSetSpeedupThrottleSel(speedup_throttle_spin->GetValue());
     }
 
@@ -2290,6 +2338,7 @@ public:
     // set speedup_throttle from speedup_throttle_sel
     void SetSpeedupThrottle(wxCommandEvent& evt)
     {
+	(void)evt; // unused params
         uint32_t val = speedup_throttle_sel->GetSelection() * 25;
 
         if (val > 0 && val <= 600) {
@@ -2312,6 +2361,7 @@ public:
 // set speedup_frame_skip_sel from speedup_frame_skip
 void SpeedupFrameSkipCtrl_t::SetSpeedupFrameSkipSel(wxSpinEvent& evt)
 {
+    (void)evt; // unused params
     DoSetSpeedupFrameSkipSel(speedup_frame_skip_spin->GetValue());
 }
 
@@ -2330,6 +2380,7 @@ void SpeedupFrameSkipCtrl_t::DoSetSpeedupFrameSkipSel(uint32_t val)
 // set speedup_frame_skip from speedup_frame_skip_sel
 void SpeedupFrameSkipCtrl_t::SetSpeedupFrameSkip(wxCommandEvent& evt)
 {
+    (void)evt; // unused params
     uint32_t val = speedup_frame_skip_sel->GetSelection();
 
     if (val > 0 && val <= 30) {
@@ -2451,7 +2502,7 @@ wxAcceleratorEntry_v MainFrame::get_accels(wxAcceleratorEntry_v user_accels)
     // then user overrides
     // silently keep only last defined binding
     // same horribly inefficent O(n*m) search for duplicates as above..
-    for (int i = 0; i < user_accels.size(); i++) {
+    for (size_t i = 0; i < user_accels.size(); i++) {
         const wxAcceleratorEntry& ae = user_accels[i];
 
         for (wxAcceleratorEntry_v::iterator e = accels.begin(); e < accels.end(); ++e)
@@ -2477,7 +2528,7 @@ void MainFrame::set_global_accels()
     // the menus will be added now
 
     // first, zero out menu item on all accels
-    for (int i = 0; i < accels.size(); i++)
+    for (size_t i = 0; i < accels.size(); i++)
         accels[i].Set(accels[i].GetFlags(), accels[i].GetKeyCode(),
             accels[i].GetCommand());
 
@@ -2495,7 +2546,7 @@ void MainFrame::set_global_accels()
         int cmd = cmdtab[i].cmd_id;
         int last_accel = -1;
 
-        for (int j = 0; j < accels.size(); j++)
+        for (size_t j = 0; j < accels.size(); j++)
             if (cmd == accels[j].GetCommand())
                 last_accel = j;
 
@@ -2512,14 +2563,14 @@ void MainFrame::set_global_accels()
     // Finally, install a global accelerator table for any non-menu accels
     int len = 0;
 
-    for (int i = 0; i < accels.size(); i++)
+    for (size_t i = 0; i < accels.size(); i++)
         if (!accels[i].GetMenuItem())
             len++;
 
     if (len) {
         wxAcceleratorEntry tab[1000];
 
-        for (int i = 0, j = 0; i < accels.size(); i++)
+        for (size_t i = 0, j = 0; i < accels.size(); i++)
             if (!accels[i].GetMenuItem())
                 tab[j++] = accels[i];
 
@@ -2534,7 +2585,7 @@ void MainFrame::set_global_accels()
     for (int i = 0; i < 10; i++)
         recent_accel[i] = wxAcceleratorEntry();
 
-    for (int i = 0; i < accels.size(); i++)
+    for (size_t i = 0; i < accels.size(); i++)
         if (accels[i].GetCommand() >= wxID_FILE1 && accels[i].GetCommand() <= wxID_FILE10)
             recent_accel[accels[i].GetCommand() - wxID_FILE1] = accels[i];
 
@@ -2545,7 +2596,7 @@ void MainFrame::MenuOptionBool(const char* menuName, bool& field)
 {
     int id = wxXmlResource::GetXRCID(wxString(menuName, wxConvUTF8));
 
-    for (int i = 0; i < checkable_mi.size(); i++) {
+    for (size_t i = 0; i < checkable_mi.size(); i++) {
         if (checkable_mi[i].cmd != id)
             continue;
 
@@ -2560,7 +2611,7 @@ void MainFrame::MenuOptionIntMask(const char* menuName, int& field, int mask)
     int id = wxXmlResource::GetXRCID(wxString(menuName, wxConvUTF8));
     int value = mask;
 
-    for (int i = 0; i < checkable_mi.size(); i++) {
+    for (size_t i = 0; i < checkable_mi.size(); i++) {
         if (checkable_mi[i].cmd != id)
             continue;
 
@@ -2576,7 +2627,7 @@ void MainFrame::MenuOptionIntRadioValue(const char* menuName, int& field, int va
 {
     int id = wxXmlResource::GetXRCID(wxString(menuName, wxConvUTF8));
 
-    for (int i = 0; i < checkable_mi.size(); i++) {
+    for (size_t i = 0; i < checkable_mi.size(); i++) {
         if (checkable_mi[i].cmd != id)
             continue;
 
@@ -2794,7 +2845,7 @@ bool MainFrame::BindControls()
 
                 // store checkable items
                 if (mi->IsCheckable()) {
-                    checkable_mi_t cmi = { cmdtab[i].cmd_id, mi };
+                    checkable_mi_t cmi = { cmdtab[i].cmd_id, mi, NULL, NULL, 0, 0 };
                     checkable_mi.push_back(cmi);
 
                     for (int j = 0; j < num_opts; j++) {
@@ -2877,7 +2928,7 @@ bool MainFrame::BindControls()
         MenuOptionIntRadioValue("LinkType4Gameboy", gopts.gba_link_type, 4);
     }
 
-    for (int i = 0; i < checkable_mi.size(); i++)
+    for (size_t i = 0; i < checkable_mi.size(); i++)
         if (!checkable_mi[i].boolopt && !checkable_mi[i].intopt) {
             wxLogError(_("Invalid menu item %s; removing"),
                 checkable_mi[i].mi->GetItemLabelText().mb_str());
@@ -3314,6 +3365,7 @@ bool MainFrame::BindControls()
         }
 #define getcbbe(n, o) getbe(n, o, cb, wxCheckBox, CB)
         wxBoolIntEnValidator* bienval;
+	(void)bienval; // not used yet
 #define getbie(n, o, v, cv, t, wt)                                        \
     do {                                                                  \
         cv = SafeXRCCTRL<t>(d, n);                                        \
@@ -3656,7 +3708,7 @@ bool MainFrame::BindControls()
             if (menubar) {
                 wxTreeItemId mid = tc->AppendItem(rid, _("Menu commands"));
 
-                for (int i = 0; i < menubar->GetMenuCount(); i++) {
+                for (size_t i = 0; i < menubar->GetMenuCount(); i++) {
 #if wxCHECK_VERSION(2, 8, 8)
                     wxTreeItemId id = tc->AppendItem(mid, menubar->GetMenuLabelText(i));
 #else

--- a/src/wx/openal.cpp
+++ b/src/wx/openal.cpp
@@ -108,28 +108,27 @@ void OpenAL::debugState()
     ALint value = 0;
     alGetSourcei(source, AL_SOURCE_STATE, &value);
     ASSERT_SUCCESS;
-
     winlog(" soundPaused = %i\n", soundPaused);
     winlog(" Source:\n");
     winlog("  State: ");
-    
+
     switch (value) {
     case AL_INITIAL:
         winlog("AL_INITIAL\n");
         break;
-    
+
     case AL_PLAYING:
         winlog("AL_PLAYING\n");
         break;
-    
+
     case AL_PAUSED:
         winlog("AL_PAUSED\n");
         break;
-    
+
     case AL_STOPPED:
         winlog("AL_STOPPED\n");
         break;
-    
+
     default:
         winlog("!unknown!\n");
         break;
@@ -255,7 +254,7 @@ void OpenAL::reset()
 
 void OpenAL::write(uint16_t* finalWave, int length)
 {
-    length = length;
+    (void)length; // unused params
     if (!initialized)
         return;
 

--- a/src/wx/openal.cpp
+++ b/src/wx/openal.cpp
@@ -27,7 +27,8 @@
 #ifdef winlog
 #undef winlog
 #endif
-#define winlog //
+// https://stackoverflow.com/a/1306690/262458
+#define winlog(x,...) do {} while(0)
 #define debugState() //
 #endif
 
@@ -107,31 +108,33 @@ void OpenAL::debugState()
     ALint value = 0;
     alGetSourcei(source, AL_SOURCE_STATE, &value);
     ASSERT_SUCCESS;
+
     winlog(" soundPaused = %i\n", soundPaused);
     winlog(" Source:\n");
     winlog("  State: ");
-
+    
     switch (value) {
     case AL_INITIAL:
         winlog("AL_INITIAL\n");
         break;
-
+    
     case AL_PLAYING:
         winlog("AL_PLAYING\n");
         break;
-
+    
     case AL_PAUSED:
         winlog("AL_PAUSED\n");
         break;
-
+    
     case AL_STOPPED:
         winlog("AL_STOPPED\n");
         break;
-
+    
     default:
         winlog("!unknown!\n");
         break;
     }
+
 
     alGetSourcei(source, AL_BUFFERS_QUEUED, &value);
     ASSERT_SUCCESS;
@@ -252,6 +255,7 @@ void OpenAL::reset()
 
 void OpenAL::write(uint16_t* finalWave, int length)
 {
+    length = length;
     if (!initialized)
         return;
 

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -15,29 +15,26 @@
 
 /* not sure how well other compilers support field-init syntax */
 #define STROPT(c, n, d, v) \
-    {                      \
-        wxT(c), (n), d, &v \
-    }
-#define INTOPT(c, n, d, v, min, max)             \
-    {                                            \
-        wxT(c), (n), d, NULL, &v, wxT(""), min, max \
-    }
-#define DOUBLEOPT(c, n, d, v, min, max)                      \
-    {                                                        \
-        wxT(c), (n), d, NULL, NULL, wxT(""), min, max, NULL, &v \
-    }
-#define UINTOPT(c, n, d, v, min, max)                      \
-    {                                                        \
-        wxT(c), (n), d, NULL, NULL, wxT(""), min, max, NULL, NULL, &v \
-    }
-#define BOOLOPT(c, n, d, v)                        \
-    {                                              \
-        wxT(c), (n), d, NULL, NULL, wxT(""), 0, 0, &v \
-    }
-#define ENUMOPT(c, n, d, v, e)      \
-    {                               \
-        wxT(c), (n), d, NULL, &v, e \
-    }
+    new_opt_desc(wxT(c), (n), d, &v)
+
+#define INTOPT(c, n, d, v, min, max) \
+    new_opt_desc(wxT(c), (n), d, NULL, &v, wxT(""), min, max)
+
+#define DOUBLEOPT(c, n, d, v, min, max) \
+    new_opt_desc(wxT(c), (n), d, NULL, NULL, wxT(""), min, max, NULL, &v)
+
+#define UINTOPT(c, n, d, v, min, max) \
+    new_opt_desc(wxT(c), (n), d, NULL, NULL, wxT(""), min, max, NULL, NULL, &v)
+
+#define BOOLOPT(c, n, d, v) \
+    new_opt_desc(wxT(c), (n), d, NULL, NULL, wxT(""), 0, 0, &v)
+
+#define ENUMOPT(c, n, d, v, e) \
+    new_opt_desc(wxT(c), (n), d, NULL, &v, e)
+
+#define NOOPT(c, n, d) \
+    new_opt_desc(c, (n), d)
+
 
 opts_t gopts;
 
@@ -137,17 +134,27 @@ const wxString joynames[NUM_KEYS] = {
 };
 
 wxJoyKeyBinding defkeys[NUM_KEYS * 2] = {
-    { WXK_UP }, { 1, WXJB_AXIS_MINUS, 1 }, { WXK_DOWN }, { 1, WXJB_AXIS_PLUS, 1 },
-    { WXK_LEFT }, { 0, WXJB_AXIS_MINUS, 1 }, { WXK_RIGHT }, { 0, WXJB_AXIS_PLUS, 1 },
-    { wxT('X') }, { 0, WXJB_BUTTON, 1 }, { wxT('Z') }, { 1, WXJB_BUTTON, 1 },
-    { wxT('A') }, { 2, WXJB_BUTTON, 1 }, { wxT('S') }, { 3, WXJB_BUTTON, 1 },
-    { WXK_BACK }, { 4, WXJB_BUTTON, 1 }, { WXK_RETURN }, { 5, WXJB_BUTTON, 1 },
-    { WXK_NUMPAD_UP }, { 0 }, { WXK_NUMPAD_DOWN }, { 0 },
-    { WXK_NUMPAD_LEFT }, { 0 }, { WXK_NUMPAD_RIGHT }, { 0 },
-    { WXK_NUMPAD_PAGEUP }, { 0 }, { WXK_NUMPAD_PAGEDOWN }, { 0 },
-    { wxT('W') }, { 0 }, { wxT('Q') }, { 0 },
-    { WXK_SPACE }, { 0 }, { 0 }, { 0 },
-    { 0 }, { 0 }
+    newWxJoyKeyBinding(WXK_UP), newWxJoyKeyBinding(1, WXJB_AXIS_MINUS, 1),
+    newWxJoyKeyBinding(WXK_DOWN), newWxJoyKeyBinding(1, WXJB_AXIS_PLUS, 1),
+    newWxJoyKeyBinding(WXK_LEFT), newWxJoyKeyBinding(0, WXJB_AXIS_MINUS, 1),
+    newWxJoyKeyBinding(WXK_RIGHT), newWxJoyKeyBinding(0, WXJB_AXIS_PLUS, 1),
+    newWxJoyKeyBinding(wxT('X')), newWxJoyKeyBinding(0, WXJB_BUTTON, 1),
+    newWxJoyKeyBinding(wxT('Z')), newWxJoyKeyBinding(1, WXJB_BUTTON, 1),
+    newWxJoyKeyBinding(wxT('A')), newWxJoyKeyBinding(2, WXJB_BUTTON, 1),
+    newWxJoyKeyBinding(wxT('S')), newWxJoyKeyBinding(3, WXJB_BUTTON, 1),
+    newWxJoyKeyBinding(WXK_BACK), newWxJoyKeyBinding(4, WXJB_BUTTON, 1),
+    newWxJoyKeyBinding(WXK_RETURN), newWxJoyKeyBinding(5, WXJB_BUTTON, 1),
+    newWxJoyKeyBinding(WXK_NUMPAD_UP), newWxJoyKeyBinding(0),
+    newWxJoyKeyBinding(WXK_NUMPAD_DOWN), newWxJoyKeyBinding(0),
+    newWxJoyKeyBinding(WXK_NUMPAD_LEFT), newWxJoyKeyBinding(0),
+    newWxJoyKeyBinding(WXK_NUMPAD_RIGHT), newWxJoyKeyBinding(0),
+    newWxJoyKeyBinding(WXK_NUMPAD_PAGEUP), newWxJoyKeyBinding(0),
+    newWxJoyKeyBinding(WXK_NUMPAD_PAGEDOWN), newWxJoyKeyBinding(0),
+    newWxJoyKeyBinding(wxT('W')), newWxJoyKeyBinding(0),
+    newWxJoyKeyBinding(wxT('Q')), newWxJoyKeyBinding(0),
+    newWxJoyKeyBinding(WXK_SPACE), newWxJoyKeyBinding(0),
+    newWxJoyKeyBinding(0), newWxJoyKeyBinding(0),
+    newWxJoyKeyBinding(0), newWxJoyKeyBinding(0)
 };
 
 wxAcceleratorEntry_v sys_accels;
@@ -178,9 +185,9 @@ opt_desc opts[] = {
     /// GB
     STROPT("GB/BiosFile", "", wxTRANSLATE("BIOS file to use for GB, if enabled"), gopts.gb_bios),
     STROPT("GB/GBCBiosFile", "", wxTRANSLATE("BIOS file to use for GBC, if enabled"), gopts.gbc_bios),
-    { wxT("GB/Palette0"), "", wxTRANSLATE("The default palette, as 8 comma-separated 4-digit hex integers (rgb555).") },
-    { wxT("GB/Palette1"), "", wxTRANSLATE("The first user palette, as 8 comma-separated 4-digit hex integers (rgb555).") },
-    { wxT("GB/Palette2"), "", wxTRANSLATE("The second user palette, as 8 comma-separated 4-digit hex integers (rgb555).") },
+    NOOPT(wxT("GB/Palette0"), "", wxTRANSLATE("The default palette, as 8 comma-separated 4-digit hex integers (rgb555).")),
+    NOOPT(wxT("GB/Palette1"), "", wxTRANSLATE("The first user palette, as 8 comma-separated 4-digit hex integers (rgb555).")),
+    NOOPT(wxT("GB/Palette2"), "", wxTRANSLATE("The second user palette, as 8 comma-separated 4-digit hex integers (rgb555).")),
     BOOLOPT("GB/PrintAutoPage", "PrintGather", wxTRANSLATE("Automatically gather a full page before printing"), gopts.print_auto_page),
     BOOLOPT("GB/PrintScreenCap", "PrintSnap", wxTRANSLATE("Automatically save printouts as screen captures with -print suffix"), gopts.print_screen_cap),
     STROPT("GB/ROMDir", "", wxTRANSLATE("Directory to look for ROM files"), gopts.gb_rom_dir),
@@ -210,14 +217,14 @@ opt_desc opts[] = {
     INTOPT("General/StatusBar", "StatusBar", wxTRANSLATE("Enable status bar"), gopts.statusbar, 0, 1),
 
     /// Joypad
-    { wxT("Joypad/*/*"), "", wxTRANSLATE("The parameter Joypad/<n>/<button> contains a comma-separated list of key names which map to joypad #<n> button <button>.  Button is one of Up, Down, Left, Right, A, B, L, R, Select, Start, MotionUp, MotionDown, MotionLeft, MotionRight, AutoA, AutoB, Speed, Capture, GS") },
+    NOOPT(wxT("Joypad/*/*"), "", wxTRANSLATE("The parameter Joypad/<n>/<button> contains a comma-separated list of key names which map to joypad #<n> button <button>.  Button is one of Up, Down, Left, Right, A, B, L, R, Select, Start, MotionUp, MotionDown, MotionLeft, MotionRight, AutoA, AutoB, Speed, Capture, GS")),
     INTOPT("Joypad/AutofireThrottle", "", wxTRANSLATE("The autofire toggle period, in frames (1/60 s)"), gopts.autofire_rate, 1, 1000),
 
     /// Keyboard
     INTOPT("Joypad/Default", "", wxTRANSLATE("The number of the stick to use in single-player mode"), gopts.default_stick, 1, 4),
 
     /// Keyboard
-    { wxT("Keyboard/*"), "", wxTRANSLATE("The parameter Keyboard/<cmd> contains a comma-separated list of key names (e.g. Alt-Shift-F1).  When the named key is pressed, the command <cmd> is executed.") },
+    NOOPT(wxT("Keyboard/*"), "", wxTRANSLATE("The parameter Keyboard/<cmd> contains a comma-separated list of key names (e.g. Alt-Shift-F1).  When the named key is pressed, the command <cmd> is executed.")),
 
     // Core
     INTOPT("preferences/agbPrint", "AGBPrinter", wxTRANSLATE("Enable AGB debug print"), agbPrint, 0, 1),
@@ -344,7 +351,6 @@ bool opt_lt(const opt_desc& opt1, const opt_desc& opt2)
 }
 
 // FIXME: simulate MakeInstanceFilename(vbam.ini) using subkeys (Slave%d/*)
-
 void load_opts()
 {
     // just for sanity...
@@ -449,7 +455,7 @@ void load_opts()
              cont = cfg->GetNextEntry(e, entry_idx)) {
             // kb options come from a different list
             if (s == wxT("Keyboard")) {
-                const cmditem dummy = { e };
+                const cmditem dummy = new_cmditem(e);
 
                 if (!std::binary_search(&cmdtab[0], &cmdtab[ncmds], dummy, cmditem_lt)) {
                     s.append(wxT('/'));
@@ -461,7 +467,7 @@ void load_opts()
             } else {
                 s.append(wxT('/'));
                 s.append(e);
-                const opt_desc dummy = { s };
+                opt_desc dummy = new_opt_desc(s);
                 wxString opt_name(dummy.opt);
 
                 if (!std::binary_search(&opts[0], &opts[num_opts], dummy, opt_lt) && opt_name != wxT("General/LastUpdated") && opt_name != wxT("General/LastUpdatedFileName")) {
@@ -476,10 +482,10 @@ void load_opts()
         cfg->SetPath(wxT("/"));
     }
 
-    for (int i = 0; i < item_del.size(); i++)
+    for (size_t i = 0; i < item_del.size(); i++)
         cfg->DeleteEntry(item_del[i]);
 
-    for (int i = 0; i < grp_del.size(); i++)
+    for (size_t i = 0; i < grp_del.size(); i++)
         cfg->DeleteGroup(grp_del[i]);
 
     // now read actual values and set to default if unset
@@ -500,7 +506,7 @@ void load_opts()
 
             if (gotit && !s.empty()) {
                 const auto found_pos = vec_find(enum_opts, s);
-                const bool matched   = found_pos != wxNOT_FOUND;
+                const bool matched   = ((int)found_pos != wxNOT_FOUND);
 
                 if (!matched) {
                     opt.curint = 0;
@@ -556,7 +562,7 @@ void load_opts()
         wxString optn;
         optn.Printf(wxT("GB/Palette%d"), i);
         wxString val;
-        const opt_desc dummy = { optn };
+        const opt_desc dummy = new_opt_desc(optn);
         opt_desc* opt = std::lower_bound(&opts[0], &opts[num_opts], dummy, opt_lt);
         wxString entry;
 
@@ -574,7 +580,7 @@ void load_opts()
             int start = cpos;
             cpos = val.find(wxT(','), cpos);
 
-            if (cpos == wxString::npos)
+            if ((size_t)cpos == wxString::npos)
                 cpos = val.size();
 
             long ival;
@@ -585,7 +591,7 @@ void load_opts()
             entry.ToLong(&ival, 16);
             systemGbPalette[i * 8 + j] = ival;
 
-            if (cpos != val.size())
+            if ((size_t)cpos != val.size())
                 cpos++;
         }
     }
@@ -624,7 +630,7 @@ void load_opts()
             if (!val.size())
                 wxLogWarning(_("Invalid key binding %s for %s"), s.mb_str(), kbopt.mb_str());
             else {
-                for (int j = 0; j < val.size(); j++)
+                for (size_t j = 0; j < val.size(); j++)
                     val[j].Set(val[j].GetFlags(), val[j].GetKeyCode(),
                         cmdtab[i].cmd_id);
 
@@ -682,7 +688,7 @@ void update_opts()
     for (int i = 0; i < 3; i++) {
         wxString optn;
         optn.Printf(wxT("GB/Palette%d"), i);
-        const opt_desc dummy = { optn };
+        const opt_desc dummy = new_opt_desc(optn);
         opt_desc* opt = std::lower_bound(&opts[0], &opts[num_opts], dummy, opt_lt);
         wxString val;
         wxString entry;
@@ -726,9 +732,9 @@ void update_opts()
 
         for (bool cont = cfg->GetFirstEntry(s, entry_idx); cont;
              cont = cfg->GetNextEntry(s, entry_idx)) {
-            const cmditem dummy = { s };
+            const cmditem dummy = new_cmditem(s);
             cmditem* cmd = std::lower_bound(&cmdtab[0], &cmdtab[ncmds], dummy, cmditem_lt);
-            int i;
+            size_t i;
 
             for (i = 0; i < gopts.accels.size(); i++)
                 if (gopts.accels[i].GetCommand() == cmd->cmd_id)
@@ -738,7 +744,7 @@ void update_opts()
                 item_del.push_back(s);
         }
 
-        for (int i = 0; i < item_del.size(); i++)
+        for (size_t i = 0; i < item_del.size(); i++)
             cfg->DeleteEntry(item_del[i]);
     }
 
@@ -777,7 +783,7 @@ void update_opts()
 
 bool opt_set(const wxString& name, const wxString& val)
 {
-    const opt_desc dummy = { name };
+    const opt_desc dummy = new_opt_desc(name);
     const opt_desc* opt = std::lower_bound(&opts[0], &opts[num_opts], dummy, opt_lt);
 
     if (!wxStrcmp(name, opt->opt)) {
@@ -795,7 +801,7 @@ bool opt_set(const wxString& name, const wxString& val)
             auto enum_opts = str_split(ev, wxT("|"));
 
             const std::size_t found_pos = vec_find(enum_opts, s);
-            const bool matched          = found_pos != wxNOT_FOUND;
+            const bool matched          = ((int)found_pos != wxNOT_FOUND);
 
             if (!matched) {
                 const wxString evx = wxGetTranslation(opt->enumvals);
@@ -844,7 +850,7 @@ bool opt_set(const wxString& name, const wxString& val)
 
                 wxString vals(val);
 
-                for (int j = 0, cpos = 0; j < 8; j++) {
+                for (size_t j = 0, cpos = 0; j < 8; j++) {
                     int start = cpos;
                     cpos = vals.find(wxT(','), cpos);
 
@@ -873,7 +879,7 @@ bool opt_set(const wxString& name, const wxString& val)
         auto parts = str_split(name, wxT("/"));
 
         if (parts[0] != wxT("Keyboard")) {
-            cmditem* cmd = std::lower_bound(&cmdtab[0], &cmdtab[ncmds], cmditem{parts[1]}, cmditem_lt);
+            cmditem* cmd = std::lower_bound(&cmdtab[0], &cmdtab[ncmds], cmditem{parts[1],wxString(),0,0,NULL}, cmditem_lt);
 
             if (cmd == &cmdtab[ncmds] || wxStrcmp(parts[1], cmd->cmd))
                 return false;
@@ -894,7 +900,7 @@ bool opt_set(const wxString& name, const wxString& val)
             if (!val.empty()) {
                 auto aval = wxKeyTextCtrl::FromString(val);
 
-                for (int i = 0; i < aval.size(); i++)
+                for (size_t i = 0; i < aval.size(); i++)
                     aval[i].Set(aval[i].GetFlags(), aval[i].GetKeyCode(),
                         cmd->cmd_id);
 

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -13,6 +13,8 @@
       -p/--profile=hz
 */
 
+#define WJKB newWxJoyKeyBinding
+
 /* not sure how well other compilers support field-init syntax */
 #define STROPT(c, n, d, v) \
     new_opt_desc(wxT(c), (n), d, &v)
@@ -134,27 +136,17 @@ const wxString joynames[NUM_KEYS] = {
 };
 
 wxJoyKeyBinding defkeys[NUM_KEYS * 2] = {
-    newWxJoyKeyBinding(WXK_UP), newWxJoyKeyBinding(1, WXJB_AXIS_MINUS, 1),
-    newWxJoyKeyBinding(WXK_DOWN), newWxJoyKeyBinding(1, WXJB_AXIS_PLUS, 1),
-    newWxJoyKeyBinding(WXK_LEFT), newWxJoyKeyBinding(0, WXJB_AXIS_MINUS, 1),
-    newWxJoyKeyBinding(WXK_RIGHT), newWxJoyKeyBinding(0, WXJB_AXIS_PLUS, 1),
-    newWxJoyKeyBinding(wxT('X')), newWxJoyKeyBinding(0, WXJB_BUTTON, 1),
-    newWxJoyKeyBinding(wxT('Z')), newWxJoyKeyBinding(1, WXJB_BUTTON, 1),
-    newWxJoyKeyBinding(wxT('A')), newWxJoyKeyBinding(2, WXJB_BUTTON, 1),
-    newWxJoyKeyBinding(wxT('S')), newWxJoyKeyBinding(3, WXJB_BUTTON, 1),
-    newWxJoyKeyBinding(WXK_BACK), newWxJoyKeyBinding(4, WXJB_BUTTON, 1),
-    newWxJoyKeyBinding(WXK_RETURN), newWxJoyKeyBinding(5, WXJB_BUTTON, 1),
-    newWxJoyKeyBinding(WXK_NUMPAD_UP), newWxJoyKeyBinding(0),
-    newWxJoyKeyBinding(WXK_NUMPAD_DOWN), newWxJoyKeyBinding(0),
-    newWxJoyKeyBinding(WXK_NUMPAD_LEFT), newWxJoyKeyBinding(0),
-    newWxJoyKeyBinding(WXK_NUMPAD_RIGHT), newWxJoyKeyBinding(0),
-    newWxJoyKeyBinding(WXK_NUMPAD_PAGEUP), newWxJoyKeyBinding(0),
-    newWxJoyKeyBinding(WXK_NUMPAD_PAGEDOWN), newWxJoyKeyBinding(0),
-    newWxJoyKeyBinding(wxT('W')), newWxJoyKeyBinding(0),
-    newWxJoyKeyBinding(wxT('Q')), newWxJoyKeyBinding(0),
-    newWxJoyKeyBinding(WXK_SPACE), newWxJoyKeyBinding(0),
-    newWxJoyKeyBinding(0), newWxJoyKeyBinding(0),
-    newWxJoyKeyBinding(0), newWxJoyKeyBinding(0)
+    WJKB(WXK_UP), WJKB(1, WXJB_AXIS_MINUS, 1), WJKB(WXK_DOWN), WJKB(1, WXJB_AXIS_PLUS, 1),
+    WJKB(WXK_LEFT), WJKB(0, WXJB_AXIS_MINUS, 1), WJKB(WXK_RIGHT), WJKB(0, WXJB_AXIS_PLUS, 1),
+    WJKB(wxT('X')), WJKB(0, WXJB_BUTTON, 1), WJKB(wxT('Z')), WJKB(1, WXJB_BUTTON, 1),
+    WJKB(wxT('A')), WJKB(2, WXJB_BUTTON, 1), WJKB(wxT('S')), WJKB(3, WXJB_BUTTON, 1),
+    WJKB(WXK_BACK), WJKB(4, WXJB_BUTTON, 1), WJKB(WXK_RETURN), WJKB(5, WXJB_BUTTON, 1),
+    WJKB(WXK_NUMPAD_UP), WJKB(0), WJKB(WXK_NUMPAD_DOWN), WJKB(0),
+    WJKB(WXK_NUMPAD_LEFT), WJKB(0), WJKB(WXK_NUMPAD_RIGHT), WJKB(0),
+    WJKB(WXK_NUMPAD_PAGEUP), WJKB(0), WJKB(WXK_NUMPAD_PAGEDOWN), WJKB(0),
+    WJKB(wxT('W')), WJKB(0), WJKB(wxT('Q')), WJKB(0),
+    WJKB(WXK_SPACE), WJKB(0), WJKB(0), WJKB(0),
+    WJKB(0), WJKB(0)
 };
 
 wxAcceleratorEntry_v sys_accels;

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -159,6 +159,19 @@ wxJoyKeyBinding defkeys[NUM_KEYS * 2] = {
 
 wxAcceleratorEntry_v sys_accels;
 
+// Initializer for struct opt_desc
+opt_desc new_opt_desc(wxString opt, const char* cmd, wxString desc,
+                      wxString* stropt, int* intopt, wxString enumvals,
+                      double min, double max, bool* boolopt,
+                      double* doubleopt, uint32_t* uintopt, wxString curstr,
+                      int curint, double curdouble, uint32_t curuint)
+{
+    struct opt_desc new_opt = {opt, cmd, desc, stropt, intopt, enumvals,
+	                       min, max, boolopt, doubleopt, uintopt,
+			       curstr, curint, curdouble, curuint};
+    return new_opt;
+}
+
 // Note: this table must be sorted in option name order
 // Both for better user display and for (fast) searching by name
 opt_desc opts[] = {

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -99,9 +99,6 @@ extern struct opt_desc {
     int curint;
     double curdouble;
     uint32_t curuint;
-//    opt_desc():opt(""),cmd(NULL),desc(""),stropt(NULL),intopt(NULL),
-//               enumvals(""),min(0),max(0),boolopt(NULL),doubleopt(NULL),
-//	       uintopt(NULL),curstr(""),curint(0),curdouble(0),curuint(0){}
 #define curbool curint
 } opts[];
 

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -105,17 +105,12 @@ extern struct opt_desc {
 #define curbool curint
 } opts[];
 
-opt_desc new_opt_desc (wxString opt = "", const char* cmd = NULL, wxString desc = "",
-                       wxString* stropt = NULL, int* intopt = NULL, wxString enumvals = "",
-                       double min = 0, double max = 0, bool* boolopt = NULL,
-                       double* doubleopt = NULL, uint32_t* uintopt = NULL, wxString curstr = "",
-                       int curint = 0, double curdouble = 0, uint32_t curuint = 0)
-{
-    struct opt_desc new_opt = {opt, cmd, desc, stropt, intopt, enumvals,
-	                       min, max, boolopt, doubleopt, uintopt,
-			       curstr, curint, curdouble, curuint};
-    return new_opt;
-}
+// Initializer for struct opt_desc
+opt_desc new_opt_desc(wxString opt = "", const char* cmd = NULL, wxString desc = "",
+                      wxString* stropt = NULL, int* intopt = NULL, wxString enumvals = "",
+                      double min = 0, double max = 0, bool* boolopt = NULL,
+                      double* doubleopt = NULL, uint32_t* uintopt = NULL, wxString curstr = "",
+                      int curint = 0, double curdouble = 0, uint32_t curuint = 0);
 
 extern const int num_opts;
 

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -99,8 +99,24 @@ extern struct opt_desc {
     int curint;
     double curdouble;
     uint32_t curuint;
+//    opt_desc():opt(""),cmd(NULL),desc(""),stropt(NULL),intopt(NULL),
+//               enumvals(""),min(0),max(0),boolopt(NULL),doubleopt(NULL),
+//	       uintopt(NULL),curstr(""),curint(0),curdouble(0),curuint(0){}
 #define curbool curint
 } opts[];
+
+opt_desc new_opt_desc (wxString opt = "", const char* cmd = NULL, wxString desc = "",
+                       wxString* stropt = NULL, int* intopt = NULL, wxString enumvals = "",
+                       double min = 0, double max = 0, bool* boolopt = NULL,
+                       double* doubleopt = NULL, uint32_t* uintopt = NULL, wxString curstr = "",
+                       int curint = 0, double curdouble = 0, uint32_t curuint = 0)
+{
+    struct opt_desc new_opt = {opt, cmd, desc, stropt, intopt, enumvals,
+	                       min, max, boolopt, doubleopt, uintopt,
+			       curstr, curint, curdouble, curuint};
+    return new_opt;
+}
+
 extern const int num_opts;
 
 extern const wxAcceleratorEntry default_accels[];

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -22,17 +22,17 @@ IMPLEMENT_DYNAMIC_CLASS(GameArea, wxPanel)
 
 GameArea::GameArea()
     : wxPanel()
-    , loaded(IMAGE_UNKNOWN)
     , panel(NULL)
     , emusys(NULL)
-    , basic_width(GBAWidth)
-    , basic_height(GBAHeight)
-    , fullscreen(false)
-    , paused(false)
     , was_paused(false)
     , rewind_time(0)
     , do_rewind(false)
     , rewind_mem(0)
+    , loaded(IMAGE_UNKNOWN)
+    , basic_width(GBAWidth)
+    , basic_height(GBAHeight)
+    , fullscreen(false)
+    , paused(false)
     , pointer_blanked(false)
     , mouse_active_time(0)
 {
@@ -155,7 +155,7 @@ void GameArea::LoadGame(const wxString& name)
             wxCharBuffer pfnb(pfn.GetFullPath().mb_fn_str());
             applyPatch(pfnb.data(), &gbRom, &size);
 
-            if (size != rom_size)
+            if (size != (int)rom_size)
                 gbUpdateSizes();
 
             rom_size = size;
@@ -371,6 +371,7 @@ void GameArea::LoadGame(const wxString& name)
                 case 0x10000:
                     if (saveType == GBA_SAVE_EEPROM || saveType == GBA_SAVE_SRAM)
                         break;
+                    break;
 
                 case 0x20000:
                     saveType = GBA_SAVE_FLASH;
@@ -842,7 +843,7 @@ void GameArea::ShowFullScreen(bool full)
                 // in particular, unix does Matches() in wrong direction
                 wxArrayVideoModes vm = d.GetModes();
                 int best_mode = -1;
-                int i;
+                size_t i;
 
                 for (i = 0; i < vm.size(); i++) {
                     if (vm[i].w != gopts.fs_mode.w || vm[i].h != gopts.fs_mode.h)
@@ -1138,9 +1139,9 @@ static std::vector<game_key>* game_keys_pressed(int key, int mod, int joy)
         for (int key_num = 0; key_num < NUM_KEYS; key_num++) {
             wxJoyKeyBinding_v& b = gopts.joykey_bindings[player][key_num];
 
-            for (int bind_num = 0; bind_num < b.size(); bind_num++)
+            for (size_t bind_num = 0; bind_num < b.size(); bind_num++)
                 if (b[bind_num].key == key && b[bind_num].mod == mod && b[bind_num].joy == joy)
-                    vec->push_back({player, key_num, bind_num, b});
+                    vec->push_back({player, key_num, (int)bind_num, b});
         }
 
     return vec;
@@ -1168,7 +1169,7 @@ static bool process_key_press(bool down, int key, int mod, int joy = 0)
     }
 
     // check if key is already pressed
-    int kpno;
+    size_t kpno;
 
     for (kpno = 0; kpno < keys_pressed.size(); kpno++)
         if (keys_pressed[kpno].key == key && keys_pressed[kpno].mod == mod && keys_pressed[kpno].joy == joy)
@@ -1201,11 +1202,11 @@ static bool process_key_press(bool down, int key, int mod, int joy = 0)
         }
         else {
             // only release if no others pressed
-            int bind2;
+            size_t bind2;
             auto b = game_key.b;
 
             for (bind2 = 0; bind2 < game_key.b.size(); bind2++) {
-                if (game_key.bind_num == bind2 || (b[bind2].key == key && b[bind2].mod == mod && b[bind2].joy == joy))
+                if ((size_t)game_key.bind_num == bind2 || (b[bind2].key == key && b[bind2].mod == mod && b[bind2].joy == joy))
                     continue;
 
                 for (kpno = 0; kpno < keys_pressed.size(); kpno++)
@@ -1322,8 +1323,8 @@ DrawingPanelBase::DrawingPanelBase(int _width, int _height)
     , todraw(0)
     , pixbuf1(0)
     , pixbuf2(0)
-    , rpi(0)
     , nthreads(0)
+    , rpi(0)
 {
     memset(delta, 0xff, sizeof(delta));
 
@@ -1419,6 +1420,7 @@ void DrawingPanelBase::DrawingPanelInit()
 
 void DrawingPanelBase::PaintEv(wxPaintEvent& ev)
 {
+    (void)ev; // unused params
     wxPaintDC dc(GetWindow());
 
     if (!todraw) {
@@ -1436,6 +1438,7 @@ void DrawingPanelBase::PaintEv(wxPaintEvent& ev)
 
 void DrawingPanelBase::EraseBackground(wxEraseEvent& ev)
 {
+    (void)ev; // unused params
     // do nothing, do not allow propagation
 }
 
@@ -1877,7 +1880,7 @@ void DrawingPanelBase::DrawOSD(wxWindowDC& dc)
             // find amt of text that will fit on a line is to search
             wxArrayInt llen; // length of each line, in chars
 
-            for (int off = 0; off < msg.size();) {
+            for (size_t off = 0; off < msg.size();) {
 // One way would be to bsearch on GetTextExtent() looking for
 // best fit.
 // Another would be to use GetPartialTextExtents and search

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2240,6 +2240,7 @@ void GLDrawingPanel::AdjustViewport()
 
 void GLDrawingPanel::DrawArea(wxWindowDC& dc)
 {
+    (void)dc; // unused params
 #ifndef wxGL_IMPLICIT_CONTEXT
     SetCurrent(*ctx);
 #else

--- a/src/wx/sys.cpp
+++ b/src/wx/sys.cpp
@@ -39,6 +39,7 @@ bool soundBufferLow;
 
 void systemMessage(int id, const char* fmt, ...)
 {
+    (void)id; // unused params
     static char* buf = NULL;
     static int buflen = 80;
     va_list args;
@@ -359,7 +360,7 @@ void system10Frames(int rate)
         static int speedadj = 0;
         uint32_t t = systemGetClock();
 
-        if (!panel->was_paused && prevclock && (t - prevclock) != 10000 / rate) {
+        if (!panel->was_paused && prevclock && (t - prevclock) != (uint32_t)(10000 / rate)) {
             int speed = t == prevclock ? 100 * 10000 / rate - (t - prevclock) : 100;
 
             // why 98??
@@ -691,11 +692,11 @@ private:
 
 IMPLEMENT_CLASS(PrintDialog, wxEvtHandler)
 
-PrintDialog::PrintDialog(const uint16_t* data, int lines, bool cont)
-    : img(160, lines)
-    , npw(1)
-    , nph(1)
-    , wxPrintout(wxGetApp().frame->GetPanel()->game_name() + wxT(" Printout"))
+PrintDialog::PrintDialog(const uint16_t* data, int lines, bool cont):
+    wxPrintout(wxGetApp().frame->GetPanel()->game_name() + wxT(" Printout")),
+    img(160, lines),
+    npw(1),
+    nph(1)
 {
     dlg = wxStaticCast(wxGetApp().frame->FindWindow(XRCID("GBPrinter")), wxDialog);
     p = XRCCTRL(*dlg, "Preview", wxPanel);
@@ -769,6 +770,7 @@ void PrintDialog::ShowImg(wxPaintEvent& evt)
 
 void PrintDialog::ChangeMag(wxCommandEvent& evt)
 {
+    (void)evt; // unused params
     int m = mag->GetSelection() + 1;
     wxScrolledWindow* pp = wxStaticCast(p->GetParent(), wxScrolledWindow);
     wxSize sz(m * 160, m * img.GetHeight());
@@ -891,6 +893,8 @@ void PrintDialog::DoPrint(wxCommandEvent&)
 
 void systemGbPrint(uint8_t* data, int len, int pages, int feed, int pal, int cont)
 {
+    (void)pages; // unused params
+    (void)cont; // unused params
     ModalPause mp; // this might take a while, so signal a pause
     GameArea* panel = wxGetApp().frame->GetPanel();
     static uint16_t* accum_prdata;
@@ -1111,6 +1115,8 @@ SoundDriver* systemSoundInit()
 
 void systemOnWriteDataToSoundBuffer(const uint16_t* finalWave, int length)
 {
+    (void)finalWave; // unused params
+    (void)length; // unused params
 #ifndef NO_FFMPEG
     GameArea* panel = wxGetApp().frame->GetPanel();
 

--- a/src/wx/viewers.cpp
+++ b/src/wx/viewers.cpp
@@ -82,11 +82,13 @@ public:
     }
     void Next(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         CPULoop(1);
         GotoPC();
     }
     void Goto(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         wxString as = goto_addr->GetValue();
 
         if (!as.size())
@@ -100,6 +102,7 @@ public:
     // wx-2.8.4 or MacOSX compiler can't resolve overloads in evt table
     void GotoPCEv(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         GotoPC();
     }
     void GotoPC()
@@ -120,6 +123,7 @@ public:
     }
     void RefreshCmd(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         UpdateDis();
     }
     void UpdateDis()
@@ -143,6 +147,7 @@ public:
 
     void RefillListEv(wxCommandEvent& ev)
     {
+        (void)ev; // unused params
         // what an unsafe calling convention
         // examination of disArm shows that max len is 69 chars
         // (e.g. 0x081cb6db), and I assume disThumb is shorter
@@ -221,11 +226,13 @@ public:
     }
     void Next(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         gbEmulate(1);
         GotoPC();
     }
     void Goto(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         wxString as = goto_addr->GetValue();
 
         if (!as.size())
@@ -239,6 +246,7 @@ public:
     // wx-2.8.4 or MacOSX compiler can't resolve overloads in evt table
     void GotoPCEv(wxCommandEvent& ev)
     {
+        (void)ev; // unused params
         GotoPC();
     }
     void GotoPC()
@@ -248,6 +256,7 @@ public:
     }
     void RefreshCmd(wxCommandEvent& ev)
     {
+        (void)ev; // unused params
         UpdateDis();
     }
     void UpdateDis()
@@ -278,6 +287,7 @@ public:
 
     void RefillListEv(wxCommandEvent& ev)
     {
+        (void)ev; // unused params
         // what an unsafe calling convention
         // examination of gbDis shows that max len is 26 chars
         // (e.g. 0xe2)
@@ -322,6 +332,10 @@ void MainFrame::Disassemble(void)
     case IMAGE_GB:
         LoadXRCViewer(GBDisassemble);
         break;
+
+    case IMAGE_UNKNOWN:
+        // do nothing
+        break;
     }
 }
 
@@ -357,7 +371,7 @@ public:
         wxString longline = lline;
         int lwidth = 0;
 
-        for (int i = 0; i < NUM_IOREGS; i++) {
+        for (long unsigned int i = 0; i < NUM_IOREGS; i++) {
             addr->Append(wxGetTranslation(ioregs[i].name));
 
             // find longest label
@@ -391,6 +405,7 @@ public:
 
     void SelectEv(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         Select(addr->GetSelection());
     }
 
@@ -450,11 +465,13 @@ public:
 
     void RefreshEv(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         Update();
     }
 
     void Apply(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         int sel = addr->GetSelection();
         uint16_t* addr = ioregs[sel].address ? ioregs[sel].address : (uint16_t*)&ioMem[ioregs[sel].offset];
         uint16_t mask, reg = *addr;
@@ -534,6 +551,7 @@ void LogDialog::Update()
 
 void LogDialog::Save(wxCommandEvent& ev)
 {
+    (void)ev; // unused params
     static wxString logdir = wxEmptyString, def_name = wxEmptyString;
 
     if (def_name.empty())
@@ -560,6 +578,7 @@ void LogDialog::Save(wxCommandEvent& ev)
 
 void LogDialog::Clear(wxCommandEvent& ev)
 {
+    (void)ev; // unused params
     wxGetApp().log.clear();
     Update();
 }
@@ -641,12 +660,14 @@ public:
     }
     void BlockStart(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         unsigned long l;
         bs->GetStringSelection().ToULong(&l, 0);
         Goto(l);
     }
     void GotoEv(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         unsigned long l;
         wxString v = goto_addr->GetValue();
 
@@ -662,6 +683,7 @@ public:
     }
     void RefreshCmd(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         Update();
     }
 
@@ -669,6 +691,7 @@ public:
 
     void Load(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         if (memsave_fn.empty())
             memsave_fn = wxGetApp().frame->GetPanel()->game_name() + wxT(".dmp");
 
@@ -720,6 +743,7 @@ public:
 
     void Save(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         wxString s;
         s.Printf(addrlen == 4 ? wxT("%04X") : wxT("%08X"), mv->GetAddr());
         selreg_addr->SetValue(s);
@@ -802,6 +826,7 @@ public:
     // wx-2.8.4 or MacOSX compiler can't resolve overloads in evt table
     void RefillListEv(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         Update();
     }
 
@@ -823,6 +848,7 @@ public:
 
     void WriteVal(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         switch (mv->fmt) {
         case 0:
             CPUWriteByteQuick(mv->writeaddr, mv->writeval);
@@ -849,7 +875,7 @@ public:
         while (len > 0) {
             memoryMap m = map[addr >> 24];
             uint32_t off = addr & m.mask;
-            uint32_t wlen = (off + len) > m.mask ? m.mask + 1 - off : len;
+            int wlen = (off + len) > m.mask ? m.mask + 1 - off : len;
             wlen = f.Read(m.address + off, wlen);
 
             if (wlen < 0)
@@ -871,7 +897,7 @@ public:
         while (len > 0) {
             memoryMap m = map[addr >> 24];
             uint32_t off = addr & m.mask;
-            uint32_t wlen = (off + len) > m.mask ? m.mask + 1 - off : len;
+            int wlen = (off + len) > m.mask ? m.mask + 1 - off : len;
             wlen = f.Write(m.address + off, wlen);
 
             if (wlen < 0)
@@ -910,6 +936,7 @@ public:
     // wx-2.8.4 or MacOSX compiler can't resolve overloads in evt table
     void RefillListEv(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         Update();
     }
 
@@ -931,6 +958,7 @@ public:
 
     void WriteVal(wxCommandEvent& ev)
     {
+	(void)ev; // unused params
         switch (mv->fmt) {
         case 0:
             GBWriteByteQuick(mv->writeaddr, mv->writeval);
@@ -957,7 +985,7 @@ public:
         while (len > 0) {
             uint8_t* maddr = gbMemoryMap[addr >> 12];
             uint32_t off = addr & 0xfff;
-            uint32_t wlen = (off + len) > 0xfff ? 0x1000 - off : len;
+            int wlen = (off + len) > 0xfff ? 0x1000 - off : len;
             wlen = f.Read(maddr + off, wlen);
 
             if (wlen < 0)
@@ -979,7 +1007,7 @@ public:
         while (len > 0) {
             uint8_t* maddr = gbMemoryMap[addr >> 12];
             uint32_t off = addr & 0xfff;
-            uint32_t wlen = (off + len) > 0xfff ? 0x1000 - off : len;
+            int wlen = (off + len) > 0xfff ? 0x1000 - off : len;
             wlen = f.Write(maddr + off, wlen);
 
             if (wlen < 0)
@@ -1008,6 +1036,9 @@ void MainFrame::MemViewer()
 
     case IMAGE_GB:
         LoadXRCViewer(GBMem);
+        break;
+
+    default:
         break;
     }
 }

--- a/src/wx/viewsupt.cpp
+++ b/src/wx/viewsupt.cpp
@@ -5,6 +5,7 @@
 namespace Viewers {
 void Viewer::CloseDlg(wxCloseEvent& ev)
 {
+    (void)ev; // unused params
     // stop tracking dialog
     MainFrame* f = wxGetApp().frame;
 
@@ -76,12 +77,12 @@ IMPLEMENT_DYNAMIC_CLASS(DisList, wxPanel)
 
 DisList::DisList()
     : wxPanel()
+    , nlines(0)
+    , topaddr(0)
     , tc()
     , sb()
     , didinit(false)
-    , nlines(0)
     , issel(false)
-    , topaddr(0)
 {
 }
 
@@ -191,7 +192,7 @@ void DisList::Refill()
     MoveSB();
     wxString val;
 
-    for (int i = 0; i < nlines && i < strings.size(); i++) {
+    for (size_t i = 0; i < (size_t)nlines && i < strings.size(); i++) {
         val += strings[i];
         val += wxT('\n');
     }
@@ -203,6 +204,7 @@ void DisList::Refill()
 // on resize, recompute shown lines and refill if necessary
 void DisList::Resize(wxSizeEvent& ev)
 {
+    (void)ev; // unused params
     if (!didinit) // prevent crash on win32
         return;
 
@@ -215,10 +217,10 @@ void DisList::Resize(wxSizeEvent& ev)
     wxString val;
     tc.SetSize(sz.GetWidth(), (nlines + 1) * lineheight + extraheight);
 
-    if (nlines > strings.size())
+    if ((size_t)nlines > strings.size())
         RefillNeeded();
     else {
-        for (int i = 0; i < nlines && i < strings.size(); i++) {
+        for (size_t i = 0; i < (size_t)nlines && i < strings.size(); i++) {
             val += strings[i];
             val += wxT('\n');
         }
@@ -236,7 +238,7 @@ void DisList::SetSel()
     if (!issel)
         return;
 
-    if (nlines > addrs.size() || (uint32_t)addrs[0] > seladdr || (uint32_t)addrs[nlines - 1] <= seladdr)
+    if ((size_t)nlines > addrs.size() || (uint32_t)addrs[0] > seladdr || (uint32_t)addrs[nlines - 1] <= seladdr)
         return;
 
     for (int i = 0, start = 0; i < nlines; i++) {
@@ -262,7 +264,7 @@ void DisList::SetSel(uint32_t addr)
     seladdr = addr;
     issel = true;
 
-    if (addrs.size() < 4 || addrs.size() < nlines || topaddr > addr || (uint32_t)addrs[addrs.size() - 4] < addr) {
+    if (addrs.size() < 4 || addrs.size() < (size_t)nlines || topaddr > addr || (uint32_t)addrs[addrs.size() - 4] < addr) {
         topaddr = addr;
         strings.clear();
         addrs.clear();
@@ -282,13 +284,13 @@ IMPLEMENT_DYNAMIC_CLASS(MemView, wxPanel)
 
 MemView::MemView()
     : wxPanel()
+    , nlines(0)
+    , topaddr(0)
+    , addrlab(0)
     , disp()
     , sb()
     , didinit(false)
-    , nlines(0)
     , selnib(-1)
-    , topaddr(0)
-    , addrlab(0)
 {
 }
 
@@ -370,7 +372,7 @@ void MemView::MouseEvent(wxMouseEvent& ev)
 
 void MemView::ShowCaret()
 {
-    if (seladdr < topaddr || seladdr >= topaddr + nlines * 16)
+    if (seladdr < (int)topaddr || seladdr >= (int)topaddr + nlines * 16)
         selnib = -1;
 
     if (selnib < 0) {
@@ -429,7 +431,7 @@ void MemView::KeyEvent(wxKeyEvent& ev)
             selnib--;
 
         if (selnib >= 32) {
-            if (seladdr == maxaddr - 16)
+            if (seladdr == (int)maxaddr - 16)
                 selnib = 32 - nnib;
             else {
                 selnib -= 32;
@@ -461,7 +463,7 @@ void MemView::KeyEvent(wxKeyEvent& ev)
 
     case WXK_DOWN:
     case WXK_NUMPAD_DOWN:
-        if (seladdr < maxaddr - 16)
+        if (seladdr < (int)maxaddr - 16)
             seladdr += 16;
 
         break;
@@ -493,7 +495,7 @@ void MemView::KeyEvent(wxKeyEvent& ev)
             selnib--;
 
         if (selnib >= 32) {
-            if (seladdr == maxaddr - 16)
+            if (seladdr == (int)maxaddr - 16)
                 selnib = 32 - nnib;
             else {
                 selnib -= 32;
@@ -507,7 +509,7 @@ void MemView::KeyEvent(wxKeyEvent& ev)
             mask = 0xff << bno * 8;
             val = k << bno * 8;
         } else {
-            mask = 0xf << bno * 8 + nibno * 4;
+            mask = 8 * (0xf << bno) + 4 * nibno;
             val = isdigit(k) ? k - '0' : tolower(k) + 10 - 'a';
             val <<= bno * 8 + nibno * 4;
         }
@@ -515,7 +517,7 @@ void MemView::KeyEvent(wxKeyEvent& ev)
         if ((words[wno] & mask) == val)
             break;
 
-        words[wno] = words[wno] & ~mask | val;
+        words[wno] = ((words[wno] & ~mask) | val);
         writeaddr = topaddr + 4 * wno;
         val = words[wno];
 
@@ -631,6 +633,7 @@ void MemView::Repaint()
 
 void MemView::RepaintEv(wxPaintEvent& ev)
 {
+    (void)ev; // unused params
     wxPaintDC dc(&disp);
     dc.SetBackgroundMode(wxSOLID);
     Refill(dc);
@@ -644,7 +647,7 @@ void MemView::Refill(wxDC& dc)
     // doesn't seem to inherit font properly
     dc.SetFont(GetFont());
 
-    for (int i = 0; i < nlines && i < words.size() / 4; i++) {
+    for (size_t i = 0; i < (size_t)nlines && i < words.size() / 4; i++) {
         wxString line, word;
         line.Printf(maxaddr > 0xffff ? wxT("%08X   ") : wxT("%04X   "), topaddr + i * 16);
 
@@ -693,6 +696,7 @@ void MemView::Refill(wxDC& dc)
 // on resize, recompute shown lines and refill if necessary
 void MemView::Resize(wxSizeEvent& ev)
 {
+    (void)ev; // unused params
     if (!didinit) // prevent crash on win32
         return;
 
@@ -705,7 +709,7 @@ void MemView::Resize(wxSizeEvent& ev)
     wxString val;
     disp.SetSize(sz.GetWidth(), (nlines + 1) * charheight);
 
-    if (nlines > words.size() / 4) {
+    if ((size_t)nlines > words.size() / 4) {
         if (topaddr + nlines * 16 > maxaddr)
             topaddr = maxaddr - nlines * 16 + 1;
 
@@ -889,6 +893,7 @@ void PixView::SetSel(int x, int y, bool desel_cview_update)
 
 void PixView::Redraw(wxPaintEvent& ev)
 {
+    (void)ev; // unused params
     if (!bm)
         return;
 
@@ -988,6 +993,7 @@ void PixViewEvt::click()
 IMPLEMENT_DYNAMIC_CLASS(GfxPanel, wxPanel)
 void GfxPanel::DrawBitmap(wxPaintEvent& ev)
 {
+    (void)ev; // unused params
     if (!bm)
         return;
 
@@ -1122,6 +1128,7 @@ void GfxViewer::BMPSize(int w, int h)
 
 void GfxViewer::StretchTog(wxCommandEvent& ev)
 {
+    (void)ev; // unused params
     wxSize sz;
 
     if (str->GetValue()) {
@@ -1138,6 +1145,7 @@ void GfxViewer::StretchTog(wxCommandEvent& ev)
 
 void GfxViewer::SaveBMP(wxCommandEvent& ev)
 {
+    (void)ev; // unused params
     GameArea* panel = wxGetApp().frame->GetPanel();
     bmp_save_dir = wxGetApp().frame->GetGamePath(gopts.scrshot_dir);
     // no attempt is made here to translate the dialog type name
@@ -1175,6 +1183,7 @@ void GfxViewer::SaveBMP(wxCommandEvent& ev)
 
 void GfxViewer::RefreshEv(wxCommandEvent& ev)
 {
+    (void)ev; // unused params
     Update();
 }
 

--- a/src/wx/viewsupt.h
+++ b/src/wx/viewsupt.h
@@ -141,6 +141,7 @@ protected:
     // assigned to textctrl to avoid mouse input
     void MouseEvent(wxMouseEvent& ev)
     {
+	(void)ev; // unused param
     }
     // the subwidgets
     wxTextCtrl tc;
@@ -412,6 +413,7 @@ public:
     }
     void MouseEvent(wxMouseEvent& ev)
     {
+	(void)ev; // unused param
     }
     DECLARE_EVENT_TABLE()
     DECLARE_DYNAMIC_CLASS(DispCheckBox)

--- a/src/wx/widgets/joyedit.cpp
+++ b/src/wx/widgets/joyedit.cpp
@@ -8,6 +8,13 @@ BEGIN_EVENT_TABLE(wxJoyKeyTextCtrl, wxKeyTextCtrl)
 EVT_SDLJOY(wxJoyKeyTextCtrl::OnJoy)
 END_EVENT_TABLE()
 
+// Initializer for struct wxJoyKeyBinding
+wxJoyKeyBinding newWxJoyKeyBinding(int key, int mod, int joy)
+{
+    struct wxJoyKeyBinding tmp = {key, mod, joy};
+    return tmp;
+}
+
 int wxJoyKeyTextCtrl::DigitalButton(wxSDLJoyEvent& event)
 {
     int sdlval = event.GetControlValue();

--- a/src/wx/widgets/joyedit.cpp
+++ b/src/wx/widgets/joyedit.cpp
@@ -151,7 +151,7 @@ wxString wxJoyKeyTextCtrl::ToString(wxJoyKeyBinding_v keys, wxChar sep)
 {
     wxString ret;
 
-    for (int i = 0; i < keys.size(); i++) {
+    for (size_t i = 0; i < keys.size(); i++) {
         if (i > 0)
             ret += sep;
 
@@ -213,7 +213,7 @@ static bool ParseJoy(const wxString& s, int len, int& mod, int& key, int& joy)
         return false;
 
     const wxString p = s.Mid(l);
-    int alen = len - l;
+    size_t alen = len - l;
     joyre.GetMatch(&b, &l, 1);
     joy = simple_atoi(s.Mid(b), l);
 #define is_ctrl(re) re.Matches(p) && re.GetMatch(&b, &l) && l == alen && !b
@@ -268,12 +268,12 @@ wxJoyKeyBinding_v wxJoyKeyTextCtrl::FromString(const wxString& s, wxChar sep)
 {
     wxJoyKeyBinding_v ret, empty;
     int mod, key, joy;
-    int len = s.size();
+    size_t len = s.size();
 
     if (!len)
         return empty;
 
-    for (int lastkey = len - 1; (lastkey = s.rfind(sep, lastkey)) != wxString::npos; lastkey--) {
+    for (size_t lastkey = len - 1; (lastkey = s.rfind(sep, lastkey)) != wxString::npos; lastkey--) {
         if (lastkey == len - 1) {
             // sep as accel
             if (!lastkey)

--- a/src/wx/widgets/keyedit.cpp
+++ b/src/wx/widgets/keyedit.cpp
@@ -16,6 +16,7 @@ void wxKeyTextCtrl::OnKeyDown(wxKeyEvent& event)
 
 void wxKeyTextCtrl::OnKeyUp(wxKeyEvent& event)
 {
+    (void)event; // unused param
     int mod = lastmod;
     int key = lastkey;
     lastmod = lastkey = 0;
@@ -30,7 +31,7 @@ void wxKeyTextCtrl::OnKeyUp(wxKeyEvent& event)
     // if blank or backspace is modified, add normally instead
     if (clearable && !mod && key == WXK_BACK && !GetValue().empty()) {
         wxString val = GetValue();
-        int lastkey = val.rfind(multikey);
+        size_t lastkey = val.rfind(multikey);
 
         if (lastkey && lastkey != wxString::npos) {
             // if this was actually a ,-accel, delete instead
@@ -79,7 +80,7 @@ wxString wxKeyTextCtrl::ToString(int mod, int key)
     wxString s = ae.ToString();
 
     if (char_override || mod_override) {
-        int l = s.rfind(wxT('-'));
+        size_t l = s.rfind(wxT('-'));
 
         if (l == wxString::npos)
             l = 0;
@@ -150,7 +151,7 @@ wxString wxKeyTextCtrl::ToString(wxAcceleratorEntry_v keys, wxChar sep)
 {
     wxString ret;
 
-    for (int i = 0; i < keys.size(); i++) {
+    for (size_t i = 0; i < keys.size(); i++) {
         if (i > 0)
             ret += sep;
 
@@ -176,16 +177,16 @@ bool wxKeyTextCtrl::ParseString(const wxString& s, int len, int& mod, int& key)
     a.Append(s.Left(len));
     wxAcceleratorEntry ae;
 #ifndef __WXMAC__
-#define check_meta(str)                                                     \
-    do {                                                                    \
-        wxString meta = str;                                                \
-        for (int ml = 0; (ml = a.find(meta, ml)) != wxString::npos; ml++) { \
-            if (!ml || a[ml - 1] == wxT('-') || a[ml - 1] == wxT('+')) {    \
-                mod |= wxMOD_META;                                          \
-                a.erase(ml, meta.size());                                   \
-                ml = -1;                                                    \
-            }                                                               \
-        }                                                                   \
+#define check_meta(str)                                                        \
+    do {                                                                       \
+        wxString meta = str;                                                   \
+        for (size_t ml = 0; (ml = a.find(meta, ml)) != wxString::npos; ml++) { \
+            if (!ml || a[ml - 1] == wxT('-') || a[ml - 1] == wxT('+')) {       \
+                mod |= wxMOD_META;                                             \
+                a.erase(ml, meta.size());                                      \
+                ml = -1;                                                       \
+            }                                                                  \
+        }                                                                      \
     } while (0)
     check_meta(wxT("Meta-"));
     check_meta(wxT("Meta+"));
@@ -252,9 +253,9 @@ wxAcceleratorEntry_v wxKeyTextCtrl::FromString(const wxString& s, wxChar sep)
 {
     wxAcceleratorEntry_v ret, empty;
     int mod, key;
-    int len = s.size();
+    size_t len = s.size();
 
-    for (int lastkey = len - 1; (lastkey = s.rfind(sep, lastkey)) != wxString::npos; lastkey--) {
+    for (size_t lastkey = len - 1; (lastkey = s.rfind(sep, lastkey)) != wxString::npos; lastkey--) {
         if (lastkey == len - 1) {
             // sep as accel
             if (!lastkey)

--- a/src/wx/widgets/sdljoy.cpp
+++ b/src/wx/widgets/sdljoy.cpp
@@ -14,6 +14,12 @@ struct wxSDLJoyState {
         if (dev)
             SDL_JoystickClose(dev);
     }
+    wxSDLJoyState()
+    {
+	dev = NULL;
+	nax = nhat = nbut = 0;
+	curval = NULL;
+    }
 };
 
 wxSDLJoy::wxSDLJoy(bool analog)
@@ -37,7 +43,6 @@ wxSDLJoy::wxSDLJoy(bool analog)
         return;
 
     joystate = new wxSDLJoyState[njoy];
-    memset(joystate, 0, njoy * sizeof(*joystate));
 
     for (int i = 0; i < njoy; i++) {
         SDL_Joystick* dev = joystate[i].dev = SDL_JoystickOpen(i);

--- a/src/wx/widgets/sdljoy.cpp
+++ b/src/wx/widgets/sdljoy.cpp
@@ -19,8 +19,8 @@ struct wxSDLJoyState {
 wxSDLJoy::wxSDLJoy(bool analog)
     : wxTimer()
     , digital(!analog)
-    , evthandler(0)
     , joystate(0)
+    , evthandler(0)
     , nosticks(true)
 {
     // Start up joystick if not already started
@@ -37,7 +37,7 @@ wxSDLJoy::wxSDLJoy(bool analog)
         return;
 
     joystate = new wxSDLJoyState_t[njoy];
-    memset(joystate, 0, njoy * sizeof(*joystate));
+    memset(static_cast<void*>(joystate), 0, njoy * sizeof(*joystate));
 
     for (int i = 0; i < njoy; i++) {
         SDL_Joystick* dev = joystate[i].dev = SDL_JoystickOpen(i);

--- a/src/wx/widgets/wx/joyedit.h
+++ b/src/wx/widgets/wx/joyedit.h
@@ -15,6 +15,12 @@ typedef struct wxJoyKeyBinding {
     // if joy is non-0, key = control number, and mod = control type
 } wxJoyKeyBinding;
 
+wxJoyKeyBinding newWxJoyKeyBinding(int key = 0, int mod = 0, int joy = 0)
+{
+    struct wxJoyKeyBinding tmp = {key, mod, joy};
+    return tmp;
+}
+
 typedef std::vector<wxJoyKeyBinding> wxJoyKeyBinding_v;
 
 // joystick control types
@@ -87,6 +93,7 @@ public:
     bool TransferFromWindow();
     bool Validate(wxWindow* p)
     {
+        (void)p; // unused params
         return true;
     }
 

--- a/src/wx/widgets/wx/joyedit.h
+++ b/src/wx/widgets/wx/joyedit.h
@@ -15,11 +15,8 @@ typedef struct wxJoyKeyBinding {
     // if joy is non-0, key = control number, and mod = control type
 } wxJoyKeyBinding;
 
-wxJoyKeyBinding newWxJoyKeyBinding(int key = 0, int mod = 0, int joy = 0)
-{
-    struct wxJoyKeyBinding tmp = {key, mod, joy};
-    return tmp;
-}
+// Initializer for struct wxJoyKeyBinding
+wxJoyKeyBinding newWxJoyKeyBinding(int key = 0, int mod = 0, int joy = 0);
 
 typedef std::vector<wxJoyKeyBinding> wxJoyKeyBinding_v;
 

--- a/src/wx/widgets/wx/keyedit.h
+++ b/src/wx/widgets/wx/keyedit.h
@@ -99,7 +99,7 @@ public:
     bool TransferFromWindow();
     bool Validate(wxWindow* p)
     {
-        p = p;
+        (void)p; // unused params
         return true;
     }
 

--- a/src/wx/widgets/wx/keyedit.h
+++ b/src/wx/widgets/wx/keyedit.h
@@ -99,6 +99,7 @@ public:
     bool TransferFromWindow();
     bool Validate(wxWindow* p)
     {
+        p = p;
         return true;
     }
 

--- a/src/wx/widgets/wx/wxmisc.h
+++ b/src/wx/widgets/wx/wxmisc.h
@@ -33,16 +33,16 @@ class wxBoolIntValidator : public wxValidator {
 public:
     wxBoolIntValidator(int* _vptr, int _val, int _mask = ~0)
         : wxValidator()
-        , vptr(_vptr)
         , val(_val)
         , mask(_mask)
+        , vptr(_vptr)
     {
     }
     wxBoolIntValidator(const wxBoolIntValidator& v)
         : wxValidator()
-        , vptr(v.vptr)
         , val(v.val)
         , mask(v.mask)
+        , vptr(v.vptr)
     {
     }
     wxObject* Clone() const
@@ -53,6 +53,7 @@ public:
     bool TransferFromWindow();
     bool Validate(wxWindow* p)
     {
+        (void)p; // unused params
         return true;
     }
 
@@ -105,6 +106,7 @@ public:
     bool TransferFromWindow();
     bool Validate(wxWindow* p)
     {
+        (void)p; // unused params
         return true;
     }
 
@@ -133,6 +135,7 @@ public:
     bool TransferFromWindow();
     bool Validate(wxWindow* p)
     {
+        (void)p; // unused params
         return true;
     }
 
@@ -156,8 +159,8 @@ public:
     }
     wxColorValidator(uint16_t* vptr)
         : wxValidator()
-        , ptr16(vptr)
         , ptr32(0)
+        , ptr16(vptr)
     {
     }
     wxColorValidator(const wxColorValidator& v)
@@ -174,6 +177,7 @@ public:
     bool TransferFromWindow();
     bool Validate(wxWindow* p)
     {
+        (void)p; // unused params
         return true;
     }
 

--- a/src/wx/widgets/wxmisc.cpp
+++ b/src/wx/widgets/wxmisc.cpp
@@ -289,7 +289,7 @@ bool wxColorValidator::TransferFromWindow()
 
 static void enable(wxWindow_v controls, std::vector<int> reverse, bool en)
 {
-    for (int i = 0; i < controls.size(); i++)
+    for (size_t i = 0; i < controls.size(); i++)
         controls[i]->Enable(reverse.size() <= i || !reverse[i] ? en : !en);
 }
 
@@ -461,6 +461,7 @@ bool wxUIntValidator::TransferFromWindow()
 
 bool wxUIntValidator::Validate(wxWindow* parent)
 {
+    (void)parent; // unused params
     wxSpinCtrl* ctrl = wxDynamicCast(GetWindow(), wxSpinCtrl);
 
     if (ctrl) {

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -32,6 +32,14 @@
 IMPLEMENT_APP(wxvbamApp)
 IMPLEMENT_DYNAMIC_CLASS(MainFrame, wxFrame)
 
+// Initializer for struct cmditem
+cmditem new_cmditem(const wxString cmd, const wxString name, int cmd_id,
+                    int mask_flags, wxMenuItem* mi)
+{
+    struct cmditem tmp = {cmd, name, cmd_id, mask_flags, mi};
+    return tmp;
+}
+
 // generate config file path
 static void get_config_path(wxPathList& path, bool exists = true)
 {

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -109,7 +109,7 @@ static void tack_full_path(wxString& s, const wxString& app = wxEmptyString)
     wxPathList full_config_path;
     get_config_path(full_config_path, false);
 
-    for (int i = 0; i < full_config_path.size(); i++)
+    for (size_t i = 0; i < full_config_path.size(); i++)
         s += wxT("\n\t") + full_config_path[i] + app;
 }
 
@@ -140,7 +140,7 @@ wxString wxvbamApp::GetConfigurationPath()
     // dir or parent to create it in in OnInit in normal order
     // (from user paths to system paths.)
     if (data_path.empty()) {
-        for (int i = 0; i < config_path.size(); i++) {
+        for (size_t i = 0; i < config_path.size(); i++) {
             // Check if path is writeable
             if (wxIsWritable(config_path[i])) {
                 data_path = config_path[i];
@@ -221,7 +221,7 @@ bool wxvbamApp::OnInit()
     // 2.9 has LoadAllFiles(), but this is 2.8, so we'll do it manually
     wxString cwd = wxGetCwd();
 
-    for (int i = 0; i < config_path.size(); i++)
+    for (size_t i = 0; i < config_path.size(); i++)
         if (wxDirExists(config_path[i]) && wxSetWorkingDirectory(config_path[i])) {
             // *.xr[cs] doesn't work (double the number of scans)
             // 2.9 gives errors for no files found, so manual precheck needed
@@ -299,7 +299,7 @@ bool wxvbamApp::OnInit()
     }
 
     // process command-line options
-    for (int i = 0; i < pending_optset.size(); i++) {
+    for (size_t i = 0; i < pending_optset.size(); i++) {
         auto parts = str_split(pending_optset[i], wxT('='));
         opt_set(parts[0], parts[1]);
     }
@@ -470,28 +470,33 @@ void wxvbamApp::OnInitCmdLine(wxCmdLineParser& cl)
     // locale
     static wxCmdLineEntryDesc opttab[] = {
         { wxCMD_LINE_OPTION, NULL, t("save-xrc"),
-            N_("Save built-in XRC file and exit") },
+            N_("Save built-in XRC file and exit"),
+	    wxCMD_LINE_VAL_NONE, wxCMD_LINE_VAL_NONE },
         { wxCMD_LINE_OPTION, NULL, t("save-over"),
-            N_("Save built-in vba-over.ini and exit") },
+            N_("Save built-in vba-over.ini and exit"),
+	    wxCMD_LINE_VAL_NONE, wxCMD_LINE_VAL_NONE },
         { wxCMD_LINE_SWITCH, NULL, t("print-cfg-path"),
-            N_("Print configuration path and exit") },
+            N_("Print configuration path and exit"),
+	    wxCMD_LINE_VAL_NONE, wxCMD_LINE_VAL_NONE },
         { wxCMD_LINE_SWITCH, t("f"), t("fullscreen"),
-            N_("Start in full-screen mode") },
+            N_("Start in full-screen mode"), 
+	    wxCMD_LINE_VAL_NONE, wxCMD_LINE_VAL_NONE },
 #if !defined(NO_LINK) && !defined(__WXMSW__)
         { wxCMD_LINE_SWITCH, t("s"), t("delete-shared-state"),
-            N_("Delete shared link state first, if it exists") },
+            N_("Delete shared link state first, if it exists"),
+	    wxCMD_LINE_VAL_NONE, wxCMD_LINE_VAL_NONE },
 #endif
         // stupid wx cmd line parser doesn't support duplicate options
         //	{ wxCMD_LINE_OPTION, t("o"),  t("option"),
         //		_("Set configuration option; <opt>=<value> or help for list"),
-        {
-            wxCMD_LINE_SWITCH, t("o"), t("list-options"),
-            N_("List all settable options and exit") },
+        { wxCMD_LINE_SWITCH, t("o"), t("list-options"),
+            N_("List all settable options and exit"),
+	    wxCMD_LINE_VAL_NONE, wxCMD_LINE_VAL_NONE },
         { wxCMD_LINE_PARAM, NULL, NULL,
             N_("ROM file"), wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
         { wxCMD_LINE_PARAM, NULL, NULL,
             N_("<config>=<value>"), wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_MULTIPLE | wxCMD_LINE_PARAM_OPTIONAL },
-        { wxCMD_LINE_NONE }
+        { wxCMD_LINE_NONE, NULL, NULL, NULL, wxCMD_LINE_VAL_NONE, wxCMD_LINE_VAL_NONE }
     };
 // 2.9 automatically translates desc, but 2.8 doesn't
 #if !wxCHECK_VERSION(2, 9, 0)
@@ -667,10 +672,10 @@ wxvbamApp::~wxvbamApp() {
 
 MainFrame::MainFrame()
     : wxFrame()
-    , focused(false)
     , paused(false)
     , menus_opened(0)
     , dialog_opened(0)
+    , focused(false)
 {
 }
 
@@ -749,6 +754,7 @@ void MainFrame::OnMenu(wxContextMenuEvent& event)
 
 void MainFrame::OnMove(wxMoveEvent& event)
 {
+    (void)event; // unused params
     wxRect pos = GetRect();
     int x = pos.GetX(), y = pos.GetY();
     if (x >= 0 && y >= 0 && !IsFullScreen())
@@ -815,7 +821,7 @@ void MainFrame::SetJoystick()
         for (int j = 0; j < NUM_KEYS; j++) {
             wxJoyKeyBinding_v b = gopts.joykey_bindings[i][j];
 
-            for (int k = 0; k < b.size(); k++) {
+            for (size_t k = 0; k < b.size(); k++) {
                 int jn = b[k].joy;
 
                 if (jn) {
@@ -884,7 +890,7 @@ void MainFrame::update_state_ts(bool force)
                 wxString df = fts.Format(wxT("0&0 %x %X"));
 
                 if (!ts.IsValid())
-                    for (int j = 0; j < df.size(); j++)
+                    for (size_t j = 0; j < df.size(); j++)
                         if (wxIsdigit(df[j]))
                             df[j] = wxT('-');
 

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -656,6 +656,14 @@ extern struct cmditem {
     wxMenuItem* mi; // the menu item to invoke command, if present
 } cmdtab[];
 extern const int ncmds;
+
+cmditem new_cmditem(const wxString cmd = "", const wxString name = "", int cmd_id = 0,
+                    int mask_flags = 0, wxMenuItem* mi = NULL)
+{
+    struct cmditem tmp = {cmd, name, cmd_id, mask_flags, mi};
+    return tmp;
+}
+
 // for binary search
 extern bool cmditem_lt(const struct cmditem& cmd1, const struct cmditem& cmd2);
 

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -657,12 +657,9 @@ extern struct cmditem {
 } cmdtab[];
 extern const int ncmds;
 
-cmditem new_cmditem(const wxString cmd = "", const wxString name = "", int cmd_id = 0,
-                    int mask_flags = 0, wxMenuItem* mi = NULL)
-{
-    struct cmditem tmp = {cmd, name, cmd_id, mask_flags, mi};
-    return tmp;
-}
+// Initializer for struct cmditem
+cmditem new_cmditem(const wxString cmd = "", const wxString name = "",
+                    int cmd_id = 0, int mask_flags = 0, wxMenuItem* mi = NULL);
 
 // for binary search
 extern bool cmditem_lt(const struct cmditem& cmd1, const struct cmditem& cmd2);


### PR DESCRIPTION
@rkitover Hey! I have been busy lately, but I will try to contribute some more!

This is a bunch of code changes regarding getting rid of compilation warnings. This was also an excuse for me to browse the code in the last few days and see how some stuff work. I am not sure if you are interested or not on this, but nevertheless I have a few doubts about where should I go next. 

So these were the commands ran.
```
$ cmake .. -DENABLE_SDL=ON -DENABLE_LIRC=ON -DENABLE_LTO=ON -DENABLE_OPENAL=ON -DENABLE_SSP=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON
$ make -j`nproc` &> warnings.txt
```

Next is the output `warnings.txt`. I will ask some questions.
```
Scanning dependencies of target fex
[  0%] Building C object fex/CMakeFiles/fex.dir/7z_C/7zAlloc.c.o
[  1%] Building C object fex/CMakeFiles/fex.dir/7z_C/7zBuf.c.o
[  1%] Building C object fex/CMakeFiles/fex.dir/7z_C/7zCrc.c.o
[  2%] Building C object fex/CMakeFiles/fex.dir/7z_C/7zCrcOpt.c.o
[  2%] Building C object fex/CMakeFiles/fex.dir/7z_C/7zDec.c.o
[  3%] Building C object fex/CMakeFiles/fex.dir/7z_C/7zIn.c.o
[  3%] Building C object fex/CMakeFiles/fex.dir/7z_C/7zStream.c.o
[  4%] Building C object fex/CMakeFiles/fex.dir/7z_C/Bcj2.c.o
[  4%] Building C object fex/CMakeFiles/fex.dir/7z_C/Bra86.c.o
[  5%] Building C object fex/CMakeFiles/fex.dir/7z_C/Bra.c.o
[  5%] Building C object fex/CMakeFiles/fex.dir/7z_C/CpuArch.c.o
[  6%] Building C object fex/CMakeFiles/fex.dir/7z_C/Lzma2Dec.c.o
[  6%] Building C object fex/CMakeFiles/fex.dir/7z_C/LzmaDec.c.o
[  7%] Building C object fex/CMakeFiles/fex.dir/7z_C/Ppmd7.c.o
[  7%] Building C object fex/CMakeFiles/fex.dir/7z_C/Ppmd7Dec.c.o
[  8%] Building CXX object fex/CMakeFiles/fex.dir/fex/Binary_Extractor.cpp.o
[  8%] Building CXX object fex/CMakeFiles/fex.dir/fex/blargg_common.cpp.o
[  9%] Building CXX object fex/CMakeFiles/fex.dir/fex/blargg_errors.cpp.o
[  9%] Building CXX object fex/CMakeFiles/fex.dir/fex/Data_Reader.cpp.o
[ 10%] Building CXX object fex/CMakeFiles/fex.dir/fex/fex.cpp.o
[ 10%] Building CXX object fex/CMakeFiles/fex.dir/fex/File_Extractor.cpp.o
[ 11%] Building CXX object fex/CMakeFiles/fex.dir/fex/Gzip_Extractor.cpp.o
[ 11%] Building CXX object fex/CMakeFiles/fex.dir/fex/Gzip_Reader.cpp.o
[ 12%] Building CXX object fex/CMakeFiles/fex.dir/fex/Rar_Extractor.cpp.o
[ 12%] Building CXX object fex/CMakeFiles/fex.dir/fex/Zip7_Extractor.cpp.o
[ 13%] Building CXX object fex/CMakeFiles/fex.dir/fex/Zip_Extractor.cpp.o
[ 13%] Building CXX object fex/CMakeFiles/fex.dir/fex/Zlib_Inflater.cpp.o
[ 14%] Linking CXX static library libfex.a
[ 14%] Built target fex
Scanning dependencies of target vbamcore
[ 15%] Building CXX object CMakeFiles/vbamcore.dir/src/Util.cpp.o
[ 15%] Building CXX object CMakeFiles/vbamcore.dir/src/common/ConfigManager.cpp.o
[ 16%] Building C object CMakeFiles/vbamcore.dir/src/common/dictionary.c.o
[ 16%] Building C object CMakeFiles/vbamcore.dir/src/common/iniparser.c.o
[ 17%] Building CXX object CMakeFiles/vbamcore.dir/src/common/Patch.cpp.o
[ 17%] Building C object CMakeFiles/vbamcore.dir/src/common/memgzio.c.o
[ 18%] Building CXX object CMakeFiles/vbamcore.dir/src/common/SoundSDL.cpp.o
[ 18%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/agbprint.cpp.o
[ 19%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/bios.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp: In function ‘int32_t BIOS_SndDriver_3e4(uint32_t, uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp:1210:19: warning: comparison of integer expressions of different signedness: ‘int32_t’ {aka ‘int’} and ‘uint32_t’ {aka ‘unsigned int’} [-Wsign-compare]
         v5 += (r0 >= (uint32_t)r2) + v5;
                ~~~^~~~~~~~~~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp:1211:16: warning: comparison of integer expressions of different signedness: ‘int32_t’ {aka ‘int’} and ‘uint32_t’ {aka ‘unsigned int’} [-Wsign-compare]
         if (r0 >= (uint32_t)r2)
             ~~~^~~~~~~~~~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp:1218:15: warning: ‘<<’ in boolean context, did you mean ‘<’ ? [-Wint-in-bool-context]
     if (!(r12 << 1))
          ~~~~~^~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp: In function ‘void BIOS_SndDriverMain()’:
/home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp:1591:23: warning: comparison of integer expressions of different signedness: ‘uint32_t’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
             while (r7 >= 4 * r9) {
                    ~~~^~~~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp:1598:20: warning: comparison of integer expressions of different signedness: ‘uint32_t’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
             if (r7 >= 2 * r9) {
                 ~~~^~~~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp:1605:20: warning: comparison of integer expressions of different signedness: ‘uint32_t’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
             if (r7 < r9)
                 ~~~^~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp:1622:25: warning: comparison of integer expressions of different signedness: ‘uint32_t’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
             } while (r7 >= r9);
                      ~~~^~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp:1647:24: warning: comparison of integer expressions of different signedness: ‘uint32_t’ {aka ‘unsigned int’} and ‘int’ [-Wsign-compare]
                 if (r7 >= r9)
                     ~~~^~~~~
In file included from /home/denisfa/Git/visualboyadvance-m/src/gba/bios.cpp:6:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘uint32_t CPUReadHalfWord(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:286:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if (cpuFlashEnabled | cpuSramEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:291:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘uint8_t CPUReadByte(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:406:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         switch (address & 0x00008f00) {
         ^~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:417:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteMemory(uint32_t, uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:525:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:530:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteByte(uint32_t, uint8_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:784:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((saveType != 5) && ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled)) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:791:5: note: here
     default:
     ^~~~~~~
```

I coded only very basic stuff from the `src/gb/*` and `src/gba/*`. The reason for this is because I don't know enough to understand if my changes are going to break the app (worst case in a silent way). You can see where the warnings are, and some of these operations I believe they are intended. This looks very `assembly-ish` to me, so I don't even want to create vars for the single purpose of dealing with these. 

For example: `v5 += (r0 >= (uint32_t)r2) + v5;`. For `int32_t r2;` and `int32_t r0`. This is very likely a smarter (and more efficient) rewrite of an `if` for `r2` values. Since I am not sure what the `if` is, I kept this untouched.

```
[ 19%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/BreakpointStructures.cpp.o
[ 20%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Cheats.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gba/Cheats.cpp: In function ‘int cheatsCheckKeys(uint32_t, uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/Cheats.cpp:1089:58: warning: bitwise comparison always evaluates to true [-Wtautological-compare]
                     if (((cheatsList[i].address & 0x3FC) != 0x6) && ((cheatsList[i].address & 0x3FC) != 0x130))
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
In file included from /home/denisfa/Git/visualboyadvance-m/src/gba/Cheats.cpp:10:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteByte(uint32_t, uint8_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:784:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((saveType != 5) && ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled)) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:791:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘uint8_t CPUReadByte(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:406:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         switch (address & 0x00008f00) {
         ^~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:417:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘uint32_t CPUReadHalfWord(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:286:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if (cpuFlashEnabled | cpuSramEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:291:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteMemory(uint32_t, uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:525:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:530:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/Cheats.cpp: In function ‘void cheatsDelete(int, bool)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/Cheats.cpp:1350:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
                 if ((cheatsList[x].address >> 24) >= 0x08) {
                 ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/Cheats.cpp:1355:13: note: here
             case GSA_16_BIT_ROM_PATCH:
             ^~~~
[ 20%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/CheatSearch.cpp.o
[ 21%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/debugger-expr-lex.cpp.o
debugger-expr-lex.cpp:1263:13: warning: ‘void yyunput(int, char*)’ defined but not used [-Wunused-function]
[ 21%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/debugger-expr-yacc.cpp.o
src/sdl/debugger-expr.y: In function ‘int dexp_error(char*)’:
src/sdl/debugger-expr.y:106:22: warning: unused parameter ‘s’ [-Wunused-parameter]
[ 22%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/EEprom.cpp.o
[ 22%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/ereader.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gba/ereader.cpp: In function ‘void BIOS_EReader_ScanCard(int)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/ereader.cpp:459:23: warning: comparison of unsigned expression >= 0 is always true [-Wtype-limits]
         if ((reg[0].I >= 0) && (reg[0].I <= 0x10)) {
              ~~~~~~~~~^~~~
In file included from /home/denisfa/Git/visualboyadvance-m/src/gba/ereader.cpp:7:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteByte(uint32_t, uint8_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:784:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((saveType != 5) && ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled)) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:791:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteMemory(uint32_t, uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:525:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:530:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘uint8_t CPUReadByte(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:406:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         switch (address & 0x00008f00) {
         ^~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:417:5: note: here
     default:
     ^~~~~~~
[ 23%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Flash.cpp.o
[ 23%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/GBA.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gba/GBA.cpp: In function ‘void CPUSoftwareInterrupt(int)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBA.cpp:2253:35: warning: this statement may fall through [-Wimplicit-fallthrough=]
         BIOS_SndDriverJmpTableCopy();
         ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBA.cpp:2255:5: note: here
     default:
     ^~~~~~~
In file included from /home/denisfa/Git/visualboyadvance-m/src/gba/GBA.cpp:22:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘uint32_t CPUReadHalfWord(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:286:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if (cpuFlashEnabled | cpuSramEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:291:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteMemory(uint32_t, uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:525:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:530:5: note: here
     default:
     ^~~~~~~
[ 24%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/GBAGfx.cpp.o
[ 24%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/GBALink.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp: In function ‘void StartRFUSocket(uint16_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:1961:52: warning: this statement may fall through [-Wimplicit-fallthrough=]
                             rfu_data.rfu_q[linkid] = 0; //to prevent leftover data from previous session received immediately in the new session
                             ~~~~~~~~~~~~~~~~~~~~~~~^~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:1962:25: note: here
                         case 0x1d: // no visible difference
                         ^~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:2084:52: warning: this statement may fall through [-Wimplicit-fallthrough=]
                             rfu_data.rfu_q[linkid] = 0; //to prevent leftover data from previous session received immediately in the new session
                             ~~~~~~~~~~~~~~~~~~~~~~~^~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:2085:25: note: here
                         case 0x1b: //host, might reset some data? may be used in the middle of host<->client communication w/o causing clients to dc?
                         ^~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:2114:45: warning: this statement may fall through [-Wimplicit-fallthrough=]
                             rfu_initialized = false;
                             ~~~~~~~~~~~~~~~~^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:2115:25: note: here
                         case 0x10: // init/reset rfu data
                         ^~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:2251:29: warning: this statement may fall through [-Wimplicit-fallthrough=]
                             }
                             ^
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:2254:25: note: here
                         case 0x27: // wait for data ?
                         ^~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:2411:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if (rfu_polarity)
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:2413:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp: At global scope:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:521:12: warning: ‘mmf’ defined but not used [-Wunused-variable]
 static int mmf = -1;
            ^~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:515:15: warning: ‘linksync’ defined but not used [-Wunused-variable]
 static sem_t* linksync[4];
               ^~~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:478:15: warning: ‘j’ defined but not used [-Wunused-variable]
 static int i, j;
               ^
/home/denisfa/Git/visualboyadvance-m/src/gba/GBALink.cpp:331:18: warning: ‘linkmem’ defined but not used [-Wunused-variable]
 static LINKDATA* linkmem = NULL;
                  ^~~~~~~
[ 25%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/GBASockClient.cpp.o
[ 25%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/GBA-thumb.cpp.o
In file included from /home/denisfa/Git/visualboyadvance-m/src/gba/GBA-thumb.cpp:19:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteMemory(uint32_t, uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:525:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:530:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘uint32_t CPUReadHalfWord(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:286:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if (cpuFlashEnabled | cpuSramEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:291:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘uint8_t CPUReadByte(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:406:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         switch (address & 0x00008f00) {
         ^~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:417:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteByte(uint32_t, uint8_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:784:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((saveType != 5) && ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled)) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:791:5: note: here
     default:
     ^~~~~~~
[ 26%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/GBA-arm.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gba/GBA-arm.cpp: In function ‘void arm009(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBA-arm.cpp:1237:9: warning: unused variable ‘acc’ [-Wunused-variable]
     int acc = (opcode >> 12) & 0x0F; /* or destLo */                   \
         ^~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBA-arm.cpp:1283:52: note: in expansion of macro ‘MUL_INSN’
 static INSN_REGPARM void arm009(uint32_t opcode) { MUL_INSN(OP_MUL, SETCOND_NONE, 1); }
                                                    ^~~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBA-arm.cpp: In function ‘void arm019(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBA-arm.cpp:1237:9: warning: unused variable ‘acc’ [-Wunused-variable]
     int acc = (opcode >> 12) & 0x0F; /* or destLo */                   \
         ^~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBA-arm.cpp:1285:52: note: in expansion of macro ‘MUL_INSN’
 static INSN_REGPARM void arm019(uint32_t opcode) { MUL_INSN(OP_MUL, SETCOND_MUL, 1); }
                                                    ^~~~~~~~
In file included from /home/denisfa/Git/visualboyadvance-m/src/gba/GBA-arm.cpp:16:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteMemory(uint32_t, uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:525:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:530:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘uint8_t CPUReadByte(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:406:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         switch (address & 0x00008f00) {
         ^~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:417:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘void CPUWriteByte(uint32_t, uint8_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:784:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((saveType != 5) && ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled)) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:791:5: note: here
     default:
     ^~~~~~~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h: In function ‘uint32_t CPUReadHalfWord(uint32_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:286:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if (cpuFlashEnabled | cpuSramEnabled) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/GBAinline.h:291:5: note: here
     default:
     ^~~~~~~
[ 27%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/gbafilter.cpp.o
[ 27%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Globals.cpp.o
[ 28%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Mode0.cpp.o
[ 28%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Mode1.cpp.o
[ 29%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Mode2.cpp.o
[ 29%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Mode3.cpp.o
[ 30%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Mode4.cpp.o
[ 30%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Mode5.cpp.o
[ 31%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/RTC.cpp.o
[ 31%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Sound.cpp.o
[ 32%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/Sram.cpp.o
[ 32%] Building CXX object CMakeFiles/vbamcore.dir/src/gb/GB.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gb/GB.cpp: In function ‘void gbWriteMemory(uint16_t, uint8_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gb/GB.cpp:1499:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if (inBios && (value & 1)) {
         ^~
/home/denisfa/Git/visualboyadvance-m/src/gb/GB.cpp:1509:5: note: here
     case 0x51: {
     ^~~~
/home/denisfa/Git/visualboyadvance-m/src/gb/GB.cpp:1701:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
         }
         ^
/home/denisfa/Git/visualboyadvance-m/src/gb/GB.cpp:1704:5: note: here
     case 0x75: {
     ^~~~
[ 33%] Building CXX object CMakeFiles/vbamcore.dir/src/gb/gbCheats.cpp.o
[ 33%] Building CXX object CMakeFiles/vbamcore.dir/src/gb/gbDis.cpp.o
[ 34%] Building CXX object CMakeFiles/vbamcore.dir/src/gb/gbGfx.cpp.o
[ 34%] Building CXX object CMakeFiles/vbamcore.dir/src/gb/gbGlobals.cpp.o
[ 35%] Building CXX object CMakeFiles/vbamcore.dir/src/gb/gbMemory.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gb/gbMemory.cpp:996:1: warning: missing initializer for member ‘mapperHuC3::mapperRAMValue’ [-Wmissing-field-initializers]
 };
 ^
/home/denisfa/Git/visualboyadvance-m/src/gb/gbMemory.cpp:996:1: warning: missing initializer for member ‘mapperHuC3::mapperRegister1’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/src/gb/gbMemory.cpp:996:1: warning: missing initializer for member ‘mapperHuC3::mapperRegister2’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/src/gb/gbMemory.cpp:996:1: warning: missing initializer for member ‘mapperHuC3::mapperRegister3’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/src/gb/gbMemory.cpp:996:1: warning: missing initializer for member ‘mapperHuC3::mapperRegister4’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/src/gb/gbMemory.cpp:996:1: warning: missing initializer for member ‘mapperHuC3::mapperRegister5’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/src/gb/gbMemory.cpp:996:1: warning: missing initializer for member ‘mapperHuC3::mapperRegister6’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/src/gb/gbMemory.cpp:996:1: warning: missing initializer for member ‘mapperHuC3::mapperRegister7’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/src/gb/gbMemory.cpp:996:1: warning: missing initializer for member ‘mapperHuC3::mapperRegister8’ [-Wmissing-field-initializers]
[ 35%] Building CXX object CMakeFiles/vbamcore.dir/src/gb/gbPrinter.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gb/gbPrinter.cpp: In function ‘uint8_t gbPrinterSend(uint8_t)’:
/home/denisfa/Git/visualboyadvance-m/src/gb/gbPrinter.cpp:182:23: warning: this statement may fall through [-Wimplicit-fallthrough=]
         gbPrinterState++;
         ~~~~~~~~~~~~~~^~
/home/denisfa/Git/visualboyadvance-m/src/gb/gbPrinter.cpp:184:5: note: here
     case 4:
     ^~~~
[ 36%] Building CXX object CMakeFiles/vbamcore.dir/src/gb/gbSGB.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gb/gbSGB.cpp: In function ‘void gbSgbReset()’:
/home/denisfa/Git/visualboyadvance-m/src/gb/gbSGB.cpp:70:39: warning: ‘memset’ used with length equal to number of elements without multiplication by element size [-Wmemset-elt-size]
     memset(gbSgbSCPPalette, 0, 512 * 4);
                                       ^
```

This is quite curious. Why zero a struct? Shouldn't we have an `new gbSgbSCPPalette()` instead?

```
[ 36%] Building CXX object CMakeFiles/vbamcore.dir/src/gb/gbSound.cpp.o
[ 37%] Building CXX object CMakeFiles/vbamcore.dir/src/apu/Blip_Buffer.cpp.o
[ 37%] Building CXX object CMakeFiles/vbamcore.dir/src/apu/Effects_Buffer.cpp.o
[ 38%] Building CXX object CMakeFiles/vbamcore.dir/src/apu/Gb_Apu.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/apu/Gb_Apu.cpp: In member function ‘void Gb_Apu::run_until_(blip_time_t)’:
/home/denisfa/Git/visualboyadvance-m/src/apu/Gb_Apu.cpp:220:23: warning: this statement may fall through [-Wimplicit-fallthrough=]
    square1.clock_sweep();
    ~~~~~~~~~~~~~~~~~~~^~
/home/denisfa/Git/visualboyadvance-m/src/apu/Gb_Apu.cpp:221:3: note: here
   case 0:
   ^~~~
[ 38%] Building CXX object CMakeFiles/vbamcore.dir/src/apu/Gb_Apu_State.cpp.o
[ 39%] Building CXX object CMakeFiles/vbamcore.dir/src/apu/Gb_Oscs.cpp.o
[ 39%] Building CXX object CMakeFiles/vbamcore.dir/src/apu/Multi_Buffer.cpp.o
[ 40%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/2xSaI.cpp.o
[ 40%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/admame.cpp.o
[ 41%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/bilinear.cpp.o
[ 41%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/hq2x.cpp.o
[ 42%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/interframe.cpp.o
[ 42%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/pixel.cpp.o
[ 43%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/scanline.cpp.o
[ 44%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/simpleFilter.cpp.o
[ 44%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/xbrzfilter.cpp.o
[ 45%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/xBRZ/xbrz.cpp.o
[ 45%] Building CXX object CMakeFiles/vbamcore.dir/src/filters/hq/c/hq_implementation.cpp.o
[ 46%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/armdis.cpp.o
[ 46%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/elf.cpp.o
[ 47%] Building CXX object CMakeFiles/vbamcore.dir/src/gba/remote.cpp.o
/home/denisfa/Git/visualboyadvance-m/src/gba/remote.cpp: In function ‘void debuggerDoSearch()’:
/home/denisfa/Git/visualboyadvance-m/src/gba/remote.cpp:863:13: warning: this statement may fall through [-Wimplicit-fallthrough=]
             if (final <= 0x09FFFFFF) {
             ^~
/home/denisfa/Git/visualboyadvance-m/src/gba/remote.cpp:868:9: note: here
         default: {
         ^~~~~~~
```

I believe these `-Wimplicit-fallthrough` are intended. But then again, more bit operations.

```
[ 47%] Linking CXX static library libvbamcore.a
[ 47%] Built target vbamcore
Scanning dependencies of target vbam
[ 48%] Building CXX object CMakeFiles/vbam.dir/src/sdl/SDL.cpp.o
[ 48%] Building CXX object CMakeFiles/vbam.dir/src/sdl/filters.cpp.o
[ 49%] Building CXX object CMakeFiles/vbam.dir/src/sdl/text.cpp.o
[ 49%] Building CXX object CMakeFiles/vbam.dir/src/sdl/inputSDL.cpp.o
[ 50%] Building CXX object CMakeFiles/vbam.dir/src/sdl/expr.cpp.o
[ 50%] Building CXX object CMakeFiles/vbam.dir/src/sdl/exprNode.cpp.o
[ 51%] Building CXX object CMakeFiles/vbam.dir/src/sdl/expr-lex.cpp.o
[ 51%] Linking CXX executable vbam
[ 51%] Built target vbam
Scanning dependencies of target translations_1
[ 51%] Generating ar.gmo
[ 52%] Generating br.gmo
[ 52%] Generating bs.gmo
[ 53%] Generating ca.gmo
[ 54%] Generating ca_ES.gmo
[ 54%] Generating cs.gmo
[ 55%] Generating da.gmo
[ 55%] Generating da_DK.gmo
[ 56%] Generating de.gmo
[ 56%] Generating de_DE.gmo
[ 57%] Generating el.gmo
[ 57%] Generating el_GR.gmo
[ 58%] Generating en.gmo
[ 58%] Generating en_GB.gmo
[ 59%] Generating en_US.gmo
[ 59%] Generating es.gmo
[ 60%] Generating es_419.gmo
[ 60%] Generating es_AR.gmo
[ 61%] Generating es_CL.gmo
[ 61%] Generating es_CO.gmo
[ 62%] Generating es_ES.gmo
[ 62%] Generating es_MX.gmo
[ 63%] Generating es_PR.gmo
[ 63%] Generating es_US.gmo
[ 64%] Generating fil.gmo
[ 64%] Generating fr.gmo
[ 65%] Generating fr_CA.gmo
[ 65%] Generating fr_FR.gmo
[ 66%] Generating gl.gmo
[ 66%] Generating haw.gmo
[ 67%] Generating he.gmo
[ 67%] Generating he_IL.gmo
[ 68%] Generating hr.gmo
[ 68%] Generating hu.gmo
[ 69%] Generating hu_HU.gmo
[ 69%] Generating id.gmo
[ 70%] Generating id_ID.gmo
[ 71%] Generating it.gmo
[ 71%] Generating it_IT.gmo
[ 72%] Generating ja.gmo
[ 72%] Generating ja_JP.gmo
[ 73%] Generating jv.gmo
[ 73%] Generating ko.gmo
[ 74%] Generating ko_KR.gmo
[ 74%] Generating ms_MY.gmo
[ 75%] Generating nb.gmo
[ 75%] Generating nl.gmo
[ 76%] Generating nl_NL.gmo
[ 76%] Generating no.gmo
[ 77%] Generating pl.gmo
[ 77%] Generating pl_PL.gmo
[ 78%] Generating pt.gmo
[ 78%] Generating pt_BR.gmo
[ 79%] Generating pt_PT.gmo
[ 79%] Generating ru.gmo
[ 80%] Generating ru_RU.gmo
[ 80%] Generating sk.gmo
[ 81%] Generating sk_SK.gmo
[ 81%] Generating sr.gmo
[ 82%] Generating su.gmo
[ 82%] Generating sv.gmo
[ 83%] Generating tk.gmo
[ 83%] Generating tr.gmo
[ 84%] Generating zh-Hans.gmo
[ 84%] Generating zh.gmo
[ 85%] Generating zh_CN.GB2312.gmo
[ 85%] Generating zh_CN.gmo
[ 86%] Generating zh_HK.gmo
[ 87%] Generating zh_TW.Big5.gmo
[ 87%] Generating zh_TW.gmo
[ 87%] Built target translations_1
Scanning dependencies of target translations
[ 87%] Built target translations
[ 87%] Generating wxvbam.xrs
[ 88%] Generating cmdtab.cpp, cmdhandlers.h, cmd-evtable.h
[ 88%] Generating builtin-xrc.h
[ 89%] Generating builtin-over.h
Scanning dependencies of target visualboyadvance-m
[ 90%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/wxvbam.cpp.o
[ 90%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/guiinit.cpp.o
[ 91%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/viewers.cpp.o
[ 91%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/gfxviewers.cpp.o
[ 92%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/cmdevents.cpp.o
[ 92%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/opts.cpp.o
[ 93%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/sys.cpp.o
[ 93%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/panel.cpp.o
[ 94%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/viewsupt.cpp.o
[ 94%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/wayland.cpp.o
[ 95%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/strutils.cpp.o
[ 95%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/widgets/keyedit.cpp.o
[ 96%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/widgets/joyedit.cpp.o
[ 96%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/widgets/sdljoy.cpp.o
[ 97%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/widgets/wxmisc.cpp.o
[ 97%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/__/sdl/text.cpp.o
[ 98%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/widgets/checkedlistctrl.cpp.o
[ 98%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/cmdtab.cpp.o
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
 };
 ^
```

Here we have a special file that is generated by `cmake`: `build/src/wx/cmdtab.cpp`. The idea here is to grab options from other file and keep them synced. This is also only generated for `debug` builds. I want to try the cmake way before actually going to the source code and doing something there.
Any special reason for this file? What it is about? Where do we use it?

```
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mask_flags’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
/home/denisfa/Git/visualboyadvance-m/build/src/wx/cmdtab.cpp:167:1: warning: missing initializer for member ‘cmditem::mi’ [-Wmissing-field-initializers]
[ 99%] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/openal.cpp.o
[100%] Linking CXX executable ../../visualboyadvance-m
[100%] Built target visualboyadvance-m
```

As far as my changes go, let's use the following example (it is not the only case):
```
void wxKeyTextCtrl::OnKeyUp(wxKeyEvent& event)
{
    (void)event; // without this, we get a warning for unused variable "event"
    ...
}
```

I know I could have done a `__attribute__((unused))` for `event`. This works on both `gcc` and `clang`. I was worried for the MacOS and Windows builds. What do they use? Is it portable enough?

I would like to confirm that with you. I have a commit that uses  `__attribute__((unused))` instead of the approach I coded here. I can easily fix this, if, of course, you want to push and use this attribute instead.


Moreover, I left out the `-DENABLE_FFMPEG=ON` option. I believe this is broken atm (or at least  the video recording). Is this a feature that you want to keep? I am very interested about working on this. It will be slow, but I believe I can do it. Also, there are a million warnings about version issues (stable stable version [3.4](https://packages.debian.org/search?keywords=ffmpeg) against stable release version [4.1](https://ffmpeg.org/index.html#news). We always want the debian stable one, right?

Feel free to comment anything you want.