### PR TITLE
Fix compilation warnings for MacOS build.

### DIFF
--- a/src/filters/2xSaI.cpp
+++ b/src/filters/2xSaI.cpp
@@ -157,10 +157,10 @@ static inline uint32_t INTERPOLATE (uint32_t A, uint32_t B)
 
 static inline uint32_t Q_INTERPOLATE (uint32_t A, uint32_t B, uint32_t C, uint32_t D)
 {
-  register uint32_t x = ((A & qcolorMask) >> 2) +
+  uint32_t x = ((A & qcolorMask) >> 2) +
     ((B & qcolorMask) >> 2) +
     ((C & qcolorMask) >> 2) + ((D & qcolorMask) >> 2);
-  register uint32_t y = (A & qlowpixelMask) +
+  uint32_t y = (A & qlowpixelMask) +
     (B & qlowpixelMask) + (C & qlowpixelMask) + (D & qlowpixelMask);
 
   y = (y >> 2) & qlowpixelMask;
@@ -283,7 +283,7 @@ void Super2xSaI (uint8_t *srcPtr, uint32_t srcPitch,
           } else if (color5 == color3 && color2 != color6) {
             product2b = product1b = color5;
           } else if (color5 == color3 && color2 == color6) {
-            register int r = 0;
+            int r = 0;
 
             r += GetResult (color6, color5, color1, colorA1);
             r += GetResult (color6, color5, color4, colorB1);
@@ -415,7 +415,7 @@ void Super2xSaI32 (uint8_t *srcPtr, uint32_t srcPitch,
       } else if (color5 == color3 && color2 != color6) {
         product2b = product1b = color5;
       } else if (color5 == color3 && color2 == color6) {
-        register int r = 0;
+        int r = 0;
 
         r += GetResult (color6, color5, color1, colorA1);
         r += GetResult (color6, color5, color4, colorB1);
@@ -575,7 +575,7 @@ void SuperEagle (uint8_t *srcPtr, uint32_t srcPitch, uint8_t *deltaPtr,
           }
 
         } else if (color5 == color3 && color2 == color6) {
-          register int r = 0;
+          int r = 0;
 
           r += GetResult (color6, color5, color1, colorA1);
           r += GetResult (color6, color5, color4, colorB1);
@@ -710,7 +710,7 @@ void SuperEagle32 (uint8_t *srcPtr, uint32_t srcPitch, uint8_t *deltaPtr,
         }
 
       } else if (color5 == color3 && color2 == color6) {
-        register int r = 0;
+        int r = 0;
 
         r += GetResult (color6, color5, color1, colorA1);
         r += GetResult (color6, color5, color4, colorB1);
@@ -790,7 +790,7 @@ void _2xSaI (uint8_t *srcPtr, uint32_t srcPitch, uint8_t *deltaPtr,
 
       for (uint32_t finish = width; finish; finish -= inc_bP) {
 
-        register uint32_t colorA, colorB;
+        uint32_t colorA, colorB;
         uint32_t colorC, colorD,
           colorE, colorF, colorG, colorH,
           colorI, colorJ, colorK, colorL,
@@ -863,7 +863,7 @@ void _2xSaI (uint8_t *srcPtr, uint32_t srcPitch, uint8_t *deltaPtr,
             product1 = colorA;
             product2 = colorA;
           } else {
-            register int r = 0;
+            int r = 0;
 
             product1 = INTERPOLATE (colorA, colorC);
             product = INTERPOLATE (colorA, colorB);
@@ -950,7 +950,7 @@ void _2xSaI32 (uint8_t *srcPtr, uint32_t srcPitch, uint8_t * /* deltaPtr */,
     dP = (uint32_t *) dstPtr;
 
     for (uint32_t finish = width; finish; finish -= inc_bP) {
-      register uint32_t colorA, colorB;
+      uint32_t colorA, colorB;
       uint32_t colorC, colorD,
         colorE, colorF, colorG, colorH,
         colorI, colorJ, colorK, colorL,
@@ -1023,7 +1023,7 @@ void _2xSaI32 (uint8_t *srcPtr, uint32_t srcPitch, uint8_t * /* deltaPtr */,
           product1 = colorA;
           product2 = colorA;
         } else {
-          register int r = 0;
+          int r = 0;
 
           product1 = INTERPOLATE (colorA, colorC);
           product = INTERPOLATE (colorA, colorB);

--- a/src/filters/hq/c/hq_shared.h
+++ b/src/filters/hq/c/hq_shared.h
@@ -152,7 +152,7 @@ inline unsigned int RGBtoYUV_32(unsigned int c)
 {
         // Division through 3 slows down the emulation about 10% !!!
 
-        register unsigned char r, g, b;
+        unsigned char r, g, b;
         b = c & 0x0000FF;
         g = (c & 0x00FF00) >> 8;
         r = c >> 16;
@@ -254,7 +254,7 @@ inline unsigned int RGBtoYUV_16(unsigned short c)
 {
         // Division through 3 slows down the emulation about 10% !!!
 
-        register unsigned char r, g, b;
+        unsigned char r, g, b;
 #ifdef RGB555
         r = (c & 0x7C00) >> 7;
         g = (c & 0x03E0) >> 2;

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -900,7 +900,7 @@ void gbCompareLYToLYC()
     }
 }
 
-void gbWriteMemory(register uint16_t address, register uint8_t value)
+void gbWriteMemory(uint16_t address, uint8_t value)
 {
 
     if (address < 0x8000) {
@@ -1720,7 +1720,7 @@ void gbWriteMemory(register uint16_t address, register uint8_t value)
     gbMemory[address] = value;
 }
 
-uint8_t gbReadMemory(register uint16_t address)
+uint8_t gbReadMemory(uint16_t address)
 {
     if (gbCheatMap[address])
         return gbCheatRead(address);
@@ -4505,7 +4505,7 @@ void gbEmulate(int ticksToStop)
     clockTicks = 0;
     gbDmaTicks = 0;
 
-    register int opcode = 0;
+    int opcode = 0;
 
     int opcode1 = 0;
     int opcode2 = 0;

--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -24,7 +24,7 @@ int gbDis(char*, uint16_t);
 bool gbLoadRom(const char*);
 bool gbUpdateSizes();
 void gbEmulate(int);
-void gbWriteMemory(register uint16_t, register uint8_t);
+void gbWriteMemory(uint16_t, uint8_t);
 void gbDrawLine();
 bool gbIsGameboyRom(const char*);
 void gbGetHardwareType();

--- a/src/gb/gbSGB.cpp
+++ b/src/gb/gbSGB.cpp
@@ -119,7 +119,7 @@ void gbSgbFillScreen(uint16_t color)
             int yLine = (y + gbBorderRowSkip + 1) * (gbBorderLineSkip + 2) + gbBorderColumnSkip;
 #endif
             uint16_t* dest = (uint16_t*)pix + yLine;
-            for (register int x = 0; x < 160; x++)
+            for (int x = 0; x < 160; x++)
                 gbSgbDraw16Bit(dest++, color);
         }
     } break;
@@ -127,7 +127,7 @@ void gbSgbFillScreen(uint16_t color)
         for (int y = 0; y < 144; y++) {
             int yLine = (y + gbBorderRowSkip) * gbBorderLineSkip + gbBorderColumnSkip;
             uint8_t* dest = (uint8_t*)pix + yLine * 3;
-            for (register int x = 0; x < 160; x++) {
+            for (int x = 0; x < 160; x++) {
                 gbSgbDraw24Bit(dest, color);
                 dest += 3;
             }
@@ -141,7 +141,7 @@ void gbSgbFillScreen(uint16_t color)
             int yLine = (y + gbBorderRowSkip + 1) * (gbBorderLineSkip + 1) + gbBorderColumnSkip;
 #endif
             uint32_t* dest = (uint32_t*)pix + yLine;
-            for (register int x = 0; x < 160; x++) {
+            for (int x = 0; x < 160; x++) {
                 gbSgbDraw32Bit(dest++, color);
             }
         }

--- a/src/gb/gbSound.cpp
+++ b/src/gb/gbSound.cpp
@@ -37,7 +37,7 @@ uint8_t gbSoundRead(uint16_t address)
     return gbMemory[address];
 }
 
-void gbSoundEvent(register uint16_t address, register int data)
+void gbSoundEvent(uint16_t address, int data)
 {
     gbMemory[address] = data;
 

--- a/src/gba/GBA-arm.cpp
+++ b/src/gba/GBA-arm.cpp
@@ -144,8 +144,8 @@ static void count(uint32_t opcode, int cond_res)
 //#ifdef __POWERPC__
 #define OP_SUBS                            \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("subco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -161,8 +161,8 @@ static void count(uint32_t opcode, int cond_res)
     }
 #define OP_RSBS                             \
     {                                       \
-        register int Flags;                 \
-        register int Result;                \
+        int Flags;                 \
+        int Result;                \
         asm volatile("subfco. %0, %2, %3\n" \
                      "mcrxr cr1\n"          \
                      "mfcr %1\n"            \
@@ -178,8 +178,8 @@ static void count(uint32_t opcode, int cond_res)
     }
 #define OP_ADDS                            \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("addco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -195,8 +195,8 @@ static void count(uint32_t opcode, int cond_res)
     }
 #define OP_ADCS                            \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("mtspr xer, %4\n"     \
                      "addeo. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
@@ -214,8 +214,8 @@ static void count(uint32_t opcode, int cond_res)
     }
 #define OP_SBCS                             \
     {                                       \
-        register int Flags;                 \
-        register int Result;                \
+        int Flags;                 \
+        int Result;                \
         asm volatile("mtspr xer, %4\n"      \
                      "subfeo. %0, %3, %2\n" \
                      "mcrxr cr1\n"          \
@@ -233,8 +233,8 @@ static void count(uint32_t opcode, int cond_res)
     }
 #define OP_RSCS                             \
     {                                       \
-        register int Flags;                 \
-        register int Result;                \
+        int Flags;                 \
+        int Result;                \
         asm volatile("mtspr xer, %4\n"      \
                      "subfeo. %0, %2, %3\n" \
                      "mcrxr cr1\n"          \
@@ -252,8 +252,8 @@ static void count(uint32_t opcode, int cond_res)
     }
 #define OP_CMP                             \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("subco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -268,8 +268,8 @@ static void count(uint32_t opcode, int cond_res)
     }
 #define OP_CMN                             \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("addco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \

--- a/src/gba/GBA-thumb.cpp
+++ b/src/gba/GBA-thumb.cpp
@@ -89,8 +89,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
 #ifdef __POWERPC__
 #define ADD_RD_RS_RN(N)                    \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("addco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -106,8 +106,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
     }
 #define ADD_RD_RS_O3(N)                    \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("addco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -124,8 +124,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
 #define ADD_RD_RS_O3_0 ADD_RD_RS_O3
 #define ADD_RN_O8(d)                       \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("addco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -141,8 +141,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
     }
 #define CMN_RD_RS                          \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("addco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -157,8 +157,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
     }
 #define ADC_RD_RS            \
     {                        \
-        register int Flags;  \
-        register int Result; \
+        int Flags;  \
+        int Result; \
                 asm volatile("mtspr 1, %4\n"		\ /* reg 1 is xer */
                              "addeo. %0, %2, %3\n"	\
                              "mcrxr cr1\n"			\
@@ -177,8 +177,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
                              }
 #define SUB_RD_RS_RN(N)                    \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("subco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -194,8 +194,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
     }
 #define SUB_RD_RS_O3(N)                    \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("subco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -212,8 +212,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
 #define SUB_RD_RS_O3_0 SUB_RD_RS_O3
 #define SUB_RN_O8(d)                       \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("subco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -229,8 +229,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
     }
 #define CMP_RN_O8(d)                       \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("subco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \
@@ -245,8 +245,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
     }
 #define SBC_RD_RS            \
     {                        \
-        register int Flags;  \
-        register int Result; \
+        int Flags;  \
+        int Result; \
                 asm volatile("mtspr 1, %4\n"		\ /* reg 1 is xer */
                              "subfeo. %0, %3, %2\n"	\
                              "mcrxr cr1\n"			\
@@ -265,8 +265,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
                              }
 #define NEG_RD_RS                           \
     {                                       \
-        register int Flags;                 \
-        register int Result;                \
+        int Flags;                 \
+        int Result;                \
         asm volatile("subfco. %0, %2, %3\n" \
                      "mcrxr cr1\n"          \
                      "mfcr %1\n"            \
@@ -282,8 +282,8 @@ static INSN_REGPARM void thumbBreakpoint(uint32_t opcode)
     }
 #define CMP_RD_RS                          \
     {                                      \
-        register int Flags;                \
-        register int Result;               \
+        int Flags;                \
+        int Result;               \
         asm volatile("subco. %0, %2, %3\n" \
                      "mcrxr cr1\n"         \
                      "mfcr %1\n"           \

--- a/src/gba/debugger-expr-lex.cpp
+++ b/src/gba/debugger-expr-lex.cpp
@@ -701,9 +701,9 @@ extern int dexp_lex(void);
  */
 YY_DECL
 {
-    register yy_state_type yy_current_state;
-    register char *yy_cp, *yy_bp;
-    register int yy_act;
+    yy_state_type yy_current_state;
+    char *yy_cp, *yy_bp;
+    int yy_act;
 
 #line 31 "debugger-expr.l"
 
@@ -748,7 +748,7 @@ YY_DECL
         yy_current_state = (yy_start);
     yy_match:
         do {
-            register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+            YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
             if (yy_accept[yy_current_state]) {
                 (yy_last_accepting_state) = yy_current_state;
                 (yy_last_accepting_cpos) = yy_cp;
@@ -1073,9 +1073,9 @@ YY_DECL
  */
 static int yy_get_next_buffer(void)
 {
-    register char* dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-    register char* source = (yytext_ptr);
-    register int number_to_move, i;
+    char* dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+    char* source = (yytext_ptr);
+    int number_to_move, i;
     int ret_val;
 
     if ((yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1])
@@ -1192,13 +1192,13 @@ static int yy_get_next_buffer(void)
 
 static yy_state_type yy_get_previous_state(void)
 {
-    register yy_state_type yy_current_state;
-    register char* yy_cp;
+    yy_state_type yy_current_state;
+    char* yy_cp;
 
     yy_current_state = (yy_start);
 
     for (yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp) {
-        register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+        YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
         if (yy_accept[yy_current_state]) {
             (yy_last_accepting_state) = yy_current_state;
             (yy_last_accepting_cpos) = yy_cp;
@@ -1221,10 +1221,10 @@ static yy_state_type yy_get_previous_state(void)
  */
 static yy_state_type yy_try_NUL_trans(yy_state_type yy_current_state)
 {
-    register int yy_is_jam;
-    register char* yy_cp = (yy_c_buf_p);
+    int yy_is_jam;
+    char* yy_cp = (yy_c_buf_p);
 
-    register YY_CHAR yy_c = 1;
+    YY_CHAR yy_c = 1;
     if (yy_accept[yy_current_state]) {
         (yy_last_accepting_state) = yy_current_state;
         (yy_last_accepting_cpos) = yy_cp;
@@ -1240,9 +1240,9 @@ static yy_state_type yy_try_NUL_trans(yy_state_type yy_current_state)
     return yy_is_jam ? 0 : yy_current_state;
 }
 
-static void yyunput(int c, register char* yy_bp)
+static void yyunput(int c, char* yy_bp)
 {
-    register char* yy_cp;
+    char* yy_cp;
 
     yy_cp = (yy_c_buf_p);
 
@@ -1251,9 +1251,9 @@ static void yyunput(int c, register char* yy_bp)
 
     if (yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2) { /* need to shift things up to make room */
         /* +2 for EOB chars. */
-        register int number_to_move = (yy_n_chars) + 2;
-        register char* dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
-        register char* source = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
+        int number_to_move = (yy_n_chars) + 2;
+        char* dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
+        char* source = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
 
         while (source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf)
             *--dest = *--source;
@@ -1849,7 +1849,7 @@ int dexp_lex_destroy(void)
 #ifndef yytext_ptr
 static void yy_flex_strncpy(char* s1, yyconst char* s2, int n)
 {
-    register int i;
+    int i;
     for (i = 0; i < n; ++i)
         s1[i] = s2[i];
 }
@@ -1858,7 +1858,7 @@ static void yy_flex_strncpy(char* s1, yyconst char* s2, int n)
 #ifdef YY_NEED_STRLEN
 static int yy_flex_strlen(yyconst char* s)
 {
-    register int n;
+    int n;
     for (n = 0; s[n]; ++n)
         ;
 

--- a/src/gba/remote.cpp
+++ b/src/gba/remote.cpp
@@ -3561,13 +3561,13 @@ void remotePutPacket(const char* packet)
         remoteSendFnc(buffer, (int)count + 4);
 
         if (remoteRecvFnc(&c, 1) < 0) {
-            delete buffer;
+            delete[] buffer;
             return;
         }
         //    fprintf(stderr,"sent:%s recieved:%c\n",buffer,c);
     }
 
-    delete buffer;
+    delete[] buffer;
 }
 
 void remoteOutput(const char* s, uint32_t addr)
@@ -3712,7 +3712,7 @@ void remoteMemoryRead(char* p)
     *s = 0;
     remotePutPacket(buffer);
 
-    delete buffer;
+    delete[] buffer;
 }
 
 void remoteQuery(char* p)

--- a/src/sdl/expr-lex.cpp
+++ b/src/sdl/expr-lex.cpp
@@ -634,9 +634,9 @@ extern int yylex(void);
  */
 YY_DECL
 {
-    register yy_state_type yy_current_state;
-    register char *yy_cp, *yy_bp;
-    register int yy_act;
+    yy_state_type yy_current_state;
+    char *yy_cp, *yy_bp;
+    int yy_act;
 
 #line 33 "expr.l"
 
@@ -681,7 +681,7 @@ YY_DECL
         yy_current_state = (yy_start);
     yy_match:
         do {
-            register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+            YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
             if (yy_accept[yy_current_state]) {
                 (yy_last_accepting_state) = yy_current_state;
                 (yy_last_accepting_cpos) = yy_cp;
@@ -912,9 +912,9 @@ YY_DECL
  */
 static int yy_get_next_buffer(void)
 {
-    register char* dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-    register char* source = (yytext_ptr);
-    register int number_to_move, i;
+    char* dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+    char* source = (yytext_ptr);
+    int number_to_move, i;
     int ret_val;
 
     if ((yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1])
@@ -1031,13 +1031,13 @@ static int yy_get_next_buffer(void)
 
 static yy_state_type yy_get_previous_state(void)
 {
-    register yy_state_type yy_current_state;
-    register char* yy_cp;
+    yy_state_type yy_current_state;
+    char* yy_cp;
 
     yy_current_state = (yy_start);
 
     for (yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp) {
-        register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+        YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
         if (yy_accept[yy_current_state]) {
             (yy_last_accepting_state) = yy_current_state;
             (yy_last_accepting_cpos) = yy_cp;
@@ -1060,10 +1060,10 @@ static yy_state_type yy_get_previous_state(void)
  */
 static yy_state_type yy_try_NUL_trans(yy_state_type yy_current_state)
 {
-    register int yy_is_jam;
-    register char* yy_cp = (yy_c_buf_p);
+    int yy_is_jam;
+    char* yy_cp = (yy_c_buf_p);
 
-    register YY_CHAR yy_c = 1;
+    YY_CHAR yy_c = 1;
     if (yy_accept[yy_current_state]) {
         (yy_last_accepting_state) = yy_current_state;
         (yy_last_accepting_cpos) = yy_cp;
@@ -1655,7 +1655,7 @@ int yylex_destroy(void)
 #ifndef yytext_ptr
 static void yy_flex_strncpy(char* s1, yyconst char* s2, int n)
 {
-    register int i;
+    int i;
     for (i = 0; i < n; ++i)
         s1[i] = s2[i];
 }
@@ -1664,7 +1664,7 @@ static void yy_flex_strncpy(char* s1, yyconst char* s2, int n)
 #ifdef YY_NEED_STRLEN
 static int yy_flex_strlen(yyconst char* s)
 {
-    register int n;
+    int n;
     for (n = 0; s[n]; ++n)
         ;
 

--- a/src/sdl/getopt.c
+++ b/src/sdl/getopt.c
@@ -340,7 +340,7 @@ static void exchange(argv) char** argv;
         if (top - middle > middle - bottom) {
             /* Bottom segment is the short one.  */
             int len = middle - bottom;
-            register int i;
+            int i;
 
             /* Swap it with the top part of the top segment.  */
             for (i = 0; i < len; i++) {
@@ -354,7 +354,7 @@ static void exchange(argv) char** argv;
         } else {
             /* Top segment is the short one.  */
             int len = top - middle;
-            register int i;
+            int i;
 
             /* Swap it with the bottom part of the bottom segment.  */
             for (i = 0; i < len; i++) {

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -522,8 +522,8 @@ void load_opts()
                     // the equals sign if necessary instead of doing it this way
                     wxLogWarning(_("Invalid value %s for option %s; valid values are %s%s%s"),
                         s.c_str(), opt.opt.c_str(), ev.c_str(),
-                        isx ? wxT(" = ") : wxT(""),
-                        isx ? evx.c_str() : wxT(""));
+                        isx ? wxT(" = ") : wxEmptyString,
+                        isx ? evx.c_str() : wxEmptyString);
                     // write first option
                     cfg->Write(opt.opt, enum_opts[0]);
                 } else
@@ -815,8 +815,8 @@ bool opt_set(const wxString& name, const wxString& val)
                 // the equals sign if necessary instead of doing it this way
                 wxLogWarning(_("Invalid value %s for option %s; valid values are %s%s%s"),
                     s.c_str(), opt->opt.c_str(), opt->enumvals.c_str(),
-                    isx ? wxT(" = ") : wxT(""),
-                    isx ? evx.c_str() : wxT(""));
+                    isx ? wxT(" = ") : wxEmptyString,
+                    isx ? evx.c_str() : wxEmptyString);
             } else {
                 *opt->intopt = found_pos;
             }


### PR DESCRIPTION
@rkitover The work we needed to do after #396. I need some checks here.

Some of these files do not include any headers except local ones. That is the reason why I copy & paste the solution for many files. I know there were memory leaks issues, but they came after compilation warnings so I think we can put these two together here.