### PR TITLE
Set default keybinding when key does not exist.

### DIFF
--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -179,8 +179,8 @@ opt_desc new_opt_desc(wxString opt, const char* cmd, wxString desc,
                       int curint, double curdouble, uint32_t curuint)
 {
     struct opt_desc new_opt = {opt, cmd, desc, stropt, intopt, enumvals,
-	                       min, max, boolopt, doubleopt, uintopt,
-			       curstr, curint, curdouble, curuint};
+                               min, max, boolopt, doubleopt, uintopt,
+                               curstr, curint, curdouble, curuint};
     return new_opt;
 }
 
@@ -634,6 +634,7 @@ void load_opts()
     }
 
     // joypad is special
+    set_default_keys();
     for (int i = 0; i < 4; i++) {
         for (int j = 0; j < NUM_KEYS; j++) {
             wxString optname;


### PR DESCRIPTION
@rkitover This should solve #463. If the key does not exist on `vbam.ini`, we set our default keybinding for that key. If the key is empty (for whatever reason), we keep the way it is: empty. It deals with case 2 from the issue.

I wanted to check if we could handle the case where a default key is set to something else and the key does not exist, but I think this is not necessary. This is a very weird use case, and I believe users would set the key to empty instead of removing it from the configuration file.