### PR TITLE
Fix wxWidgets assertion error on `Logging...` menu.

### DIFF
--- a/src/wx/sys.cpp
+++ b/src/wx/sys.cpp
@@ -1294,8 +1294,10 @@ bool debugWaitSocket()
 void log(const char* defaultMsg, ...)
 {
     va_list valist;
+    char buf[2048];
     va_start(valist, defaultMsg);
-    wxString msg = wxString::Format(defaultMsg, valist);
+    vsnprintf(buf, 2048, defaultMsg, valist);
+    wxString msg = wxString(buf, wxConvLibc);
     va_end(valist);
     wxGetApp().log.append(msg);
 


### PR DESCRIPTION
@rkitover This is a regression needed for #476 (it will not close it, but partially fix it).

I also did the test of `log("%02x %04x %08x\n", 0xff, 0xffff, 0xffffffff);` on a random scope to check its return and it seems to be working.

The memory leak is a bit more complicated... There are some things mixed there and It is probably needed to do something more towards refactoring. It will be on the list of memory issues, nevertheless.