### PR TITLE
[WIP] Fix video/audio recording.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,7 @@ set(
 if(ENABLE_FFMPEG)
     find_package(PkgConfig REQUIRED)
 
-    pkg_check_modules(FFMPEG REQUIRED libavcodec libavformat libswscale libavutil)
+    pkg_check_modules(FFMPEG REQUIRED libavcodec libavformat libswscale libavutil libswresample)
 
     if(FFMPEG_STATIC)
         set(FFMPEG_LIBRARIES ${FFMPEG_STATIC_LIBRARIES})
@@ -625,7 +625,7 @@ set(
 )
 
 if(MSVC)
-	set(SRC_MAIN ${SRC_MAIN} "dependencies/msvc/getopt.c")
+        set(SRC_MAIN ${SRC_MAIN} "dependencies/msvc/getopt.c")
 endif()
 
 set(
@@ -643,7 +643,7 @@ set(
 )
 
 if(MSVC)
-	set(HDR_MAIN ${HDR_MAIN} "dependencies/msvc/getopt.h")
+        set(HDR_MAIN ${HDR_MAIN} "dependencies/msvc/getopt.h")
 endif()
 
 if(ENABLE_FFMPEG)

--- a/src/common/ffmpeg.cpp
+++ b/src/common/ffmpeg.cpp
@@ -106,15 +106,21 @@ recording::MediaRet recording::MediaRecorder::setup_audio_stream()
     aenc->sample_fmt = acodec->sample_fmts ? acodec->sample_fmts[0] : AV_SAMPLE_FMT_FLTP;
     aenc->bit_rate = 128000; // mp3
     aenc->sample_rate = sampleRate;
+    // this might be useful to check if the codec suports the
+    // sample rate, but it is not strictly needed for now
+    bool isSupported = false;
     if (acodec->supported_samplerates)
     {
-        aenc->sample_rate = acodec->supported_samplerates[0];
         for (int i = 0; acodec->supported_samplerates[i]; ++i)
         {
-            if (acodec->supported_samplerates[i] == 44100)
-                aenc->sample_rate = 44100;
+            if (acodec->supported_samplerates[i] == sampleRate)
+            {
+                isSupported = true;
+                break;
+            }
         }
     }
+    if (!isSupported) return MRET_ERR_NOCODEC;
     aenc->channels = av_get_channel_layout_nb_channels(aenc->channel_layout);
     aenc->channel_layout = AV_CH_LAYOUT_STEREO;
     if (acodec->channel_layouts)

--- a/src/common/ffmpeg.cpp
+++ b/src/common/ffmpeg.cpp
@@ -450,6 +450,7 @@ void recording::MediaRecorder::Stop()
     npts = 0;
     if (oc)
     {
+        flush_frames();
         // close the output file
         if (!(fmt->flags & AVFMT_NOFILE))
         {
@@ -622,4 +623,17 @@ recording::MediaRet recording::MediaRecorder::AddFrame(const uint16_t *aud, int 
         samplesInAudioBuffer = (cp / 2);
     }
     return MRET_OK;
+}
+
+// flush last frames to avoid
+// "X frames left in the queue on closing"
+void recording::MediaRecorder::flush_frames()
+{
+    AVPacket pkt;
+    av_init_packet(&pkt);
+    pkt.data = NULL;
+    pkt.size = 0;
+    // flush last audio frames
+    while (avcodec_receive_packet(aenc, &pkt) >= 0)
+        avcodec_send_frame(aenc, NULL);
 }

--- a/src/common/ffmpeg.cpp
+++ b/src/common/ffmpeg.cpp
@@ -11,12 +11,14 @@ struct supportedCodecs {
 };
 
 const supportedCodecs audioSupported[] = {
-    { AV_CODEC_ID_MP3, "MP3 (MPEG audio layer 3)", "mp3" }
+    { AV_CODEC_ID_MP3, "MP3 (MPEG audio layer 3)", "mp3" },
+    { AV_CODEC_ID_AAC, "ADTS AAC (Advanced Audio Coding)", "aac,adts" }
 };
 
 const supportedCodecs videoSupported[] = {
     { AV_CODEC_ID_MPEG4, "AVI (Audio Video Interleaved)", "avi" },
-    { AV_CODEC_ID_MPEG4, "raw MPEG-4 video", "m4v" }
+    { AV_CODEC_ID_MPEG4, "raw MPEG-4 video", "m4v" },
+    { AV_CODEC_ID_FLV1, "FLV (Flash Video)", "flv" }
 };
 
 std::vector<char *> recording::getSupVidNames()

--- a/src/common/ffmpeg.h
+++ b/src/common/ffmpeg.h
@@ -111,6 +111,9 @@ class MediaRecorder
         MediaRet setup_video_stream(int width, int height);
         MediaRet setup_audio_stream();
         MediaRet finish_setup(const char *fname);
+        // flush last frames to avoid
+        // "X frames left in the queue on closing"
+        void flush_frames();
 };
 
 }

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -5150,8 +5150,8 @@ void gbEmulate(int ticksToStop)
                         gbDrawLine();
                     } else if ((register_LY == 144) && (!systemFrameSkip)) {
                         int framesToSkip = systemFrameSkip;
-                        if (speedup)
-                            framesToSkip = 9; // try 6 FPS during speedup
+                        //if (speedup)
+                        //    framesToSkip = 9; // try 6 FPS during speedup
                         if ((gbFrameSkipCount >= framesToSkip) || (gbWhiteScreen == 1)) {
                             gbWhiteScreen = 2;
 

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -1,8 +1,3 @@
-#ifndef NO_FFMPEG
-#define __STDC_LIMIT_MACROS // required for ffmpeg
-#define __STDC_CONSTANT_MACROS // required for ffmpeg
-#endif
-
 #include "wxvbam.h"
 #include <algorithm>
 #include <wx/aboutdlg.h>
@@ -15,16 +10,6 @@
 #include <wx/wfstream.h>
 #include <wx/msgdlg.h>
 
-#ifndef NO_FFMPEG
-extern "C" {
-#include <libavformat/avformat.h>
-}
-// For compatibility with 3.0+ ffmpeg
-#include <libavcodec/version.h>
-#if LIBAVCODEC_VERSION_MAJOR >= 56
-#define CODEC_ID_NONE AV_CODEC_ID_NONE
-#endif
-#endif
 #include "version.h"
 #include "../common/ConfigManager.h"
 #include "../gb/gbPrinter.h"
@@ -828,7 +813,7 @@ EVT_HANDLER_MASK(RomInformation, "ROM information...", CMDEN_GB | CMDEN_GBA)
     } break;
 
     default:
-	break;
+        break;
     }
 }
 
