### PR TITLE
Allow UPS patch for GBA games.

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -216,7 +216,7 @@ void GameArea::LoadGame(const wxString& name)
         if (loadpatch) {
             // don't use real rom size or it might try to resize rom[]
             // instead, use known size of rom[]
-            int size = 0x2000000;
+            int size = 0x2000000 < rom_size ? 0x2000000 : rom_size;
             applyPatch(pfn.GetFullPath().mb_str(), &rom, &size);
             // that means we no longer really know rom_size either <sigh>
         }


### PR DESCRIPTION
From my very superficial understanding, the `rom[]` resize happens only when `rom_size` is greater than `0x2000000`.

We should probably study this better for an actual explanation.

- Fix #487.

This is a little shady for me... As I don't quite understand what is the problem of resizing `rom[]`. This solution is very simple, though. It should still protect the case for when the resize could happen. This is only for GBA ROMs, it seems (because they are bigger, probably);