### PR TITLE
Fix pause behaviour with `Pause when inactive`.

### DIFF
--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -732,7 +732,7 @@ void MainFrame::OnActivate(wxActivateEvent& event)
         panel->SetFocus();
 
     if (pauseWhenInactive) {
-        if (panel && focused) {
+        if (panel && focused && !paused) {
             panel->Resume();
         }
         else if (panel && !focused) {


### PR DESCRIPTION
If the user pauses with the keybinding or the menu `Emulation` > `Pause`
while `Pause when inactive` is enabled, the game should not unpause when
the window receives focus again. It should wait for the user to trigger
the manual unpause.

- Fix #460.