### PR TITLE
Translation issues.

### DIFF
--- a/src/wx/widgets/joyedit.cpp
+++ b/src/wx/widgets/joyedit.cpp
@@ -101,52 +101,52 @@ wxString wxJoyKeyTextCtrl::ToString(int mod, int key, int joy)
     wxString s;
     // Note: wx translates unconditionally (2.8.12, 2.9.1)!
     // So any strings added below must also be translated unconditionally
-    s.Printf(_("Joy%d-"), joy);
+    s.Printf(("Joy%d-"), joy);
     wxString mk;
 
     switch (mod) {
     case WXJB_AXIS_PLUS:
-        mk.Printf(_("Axis%d+"), key);
+        mk.Printf(("Axis%d+"), key);
         break;
 
     case WXJB_AXIS_MINUS:
-        mk.Printf(_("Axis%d-"), key);
+        mk.Printf(("Axis%d-"), key);
         break;
 
     case WXJB_BUTTON:
-        mk.Printf(_("Button%d"), key);
+        mk.Printf(("Button%d"), key);
         break;
 
     case WXJB_HAT_N:
-        mk.Printf(_("Hat%dN"), key);
+        mk.Printf(("Hat%dN"), key);
         break;
 
     case WXJB_HAT_S:
-        mk.Printf(_("Hat%dS"), key);
+        mk.Printf(("Hat%dS"), key);
         break;
 
     case WXJB_HAT_W:
-        mk.Printf(_("Hat%dW"), key);
+        mk.Printf(("Hat%dW"), key);
         break;
 
     case WXJB_HAT_E:
-        mk.Printf(_("Hat%dE"), key);
+        mk.Printf(("Hat%dE"), key);
         break;
 
     case WXJB_HAT_NW:
-        mk.Printf(_("Hat%dNW"), key);
+        mk.Printf(("Hat%dNW"), key);
         break;
 
     case WXJB_HAT_NE:
-        mk.Printf(_("Hat%dNE"), key);
+        mk.Printf(("Hat%dNE"), key);
         break;
 
     case WXJB_HAT_SW:
-        mk.Printf(_("Hat%dSW"), key);
+        mk.Printf(("Hat%dSW"), key);
         break;
 
     case WXJB_HAT_SE:
-        mk.Printf(_("Hat%dSE"), key);
+        mk.Printf(("Hat%dSE"), key);
         break;
     }
 
