### PR TITLE
[WIP] Fix for unicode related issues.

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -569,7 +569,8 @@ IMAGE_TYPE utilFindType(const char *file, char (&buffer)[2048])
                 return IMAGE_UNKNOWN;
         }
         MultiByteToWideChar(CP_ACP, 0, file, -1, pwText, dwNum);
-        char *file_conv = fex_wide_to_path(pwText);
+        //char *file_conv = fex_wide_to_path(file);
+        char *file_conv = (char *)file;
         //	if ( !utilIsImage( file_conv ) ) // TODO: utilIsArchive() instead?
         //	{
         fex_t *fe = scan_arc(file_conv, utilIsImage, buffer);
@@ -578,7 +579,7 @@ IMAGE_TYPE utilFindType(const char *file, char (&buffer)[2048])
         fex_close(fe);
         file = buffer;
         //	}
-        free(file_conv);
+        //free(file_conv);
 #else
         //	if ( !utilIsImage( file ) ) // TODO: utilIsArchive() instead?
         //	{
@@ -612,12 +613,13 @@ uint8_t *utilLoad(const char *file, bool (*accept)(const char *), uint8_t *data,
                 return NULL;
         }
         MultiByteToWideChar(CP_ACP, 0, file, -1, pwText, dwNum);
-        char *file_conv = fex_wide_to_path(pwText);
+        //char *file_conv = fex_wide_to_path(file);
+        char *file_conv = (char *)file;
         delete[] pwText;
         fex_t *fe = scan_arc(file_conv, accept, buffer);
         if (!fe)
                 return NULL;
-        free(file_conv);
+        //free(file_conv);
 #else
         fex_t *fe = scan_arc(file, accept, buffer);
         if (!fe)

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -78,7 +78,10 @@ void GameArea::LoadGame(const wxString& name)
         }
     }
 
-    const char* fn = fnfn.GetFullPath().mb_str();
+    // auto-conversion of wxCharBuffer to const char * seems broken
+    // so save underlying wxCharBuffer (or create one of none is used)
+    wxCharBuffer fnb(fnfn.GetFullPath().mb_str(wxConvUTF8));
+    const char* fn = fnb.data();
     IMAGE_TYPE t = badfile ? IMAGE_UNKNOWN : utilFindType(fn);
 
     if (t == IMAGE_UNKNOWN) {

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -44,7 +44,7 @@
     #undef  wxLogDebug
     #define wxLogDebug(...)                                                                                                           \
     do {                                                                                                                              \
-        fputs(wxString::Format(wxDateTime::UNow().Format(wxT("%X")) + wxT(": Debug: ") + __VA_ARGS__).mb_str(), VBAM_DEBUG_STREAM); \
+        fputs(wxString::Format(wxDateTime::UNow().Format(wxT("%X")) + wxT(": Debug: ") + __VA_ARGS__).utf8_str(), VBAM_DEBUG_STREAM); \
         fputc('\n', VBAM_DEBUG_STREAM);                                                                                               \
     } while(0)
 #endif


### PR DESCRIPTION
@rkitover this is a quick fix, considering there still are some possible solutions available.

At first, when this issue first happened, I thought it very strange for something to break like this suddenly. Then I remembered that from `2.1.1.` to `2.1.2` there was that compilation warnings commit. I reviewed what I changed (already considering that as the cause), but failed to find the answer.

So I went to your `unicode-filenames` branch to test some stuff, but the compilation was failing with weird errors (that do not happen for current master). That's why I created this new branch and cherry-picked your commit from there. 

I will comment some of the code, but it should be fairly straightforward about why this works. It is probably not the best solution, though.

As far as testing goes, I tried opening all the files from the current zip on `Windows 10 x64`. They are all variations from a custom ROM with different names. I believe this is enough for the open issues.

[testing.zip](https://github.com/visualboyadvance-m/visualboyadvance-m/files/3309353/testing.zip)

 