### PR TITLE
Fix #142 and #390.

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1183,6 +1183,9 @@ static bool process_key_press(bool down, int key, int mod, int joy = 0)
             mod |= wxMOD_RAW_CONTROL;
             break;
 #endif
+        default:
+            mod = 0;
+            break;
     }
 
     // check if key is already pressed


### PR DESCRIPTION
@rkitover I copied my commit message here. See if you can understand.

```
Fix continuous sprinting when using a modifier key as a mapping key (#142).

When holding a key(W,A,S,D) and then pressing a modifier(SHIFT,CTRL,ALT), we get two sets {MOD,MOD,0} and {KEY,MOD,0} with MOD > 0 after a {KEY,0,0}. When releasing the initial key while holding the modifier, we search for {KEY,MOD,0} instead of {KEY,0,0} to be removed.

Finally, when releasing the modifier, we remove {MOD,MOD,0} from our stack. This means the {KEY,0,0} stays "pressed", although no input is being taken from the keyboard.

Full example using WASD as movement keys and L_SHIFT as our B button.
1. Press and hold "A" --> add {A,0,0} to stack;
2. Press "L_SHIFT" --> add {L_SHIFT,4,0} and {A,4,0} to stack;
3. Release "A" --> remove {A,4,0} from stack (no effect);
4. Release "L_SHIFT" --> remove {L_SHIFT,4,0} from stack;
5. {A,0,0} still on stack.

No keyboard button is being pressed anymore, but there is a continuous movement towards the direction mapped by "A" {A,0,0}. It is only fixed when "A" is pressed two times in succession, because we don't add duplicate sets to our stack, but try to remove them anyway.
```

There is one big implication here that we should no longer support key combinations as input mappings. Not sure this is too much to give away (I don't use it, but there might be some use case that I am not aware about it -- using stuff as "SHIFT+W" to do something). I believe this should not be that big of deal because we would not need to check for conflict with stuff such as "SHIFT+F1".

Check if you like it.
