### PR TITLE
Fix pause toggle keybinding when unmuting.

### DIFF
--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -1353,7 +1353,20 @@ EVT_HANDLER(wxID_EXIT, "Exit")
 // Emulation menu
 EVT_HANDLER(Pause, "Pause (toggle)")
 {
-    GetMenuOptionBool("Pause", paused);
+    bool menuPress;
+    GetMenuOptionBool("Pause", menuPress);
+
+    if (paused == menuPress)
+    {
+	// used accelerator
+	paused = !paused;
+	SetMenuOption("Pause", paused ? 1 : 0);
+    }
+    else
+    {
+	// used menu item
+	paused = menuPress;
+    }
 
     if (paused)
         panel->Pause();

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -818,7 +818,7 @@ void MainFrame::OnSize(wxSizeEvent& event)
 
 int MainFrame::FilterEvent(wxEvent& event)
 {
-    if (!IsPaused() && event.GetEventType() == wxEVT_KEY_DOWN)
+    if (event.GetEventType() == wxEVT_KEY_DOWN)
     {
         wxKeyEvent& ke = (wxKeyEvent&)event;
         int keyCode = ke.GetKeyCode();


### PR DESCRIPTION
We use the same event for both keybinding and `Emulation` > `Pause`
actions. The issue here is that the menu item is checkable, meaning
that you toggle its value and then run the handler.

The handler checks the value of the menu item `Emulation` > `Pause`,
and toggle the game pause accordingly. Such thing does not happen when
using the keybinding. Hence, it did not toggle the pause as expected.

- Related to #454.