### PR TITLE
Fix some memory leak.

### DIFF
--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -663,12 +663,12 @@ const char* FindConfigFile(const char *name)
 
 	struct stat s;
 	std::string homeDirTmp = get_xdg_user_config_home() + DOT_DIR;
-	homeDir = strdup(homeDirTmp.c_str());
-	if (stat(homeDir, &s) == -1 || !S_ISDIR(s.st_mode))
-		mkdir(homeDir, 0755);
+	char *fullDir = (char *)homeDirTmp.c_str();
+	if (stat(fullDir, &s) == -1 || !S_ISDIR(s.st_mode))
+		mkdir(fullDir, 0755);
 
-	if (homeDir) {
-		sprintf(path, "%s%c%s", homeDir, FILE_SEP, name);
+	if (fullDir) {
+		sprintf(path, "%s%c%s", fullDir, FILE_SEP, name);
 		if (FileExists(path))
 		{
 			return path;

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -369,7 +369,7 @@ FILE* sdlFindFile(const char* name)
         return f;
     }
 
-    if (homeDir) {
+    if (homeDataDir) {
         fprintf(stdout, "Searching home directory: %s\n", homeDataDir);
         sprintf(path, "%s%c%s", homeDataDir, FILE_SEP, name);
         f = fopen(path, "r");


### PR DESCRIPTION
@rkitover This is a followup work for 684b1bb7aaa220b8f00b46612846fb04c0f5fe89. I checked on the code if that variable `homeDir` was being used elsewhere, and turns out it was unnecessary.

We also did not free that `strdup`. So there was a small memory leak. This should allow us to not worry about this anymore.