### PR TITLE
Fix behaviour of `Tools` > `Memory Viewer`.

### DIFF
--- a/src/wx/viewsupt.cpp
+++ b/src/wx/viewsupt.cpp
@@ -136,7 +136,7 @@ void DisList::MoveSB()
         pos = (topaddr - 100) / 10 + 100;
     else if (topaddr >= maxaddr - 1100)
         pos = (topaddr - maxaddr + 1100) / 10 + 300;
-    else
+    else // FIXME this pos is very likely wrong... but I cannot trigger it
         pos = 250;
 
     sb.SetScrollbar(pos, 20, 500, 20);
@@ -553,16 +553,16 @@ void MemView::MoveSB()
 {
     int pos;
 
-    if (topaddr / 16 <= 100)
+    if (topaddr / 16 <= 100) // <= 100
         pos = topaddr / 16;
-    else if (topaddr / 16 >= maxaddr / 16 - 100)
+    else if (topaddr / 16 >= maxaddr / 16 - 100) // >= 400
         pos = topaddr / 16 - maxaddr / 16 + 500;
-    else if (topaddr / 16 < 1100)
+    else if (topaddr / 16 < 1100) // <= 200
         pos = (topaddr / 16 - 100) / 10 + 100;
-    else if (topaddr / 16 >= maxaddr / 16 - 1100)
+    else if (topaddr / 16 >= maxaddr / 16 - 1100) // >= 300
         pos = (topaddr / 16 - maxaddr / 16 + 1100) / 10 + 300;
-    else
-        pos = 250;
+    else // > 200 && < 300
+        pos = ((topaddr / 16) - 1100) / (((maxaddr / 16) - 2200) / 100) + 200;
 
     sb.SetScrollbar(pos, 20, 500, 20);
 }
@@ -597,6 +597,13 @@ void MemView::MoveView(wxScrollEvent& ev)
 
         MoveSB();
     } // ignore THUMBTRACK and CHANGED
+    // do not interrupt scroll because no event was triggered
+    else if (pos <= 200)
+        topaddr = ((pos - 100) * 10 + 100) * 16;
+    else if (pos >= 300)
+        topaddr = ((pos - 300) * 10 - 1100) * 16 + maxaddr;
+    else if (pos > 200 && pos < 300)
+        topaddr = ((pos - 200) * ((maxaddr / 16 - 2200) / 100) + 1100) * 16;
 
     RefillNeeded();
 }
@@ -649,7 +656,7 @@ void MemView::Refill(wxDC& dc)
 
     for (size_t i = 0; i < (size_t)nlines && i < words.size() / 4; i++) {
         wxString line, word;
-        line.Printf(maxaddr > 0xffff ? wxT("%08X   ") : wxT("%04X   "), topaddr + i * 16);
+        line.Printf(maxaddr > 0xffff ? wxT("%08X   ") : wxT("%04X   "), topaddr + (int)i * 16);
 
         for (int j = 0; j < 4; j++) {
             uint32_t v = words[i * 4 + j];
@@ -720,14 +727,24 @@ void MemView::Resize(wxSizeEvent& ev)
 
 void MemView::Show(uint32_t addr, bool force_update)
 {
+    // go forward 1 line when clicking bottom
     if (addr < topaddr || addr >= topaddr + (nlines - 1) * 16) {
         // align to nearest 16-byte block
         // note that mfc interface only aligns to nearest (1<<fmt)-byte
-        uint32_t newtopaddr = addr & ~0xf;
+        //uint32_t newtopaddr = addr & ~0xf;
+        uint32_t newtopaddr = topaddr + 16;
 
         if (newtopaddr + nlines * 16 > maxaddr)
             newtopaddr = maxaddr - nlines * 16 + 1;
 
+        force_update = newtopaddr != topaddr;
+        topaddr = newtopaddr;
+    }
+    // go back 1 line when clicking top
+    else if (addr >= topaddr && addr <= topaddr + 16 && topaddr > 0)
+    {
+        uint32_t newtopaddr = addr & ~0xf;
+        newtopaddr -= 16;
         force_update = newtopaddr != topaddr;
         topaddr = newtopaddr;
     }

--- a/src/wx/viewsupt.cpp
+++ b/src/wx/viewsupt.cpp
@@ -727,24 +727,14 @@ void MemView::Resize(wxSizeEvent& ev)
 
 void MemView::Show(uint32_t addr, bool force_update)
 {
-    // go forward 1 line when clicking bottom
     if (addr < topaddr || addr >= topaddr + (nlines - 1) * 16) {
         // align to nearest 16-byte block
         // note that mfc interface only aligns to nearest (1<<fmt)-byte
-        //uint32_t newtopaddr = addr & ~0xf;
-        uint32_t newtopaddr = topaddr + 16;
+        uint32_t newtopaddr = addr & ~0xf;
 
         if (newtopaddr + nlines * 16 > maxaddr)
             newtopaddr = maxaddr - nlines * 16 + 1;
 
-        force_update = newtopaddr != topaddr;
-        topaddr = newtopaddr;
-    }
-    // go back 1 line when clicking top
-    else if (addr >= topaddr && addr <= topaddr + 16 && topaddr > 0)
-    {
-        uint32_t newtopaddr = addr & ~0xf;
-        newtopaddr -= 16;
         force_update = newtopaddr != topaddr;
         topaddr = newtopaddr;
     }


### PR DESCRIPTION
@rkitover This is like one of those dumb segfaults that I mentioned earlier. As soon as you click this item, it appears a wxWidgets error message. It has been like this since my pr to remove most of the compilation warnings... 

@retro-wertz You are interested on this, at least at the time of the issue reporting. Check if this is what you want and test it, please. I know I can see rows of memory maps, but I don't know if they are correct or not. The GUI behaviour I could test myself, but we need to be sure that I am not going to break something else with this solution.

Feel free to comment whatever you want. If there is some type of improvement desired, leave a note. I will be off from now until next wednesday (14.8.19) to focus on personal stuff. When I am back, I will see what I can do for this.