### PR TITLE
Fix incorrect starting video showing and geometry.

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1056,6 +1056,8 @@ void GameArea::OnIdle(wxIdleEvent& event)
 #endif
 
         Layout();
+        SendSizeEvent();
+
 
         if (pointer_blanked)
             w->SetCursor(wxCursor(wxCURSOR_BLANK));

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1046,9 +1046,9 @@ void GameArea::OnIdle(wxIdleEvent& event)
         // On windows with the vcpkg version of wxWidgets which is 3.1.2, the
         // wxEXPAND flag throws an XRC error, but it is necessary on earlier versions of wxWidgets
 #if defined(__WXMSW__) && wxCHECK_VERSION(3, 1, 2)
-        GetSizer()->Add(w,    frame_priority, gopts.retain_aspect ? (wxSHAPED | wxALIGN_CENTER_HORIZONTAL) : wxEXPAND);
+        GetSizer()->Add(w,    frame_priority, gopts.retain_aspect ? (wxSHAPED | wxALIGN_CENTER) : wxEXPAND);
 #else
-        GetSizer()->Add(w,    frame_priority, gopts.retain_aspect ? (wxSHAPED | wxALIGN_CENTER_HORIZONTAL | wxEXPAND) : wxEXPAND);
+        GetSizer()->Add(w,    frame_priority, gopts.retain_aspect ? (wxSHAPED | wxALIGN_CENTER | wxEXPAND) : wxEXPAND);
 #endif
 
 #if wxCHECK_VERSION(2, 9, 0)

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -763,22 +763,23 @@ void MainFrame::OnMenu(wxContextMenuEvent& event)
 void MainFrame::OnMove(wxMoveEvent& event)
 {
     (void)event; // unused params
-    wxRect pos = GetRect();
-    int x = pos.GetX(), y = pos.GetY();
+    wxPoint pos = GetScreenPosition();
+    int x = pos.x, y = pos.y;
     if (x >= 0 && y >= 0 && !IsFullScreen())
     {
 	windowPositionX = x;
 	windowPositionY = y;
-	update_opts();
     }
+    update_opts();
 }
 
 void MainFrame::OnSize(wxSizeEvent& event)
 {
     wxFrame::OnSize(event);
     wxRect pos = GetRect();
+    wxPoint windowPos = GetScreenPosition();
     int height = pos.GetHeight(), width = pos.GetWidth();
-    int x = pos.GetX(), y = pos.GetY();
+    int x = windowPos.x, y = windowPos.y;
     bool isFullscreen = IsFullScreen();
     if (height > 0 && width > 0 && !isFullscreen)
     {


### PR DESCRIPTION
@rkitover @retro-wertz This is a little trick because we need to decide a behaviour.

The reason such thing happened was  with option `Display/Stretch=1`. Changing on file `panel.cpp`:

```
GetSizer()->Add(w,    frame_priority, gopts.retain_aspect ? (wxSHAPED | wxALIGN_CENTER_HORIZONTAL | wxEXPAND) : wxEXPAND);

to

GetSizer()->Add(w,    frame_priority, gopts.retain_aspect ? (wxALIGN_CENTER_HORIZONTAL | wxEXPAND) : wxEXPAND);
```

The `wxSHAPED` is behind this. From the docs: `wxSHAPED flag tells the window to change it is size proportionally, preserving original aspect ratio`. When we had a default startup, the zoom level decided the window size (by setting the minimal one required for it). Then you could expand however you like it and it would work. When trying a custom size, the window would be a different size from the minimal one, and this is where this weird (for me) issue happen.

If you guys don't like this solution (I don't because it feels like a blob), I would suggest to drop this geometry support entirely. There is a better way, but just requires more time of research and docs hunting.