### PR TITLE
Fix key shortcuts for save/load states.

### DIFF
--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2244,13 +2244,28 @@ void MainFrame::add_menu_accels(wxTreeCtrl* tc, wxTreeItemId& parent, wxMenu* me
             // but then if the user overides main menu, that req. is broken..
             wxString txt = (*mi)->GetItemLabelText();
 
-            // It is not necessary unless we want the full description.
-            //for (int i = 0; i < 10; i++)
-            //    if (*mi == loadst_mi[i] || *mi == savest_mi[i]) {
-            //        txt = cmdtab[i].name;
-            //        break;
-            //    }
-
+            // we could probably have a global hashmap:
+            // cmdtab[i].cmd -> cmdtab[i]
+            for (int i = 0; i < 10; i++) {
+                wxString slot;
+                if (*mi == loadst_mi[i]) {
+                    slot.Printf(wxT("LoadGame%02d"), wxAtoi(txt));
+                }
+                else if (*mi == savest_mi[i]) {
+                    slot.Printf(wxT("SaveGame%02d"), wxAtoi(txt));
+                }
+                else {
+                    continue;
+                }
+                for (int j = 0; j < ncmds; ++j) {
+                    if (cmdtab[j].cmd == slot) {
+                        txt = cmdtab[j].name;
+                        break;
+                    }
+                }
+                // no need to look further
+                break;
+            }
             tc->AppendItem(parent, txt, -1, -1, val);
         }
     }

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2244,11 +2244,12 @@ void MainFrame::add_menu_accels(wxTreeCtrl* tc, wxTreeItemId& parent, wxMenu* me
             // but then if the user overides main menu, that req. is broken..
             wxString txt = (*mi)->GetItemLabelText();
 
-            for (int i = 0; i < 10; i++)
-                if (*mi == loadst_mi[i] || *mi == savest_mi[i]) {
-                    txt = cmdtab[i].name;
-                    break;
-                }
+            // It is not necessary unless we want the full description.
+            //for (int i = 0; i < 10; i++)
+            //    if (*mi == loadst_mi[i] || *mi == savest_mi[i]) {
+            //        txt = cmdtab[i].name;
+            //        break;
+            //    }
 
             tc->AppendItem(parent, txt, -1, -1, val);
         }


### PR DESCRIPTION
@rkitover 

We show the wrong description for these shortcuts, although it works
correctly for the keybinding.

Original:
![original](https://user-images.githubusercontent.com/11354751/60058769-1a430d80-96c0-11e9-937f-cdc0a522a333.png)

New:
![new](https://user-images.githubusercontent.com/11354751/60058793-28912980-96c0-11e9-803c-0c8dac7f2472.png)

I will explain why this happens on the code. Fix for #411.
