### PR TITLE
[WIP] Fix "Joybus host invalid; disabling" warning.

### DIFF
--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -516,7 +516,7 @@ void LoadConfig()
 	languageOption = ReadPref("language", 1);
 	linkAuto = ReadPref("LinkAuto", 1);
 	linkHacks = ReadPref("LinkHacks", 0);
-	linkHostAddr = ReadPrefString("LinkHostAddr", "localhost");
+	linkHostAddr = ReadPrefString("LinkHost", "localhost");
 	linkMode = ReadPref("LinkMode", 0); // LINK_DISCONNECTED = 0
 	linkNumPlayers = ReadPref("LinkNumPlayers", 2);
 	linkTimeout = ReadPref("LinkTimeout", 1);

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -347,6 +347,8 @@ opts_t::opts_t()
     print_auto_page = true;
     autoPatch = true;
     onlineupdates = 1;
+    // quick fix for issues #48 and #445
+    link_host = "127.0.0.1";
 }
 
 // for binary_search() and friends


### PR DESCRIPTION
We have some possibilities here. This warning is issued because "GBA/LinkHost" is an empty string unless the user knows he needs to set a server ip address for whatever he wants to do.

The current code for this shows we use the `gopts.link_host` everywhere:
```
$ fgrep -RnwI . -e "link_host"
./src/wx/guiinit.cpp:93:            bool valid = SetLinkServerHost(gopts.link_host.utf8_str());
./src/wx/guiinit.cpp:119:            connmsg.Printf(_("Connecting to %s\n"), gopts.link_host.c_str());
./src/wx/guiinit.cpp:3094:            gettc("ServerIP", gopts.link_host);
./src/wx/guiinit.cpp:3836:        bool isv = !gopts.link_host.empty();
./src/wx/guiinit.cpp:3839:            isv = SetLinkServerHost(gopts.link_host.utf8_str());
./src/wx/opts.cpp:206:    STROPT("GBA/LinkHost", "", wxTRANSLATE("Default network link client host"), gopts.link_host),
./src/wx/opts.cpp:351:    link_host = "127.0.0.1";
./src/wx/opts.h:36:    wxString link_host;
./src/wx/panel.cpp:428:        BootLink(linkMode, gopts.link_host.mb_str(wxConvUTF8), linkTimeout, linkHacks, linkNumPlayers);
```

On the other hand, we also have this `linkHostAddr` global variable that it is not used anywhere:
```
$ fgrep -RnwI . -e "linkHostAddr"
./src/common/ConfigManager.cpp:144:const char* linkHostAddr;
./src/common/ConfigManager.cpp:519:	linkHostAddr = ReadPrefString("LinkHostAddr", "localhost");
./src/common/ConfigManager.cpp:1309:			linkHostAddr = optarg;
./src/common/ConfigManager.h:35:extern const char *linkHostAddr;
```

This `linkHostAddr` variable looks to be precisely the option to configure such stuff. Unless it is leftover from something from the past, since it was trying to get `LinkHostAddr` from `vbam.ini`.

I believe we could use `LinkHostAddr` to set this option, instead of `gopts.link_host`; or we can set `gopts.link_host` default like we do to other relevant variables, such as all the ones initialized in `gopts` struct constructor (the current solution).

What do you think, @ZachBacon, @rkitover? This is for #48 and #445.