### PR TITLE
Add hotkeys for changing sizes (1x ... 6x).

### DIFF
--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2102,6 +2102,42 @@ EVT_HANDLER(GameBoyConfigure, "Game Boy options...")
     update_opts();
 }
 
+EVT_HANDLER(SetSize1x, "1x")
+{
+    gopts.video_scale = 1;
+    panel->AdjustSize(true);
+}
+
+EVT_HANDLER(SetSize2x, "2x")
+{
+    gopts.video_scale = 2;
+    panel->AdjustSize(true);
+}
+
+EVT_HANDLER(SetSize3x, "3x")
+{
+    gopts.video_scale = 3;
+    panel->AdjustSize(true);
+}
+
+EVT_HANDLER(SetSize4x, "4x")
+{
+    gopts.video_scale = 4;
+    panel->AdjustSize(true);
+}
+
+EVT_HANDLER(SetSize5x, "5x")
+{
+    gopts.video_scale = 5;
+    panel->AdjustSize(true);
+}
+
+EVT_HANDLER(SetSize6x, "6x")
+{
+    gopts.video_scale = 6;
+    panel->AdjustSize(true);
+}
+
 EVT_HANDLER(GameBoyAdvanceConfigure, "Game Boy Advance options...")
 {
     wxDialog* dlg = GetXRCDialog("GameBoyAdvanceConfig");

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -74,6 +74,13 @@ const wxAcceleratorEntry default_accels[] = {
     wxAcceleratorEntry(wxMOD_NONE, WXK_PAUSE, XRCID("Pause")),
     wxAcceleratorEntry(wxMOD_CMD, wxT('P'), XRCID("Pause")),
     wxAcceleratorEntry(wxMOD_CMD, wxT('R'), XRCID("Reset")),
+    // add shortcuts for original size multiplier #415
+    wxAcceleratorEntry(wxMOD_NONE, wxT('1'), XRCID("SetSize1x")),
+    wxAcceleratorEntry(wxMOD_NONE, wxT('2'), XRCID("SetSize2x")),
+    wxAcceleratorEntry(wxMOD_NONE, wxT('3'), XRCID("SetSize3x")),
+    wxAcceleratorEntry(wxMOD_NONE, wxT('4'), XRCID("SetSize4x")),
+    wxAcceleratorEntry(wxMOD_NONE, wxT('5'), XRCID("SetSize5x")),
+    wxAcceleratorEntry(wxMOD_NONE, wxT('6'), XRCID("SetSize6x")),
     // save oldest is more commonly used than save other
     //wxAcceleratorEntry(wxMOD_CMD, wxT('S'), XRCID("Save")),
     wxAcceleratorEntry(wxMOD_CMD, wxT('S'), XRCID("SaveGameOldest")),

--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -295,6 +295,27 @@
           <label>_Start in full screen</label>
           <checkable>1</checkable>
         </object>
+        <object class="wxMenu">
+          <label>_Quick resize</label>
+          <object class="wxMenuItem" name="SetSize1x">
+            <label>_1x</label>
+          </object>
+          <object class="wxMenuItem" name="SetSize2x">
+            <label>_2x</label>
+          </object>
+          <object class="wxMenuItem" name="SetSize3x">
+            <label>_3x</label>
+          </object>
+          <object class="wxMenuItem" name="SetSize4x">
+            <label>_4x</label>
+          </object>
+          <object class="wxMenuItem" name="SetSize5x">
+            <label>_5x</label>
+          </object>
+          <object class="wxMenuItem" name="SetSize6x">
+            <label>_6x</label>
+          </object>
+        </object>
         <object class="wxMenuItem" name="RetainAspect">
           <label>_Retain aspect ratio</label>
           <checkable>1</checkable>


### PR DESCRIPTION
Use a accelerator to quickly provide a way to change to/from multipliers
of the original size.

- Fix #415.

The only thing I would like to add here is some stuff is being done the way it is so we can also allow the users to change these keybindings via `Options` > `Key Shortcuts`. This explains whey this appears on the main menu.