@@ -205,14 +205,14 @@ static int simple_atoi(const wxString& s, int len)
 static void CompileRegex()
 {
     // \1 is joy #
-    joyre.Compile(_("^Joy([0-9]+)[-+]"), wxRE_EXTENDED | wxRE_ICASE);
+    joyre.Compile(("^Joy([0-9]+)[-+]"), wxRE_EXTENDED | wxRE_ICASE);
     // \1 is axis# and \2 is + or -
-    axre.Compile(_("Axis([0-9]+)([+-])"), wxRE_EXTENDED | wxRE_ICASE);
+    axre.Compile(("Axis([0-9]+)([+-])"), wxRE_EXTENDED | wxRE_ICASE);
     // \1 is button#
-    butre.Compile(_("Button([0-9]+)"), wxRE_EXTENDED | wxRE_ICASE);
+    butre.Compile(("Button([0-9]+)"), wxRE_EXTENDED | wxRE_ICASE);
     // \1 is hat#, \3 is N, \4 is S, \5 is E, \6 is W, \7 is NE,
     // \8 is SE, \9 is SW, \10 is NW
-    hatre.Compile(_("Hat([0-9]+)((N|North|U|Up)|(S|South|D|Down)|"
+    hatre.Compile(("Hat([0-9]+)((N|North|U|Up)|(S|South|D|Down)|"
                     "(E|East|R|Right)|(W|West|L|Left)|"
                     "(NE|NorthEast|UR|UpRight)|(SE|SouthEast|DR|DownRight)|"
                     "(SW|SouthWest|DL|DownLeft)|(NW|NorthWest|UL|UpLeft))"),

--- a/src/wx/widgets/joyedit.cpp
+++ b/src/wx/widgets/joyedit.cpp
@@ -179,18 +179,14 @@ wxString wxJoyKeyTextCtrl::ToString(wxJoyKeyBinding_v keys, wxChar sep)
 // Note: wx translates unconditionally (2.8.12, 2.9.1)!
 // So any strings added below must also be translated unconditionally
 // \1 is joy #
-static wxRegEx joyre(_("^Joy([0-9]+)[-+]"), wxRE_EXTENDED | wxRE_ICASE);
+static wxRegEx joyre;
 // \1 is axis# and \2 is + or -
-static wxRegEx axre(_("Axis([0-9]+)([+-])"), wxRE_EXTENDED | wxRE_ICASE);
+static wxRegEx axre;
 // \1 is button#
-static wxRegEx butre(_("Button([0-9]+)"), wxRE_EXTENDED | wxRE_ICASE);
+static wxRegEx butre;
 // \1 is hat#, \3 is N, \4 is S, \5 is E, \6 is W, \7 is NE, \8 is SE,
 // \9 is SW, \10 is NW
-static wxRegEx hatre(_("Hat([0-9]+)((N|North|U|Up)|(S|South|D|Down)|"
-                       "(E|East|R|Right)|(W|West|L|Left)|"
-                       "(NE|NorthEast|UR|UpRight)|(SE|SouthEast|DR|DownRight)|"
-                       "(SW|SouthWest|DL|DownLeft)|(NW|NorthWest|UL|UpLeft))"),
-    wxRE_EXTENDED | wxRE_ICASE);
+static wxRegEx hatre;
 // use of static wxRegeEx is not thread-safe
 static wxCriticalSection recs;
 
@@ -206,6 +202,23 @@ static int simple_atoi(const wxString& s, int len)
     return ret;
 }
 
+static void CompileRegex()
+{
+    // \1 is joy #
+    joyre.Compile(_("^Joy([0-9]+)[-+]"), wxRE_EXTENDED | wxRE_ICASE);
+    // \1 is axis# and \2 is + or -
+    axre.Compile(_("Axis([0-9]+)([+-])"), wxRE_EXTENDED | wxRE_ICASE);
+    // \1 is button#
+    butre.Compile(_("Button([0-9]+)"), wxRE_EXTENDED | wxRE_ICASE);
+    // \1 is hat#, \3 is N, \4 is S, \5 is E, \6 is W, \7 is NE,
+    // \8 is SE, \9 is SW, \10 is NW
+    hatre.Compile(_("Hat([0-9]+)((N|North|U|Up)|(S|South|D|Down)|"
+                    "(E|East|R|Right)|(W|West|L|Left)|"
+                    "(NE|NorthEast|UR|UpRight)|(SE|SouthEast|DR|DownRight)|"
+                    "(SW|SouthWest|DL|DownLeft)|(NW|NorthWest|UL|UpLeft))"),
+                  wxRE_EXTENDED | wxRE_ICASE);
+}
+
 static bool ParseJoy(const wxString& s, int len, int& mod, int& key, int& joy)
 {
     mod = key = joy = 0;
@@ -216,6 +229,7 @@ static bool ParseJoy(const wxString& s, int len, int& mod, int& key, int& joy)
     wxCriticalSectionLocker lk(recs);
     size_t b, l;
 
+    CompileRegex();
     if (!joyre.Matches(s) || !joyre.GetMatch(&b, &l) || b)
         return false;
 


### PR DESCRIPTION
@rkitover  I had to fix some spelling for the french translation and create a function to initialize the regex properly. If we try like was before, the regex compiles the english words (don't use gettext to translate it). This is why the configuration was not set.

I have to update the transifex too, but first want your feedback regarding this. I suggest we drop all translation for buttons/axes/joy and use the english text only. The labels will remain translated, but these may cause a minor inconvenience when switching languages, as the app will complain about weird strings (set as french, then use en_US ==> warning about wrong configuration).

Fix #441, #437 and #273. I tested for french, german and portuguese. Everything worked as expected.

After your feedback I will update transifex accordingly. Then we can merge this.