### PR TITLE
Check ASAN support when `ENABLE_ASAN=ON`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
         set(MY_C_DBG_FLAGS -g -fno-omit-frame-pointer)
     endif()
 
+    include(CheckCXXCompilerFlag)
+
     if(ENABLE_ASAN)
         string(TOLOWER ${CMAKE_BUILD_TYPE} build)
         if(NOT build STREQUAL "debug")
@@ -490,7 +492,13 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
         if(SANITIZER STREQUAL "on" OR SANITIZER STREQUAL "true")
             set(SANITIZER address)
         endif()
-        set(MY_C_DBG_FLAGS ${MY_C_DBG_FLAGS} -fsanitize=${SANITIZER} -lasan)
+        set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} "-lasan")
+        check_cxx_compiler_flag("-fsanitize=${SANITIZER} -lasan" ASAN_SUPPORT_FLAG)
+        if(${ASAN_SUPPORT_FLAG})
+            set(MY_C_DBG_FLAGS ${MY_C_DBG_FLAGS} -fsanitize=${SANITIZER} -lasan)
+        else()
+            message(FATAL_ERROR "asan not available to compiler.")
+        endif()
     endif()
 
     # common flags
@@ -499,8 +507,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
     if(NOT (WIN32 OR X86_32)) # inline asm is not allowed with -fPIC
         set(MY_C_FLAGS ${MY_C_FLAGS} -fPIC)
     endif()
-
-    include(CheckCXXCompilerFlag)
 
     # check if ssp flags are supported for this version of gcc
     if(CMAKE_COMPILER_IS_GNUCXX)


### PR DESCRIPTION
```
We check if the compiler has asan support when the option is enabled.
If it does not, then we stop compiling with the proper message.

To test this, we use `gcc (GCC) 4.4.7` (no asan support) and
`gcc (GCC) 9.1.0` (asan is supported). Call cmake like this:

`cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=On` and
`CXX=g++-4.4 cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=On`

we then check that it fails for the older version and it works for
the newer gcc, like expected.

- Fix #409.
```

@rkitover  I know this PR has weird timing, but I try to match whatever tool I am handling at work with the closest thing we have here. This way I can double practice whenever I have to do stuff. Check if this is enough.