@@ -1179,23 +1164,20 @@ EVT_HANDLER_MASK(RecordSoundStartRecording, "Start sound recording...", CMDEN_NS
 
     if (!sound_exts.size()) {
         sound_extno = -1;
-        int extno;
-        AVOutputFormat* fmt;
+        int extno = 0;
 
-        for (fmt = NULL, extno = 0; (fmt = av_oformat_next(fmt));) {
-            if (!fmt->extensions)
-                continue;
+        std::vector<char *> fmts = recording::getSupAudNames();
+        std::vector<char *> exts = recording::getSupAudExts();
 
-            if (fmt->audio_codec == CODEC_ID_NONE)
-                continue;
-
-            sound_exts.append(wxString(fmt->long_name ? fmt->long_name : fmt->name, wxConvLibc));
+        for (size_t i = 0; i < fmts.size(); ++i)
+        {
+            sound_exts.append(wxString(fmts[i], wxConvLibc));
             sound_exts.append(_(" files ("));
-            wxString ext(fmt->extensions, wxConvLibc);
+            wxString ext(exts[i], wxConvLibc);
             ext.Replace(wxT(","), wxT(";*."));
             ext.insert(0, wxT("*."));
 
-            if (sound_extno < 0 && ext.find(wxT("*.wav")) != wxString::npos)
+            if (sound_extno < 0 && ext.find(wxT("*.mp3")) != wxString::npos)
                 sound_extno = extno;
 
             sound_exts.append(ext);
@@ -1252,19 +1234,16 @@ EVT_HANDLER_MASK(RecordAVIStartRecording, "Start video recording...", CMDEN_NVRE
 
     if (!vid_exts.size()) {
         vid_extno = -1;
-        int extno;
-        AVOutputFormat* fmt;
+        int extno = 0;
 
-        for (fmt = NULL, extno = 0; (fmt = av_oformat_next(fmt));) {
-            if (!fmt->extensions)
-                continue;
+        std::vector<char *> fmts = recording::getSupVidNames();
+        std::vector<char *> exts = recording::getSupVidExts();
 
-            if (fmt->video_codec == CODEC_ID_NONE)
-                continue;
-
-            vid_exts.append(wxString(fmt->long_name ? fmt->long_name : fmt->name, wxConvLibc));
+        for (size_t i = 0; i < fmts.size(); ++i)
+        {
+            vid_exts.append(wxString(fmts[i], wxConvLibc));
             vid_exts.append(_(" files ("));
-            wxString ext(fmt->extensions, wxConvLibc);
+            wxString ext(exts[i], wxConvLibc);
             ext.Replace(wxT(","), wxT(";*."));
             ext.insert(0, wxT("*."));
 

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2340,6 +2340,7 @@ void GameArea::StartVidRecording(const wxString& fname)
 {
     recording::MediaRet ret;
 
+    vid_rec.SetSampleRate(soundGetSampleRate());
     if ((ret = vid_rec.Record(fname.mb_str(), basic_width, basic_height,
              systemColorDepth))
         != recording::MRET_OK)
@@ -2370,6 +2371,7 @@ void GameArea::StartSoundRecording(const wxString& fname)
 {
     recording::MediaRet ret;
 
+    snd_rec.SetSampleRate(soundGetSampleRate());
     if ((ret = snd_rec.Record(fname.mb_str())) != recording::MRET_OK)
         wxLogError(_("Unable to begin recording to %s (%s)"), fname.mb_str(),
             media_err(ret));

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1016,8 +1016,8 @@ void GameArea::OnIdle(wxIdleEvent& event)
         // the userdata is freed on disconnect/destruction
         this->Connect(wxEVT_SIZE,          wxSizeEventHandler(GameArea::OnSize),           NULL, this);
 
-	// we need to check if the buttons stayed pressed when focus the panel
-	w->Connect(wxEVT_KILL_FOCUS,       wxFocusEventHandler(GameArea::OnKillFocus),     NULL, this);
+        // we need to check if the buttons stayed pressed when focus the panel
+        w->Connect(wxEVT_KILL_FOCUS,       wxFocusEventHandler(GameArea::OnKillFocus),     NULL, this);
 
         w->SetBackgroundStyle(wxBG_STYLE_CUSTOM);
         w->SetSize(wxSize(basic_width, basic_height));
@@ -1143,7 +1143,7 @@ static void clear_input_press()
     int i;
     for (i = 0; i < 4; ++i)
     {
-	joypress[i] = 0;
+        joypress[i] = 0;
     }
     keys_pressed.clear();
 }
@@ -2179,15 +2179,15 @@ void GLDrawingPanel::DrawingPanelInit()
 #define tex_fmt out_16 ? GL_BGRA : GL_RGBA, \
                 out_16 ? GL_UNSIGNED_SHORT_1_5_5_5_REV : GL_UNSIGNED_BYTE
 #if 0
-	texsize = width > height ? width : height;
-	texsize = std::ceil(texsize * scale);
-	// texsize = 1 << ffs(texsize);
-	texsize = texsize | (texsize >> 1);
-	texsize = texsize | (texsize >> 2);
-	texsize = texsize | (texsize >> 4);
-	texsize = texsize | (texsize >> 8);
-	texsize = (texsize >> 1) + 1;
-	glTexImage2D(GL_TEXTURE_2D, 0, int_fmt, texsize, texsize, 0, tex_fmt, NULL);
+        texsize = width > height ? width : height;
+        texsize = std::ceil(texsize * scale);
+        // texsize = 1 << ffs(texsize);
+        texsize = texsize | (texsize >> 1);
+        texsize = texsize | (texsize >> 2);
+        texsize = texsize | (texsize >> 4);
+        texsize = texsize | (texsize >> 8);
+        texsize = (texsize >> 1) + 1;
+        glTexImage2D(GL_TEXTURE_2D, 0, int_fmt, texsize, texsize, 0, tex_fmt, NULL);
 #else
     // but really, most cards support non-p2 and rect
     // if not, use cairo or wx renderer
@@ -2311,22 +2311,22 @@ void DXDrawingPanel::DrawArea(wxWindowDC& dc)
 #endif
 
 #ifndef NO_FFMPEG
-static const wxString media_err(MediaRet ret)
+static const wxString media_err(recording::MediaRet ret)
 {
     switch (ret) {
-    case MRET_OK:
+    case recording::MRET_OK:
         return wxT("");
 
-    case MRET_ERR_NOMEM:
+    case recording::MRET_ERR_NOMEM:
         return _("memory allocation error");
 
-    case MRET_ERR_NOCODEC:
+    case recording::MRET_ERR_NOCODEC:
         return _("error initializing codec");
 
-    case MRET_ERR_FERR:
+    case recording::MRET_ERR_FERR:
         return _("error writing to output file");
 
-    case MRET_ERR_FMTGUESS:
+    case recording::MRET_ERR_FMTGUESS:
         return _("can't guess output format from file name");
 
     default:
@@ -2338,11 +2338,11 @@ static const wxString media_err(MediaRet ret)
 
 void GameArea::StartVidRecording(const wxString& fname)
 {
-    MediaRet ret;
+    recording::MediaRet ret;
 
     if ((ret = vid_rec.Record(fname.mb_str(), basic_width, basic_height,
              systemColorDepth))
-        != MRET_OK)
+        != recording::MRET_OK)
         wxLogError(_("Unable to begin recording to %s (%s)"), fname.mb_str(),
             media_err(ret));
     else {
@@ -2368,9 +2368,9 @@ void GameArea::StopVidRecording()
 
 void GameArea::StartSoundRecording(const wxString& fname)
 {
-    MediaRet ret;
+    recording::MediaRet ret;
 
-    if ((ret = snd_rec.Record(fname.mb_str())) != MRET_OK)
+    if ((ret = snd_rec.Record(fname.mb_str())) != recording::MRET_OK)
         wxLogError(_("Unable to begin recording to %s (%s)"), fname.mb_str(),
             media_err(ret));
     else {
@@ -2396,15 +2396,15 @@ void GameArea::StopSoundRecording()
 
 void GameArea::AddFrame(const uint16_t* data, int length)
 {
-    MediaRet ret;
+    recording::MediaRet ret;
 
-    if ((ret = vid_rec.AddFrame(data)) != MRET_OK) {
+    if ((ret = vid_rec.AddFrame(data, length)) != recording::MRET_OK) {
         wxLogError(_("Error in audio/video recording (%s); aborting"),
             media_err(ret));
         vid_rec.Stop();
     }
 
-    if ((ret = snd_rec.AddFrame(data)) != MRET_OK) {
+    if ((ret = snd_rec.AddFrame(data, length)) != recording::MRET_OK) {
         wxLogError(_("Error in audio recording (%s); aborting"), media_err(ret));
         snd_rec.Stop();
     }
@@ -2412,9 +2412,9 @@ void GameArea::AddFrame(const uint16_t* data, int length)
 
 void GameArea::AddFrame(const uint8_t* data)
 {
-    MediaRet ret;
+    recording::MediaRet ret;
 
-    if ((ret = vid_rec.AddFrame(data)) != MRET_OK) {
+    if ((ret = vid_rec.AddFrame(data)) != recording::MRET_OK) {
         wxLogError(_("Error in video recording (%s); aborting"), media_err(ret));
         vid_rec.Stop();
     }

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2336,10 +2336,15 @@ static const wxString media_err(recording::MediaRet ret)
     }
 }
 
+int save_speedup_frame_skip;
+
 void GameArea::StartVidRecording(const wxString& fname)
 {
     recording::MediaRet ret;
 
+    // do not skip frames when recording
+    save_speedup_frame_skip = speedup_frame_skip;
+    speedup_frame_skip = 0;
     vid_rec.SetSampleRate(soundGetSampleRate());
     if ((ret = vid_rec.Record(fname.mb_str(), basic_width, basic_height,
              systemColorDepth))
@@ -2357,6 +2362,8 @@ void GameArea::StartVidRecording(const wxString& fname)
 void GameArea::StopVidRecording()
 {
     vid_rec.Stop();
+    // allow to skip frames again
+    speedup_frame_skip = save_speedup_frame_skip;
     MainFrame* mf = wxGetApp().frame;
     mf->cmd_enable &= ~CMDEN_VREC;
     mf->cmd_enable |= CMDEN_NVREC;

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -114,7 +114,7 @@ public:
 
     wxAcceleratorEntry_v GetAccels()
     {
-	return accels;
+        return accels;
     }
 
     // the main configuration
@@ -632,7 +632,7 @@ protected:
     void OnKillFocus(wxFocusEvent& ev);
 
 #ifndef NO_FFMPEG
-    MediaRecorder snd_rec, vid_rec;
+    recording::MediaRecorder snd_rec, vid_rec;
 #endif
 
 public:


### PR DESCRIPTION
@rkitover @ZachBacon 

```
We create a namespace to deal with most of our recording solution.

Besides that, we also add some functions to remove the need of
including libavutil headers on other part of the code. This is meant to
isolate most of recording solution components on the proper files.

We will start with a limited number of codecs supported; slowly we
should add them as they are tested (the previous one did not work for
most codecs listed).

This should support `ffmpeg 4.1` and further, including removing
all compilation warnings related to versions discrepancy.
```

This is my promised solution for #124, and it includes a heavy refactoring from the former one. I tried to put as much work as possible on this (not because it is hard, but I needed a continuous amount of time to do it; which I did not have thanks to my work schedule from the recent past). I did some basic testing with my games and it worked; more testing is always good, though.

Feel free to comment and ask for any type of adjustment relevant here. I believe I learned a lot about `FFmpeg`, so I should be able to answer some questions.

Also, I have a followup commit about adding new formats for the output (both audio/video), but I need you guys approve the structure overall before doing so. It might take some time to review this, but it will be worth it!