### PR TITLE
Fix for resizing window geometry when loading games.

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -302,7 +302,8 @@ void GameArea::LoadGame(const wxString& name)
     loaded = t;
     SetFrameTitle();
     SetFocus();
-    AdjustSize(true);
+    // Use custom geometry
+    AdjustSize(false);
     emulating = true;
     was_paused = true;
     MainFrame* mf = wxGetApp().frame;


### PR DESCRIPTION
@rkitover The window was being forced to resize every time a game loads. The idea is to resize only if the minimum size (determined by the zoom configuration) requires a window bigger than the custom one set by the user. In this case, we should set it to the minimum size asked by the zoom.

@retro-wertz I believe this should be enough to deal with the zoom. If I understand it right, the zoom level X means the minimum size for the window is `X * (min_width, min_height)`. Is this correct?

There is still something bothering me here. The window size set by the frame does not include status bar or menu bar. There might be some cases where the window will be either a little bigger than expected (the status bar pixels) or be slight incorrect `X,Y` starting positions. I will try some more tests to see If I can confirm this behaviour.

Fix for #79.