### PR TITLE
Fix compilation issue when `ENABLE_DEBUGGER=Off`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,13 +103,13 @@ set(ENABLE_LINK_DEFAULT OFF)
 # msys2 does not have static sfml libs atm
 # while on mxe we use static libs
 if(WIN32 AND ((NOT (MINGW AND MSYS)) OR CMAKE_TOOLCHAIN_FILE MATCHES mxe) AND NOT CMAKE_TOOLCHAIN_FILE MATCHES vcpkg)
-	set(SFML_STATIC_LIBRARIES TRUE)
+    set(SFML_STATIC_LIBRARIES TRUE)
 endif()
 
 find_package(SFML 2 COMPONENTS network system)
 
 if(SFML_FOUND)
-	set(ENABLE_LINK_DEFAULT ON)
+    set(ENABLE_LINK_DEFAULT ON)
 endif()
 
 option(ENABLE_LINK "Enable GBA linking functionality" ${ENABLE_LINK_DEFAULT})
@@ -697,7 +697,6 @@ set(
     SRC_GBA
     src/gba/agbprint.cpp
     src/gba/bios.cpp
-    src/gba/BreakpointStructures.cpp
     src/gba/Cheats.cpp
     src/gba/CheatSearch.cpp
     src/gba/debugger-expr-lex.cpp
@@ -723,6 +722,12 @@ set(
     src/gba/Sound.cpp
     src/gba/Sram.cpp
 )
+
+if(ENABLE_DEBUGGER)
+    list(APPEND SRC_GBA
+        src/gba/BreakpointStructures.cpp
+    )
+endif()
 
 set(
     HDR_GBA
@@ -873,17 +878,28 @@ else()
     add_definitions(-DNO_ASM)
 endif()
 
+
+set(
+    SRC_DEBUGGER
+    src/gba/armdis.cpp
+    src/gba/elf.cpp
+)
+
+set(
+    HDR_DEBUGGER
+    src/gba/armdis.h
+    src/gba/elf.h
+)
+
 if(ENABLE_DEBUGGER)
     set(
         SRC_DEBUGGER
-        src/gba/armdis.cpp
-        src/gba/elf.cpp
+        ${SRC_DEBUGGER}
         src/gba/remote.cpp
     )
     set(
         HDR_DEBUGGER
-        src/gba/armdis.h
-        src/gba/elf.h
+        ${HDR_DEBUGGER}
         src/gba/remote.h
     )
 endif()

--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -267,9 +267,11 @@ IFBFilterFunc ifbFunction = 0;
 int	patchNum = 0;
 char *patchNames[PATCH_MAX_NUM] = { NULL }; // and so on
 
+#ifndef NO_DEBUGGER
 void(*dbgMain)() = remoteStubMain;
 void(*dbgSignal)(int, int) = remoteStubSignal;
 void(*dbgOutput)(const char *, uint32_t) = debuggerOutput;
+#endif
 
 char* homeDir = NULL;
 char* arg0 = NULL;
@@ -918,6 +920,7 @@ int ReadOpts(int argc, char ** argv)
 				patchNum++;
 			}
 			break;
+#ifndef NO_DEBUGGER
 		case 'G':
 			dbgMain = remoteStubMain;
 			dbgSignal = remoteStubSignal;
@@ -946,6 +949,7 @@ int ReadOpts(int argc, char ** argv)
 				remoteSetProtocol(0);
 			}
 			break;
+#endif
 		case 'N':
 			parseDebug = false;
 			break;

--- a/src/gba/agbprint.cpp
+++ b/src/gba/agbprint.cpp
@@ -56,7 +56,9 @@ void agbPrintFlush()
 
     uint32_t address = (debuggerReadHalfWord(0x9fe20fa) << 16);
     if (address != 0xfd0000 && address != 0x1fd0000) {
+#ifdef BKPT_SUPPORT
         dbgOutput("Did you forget to call AGBPrintInit?\n", 0);
+#endif
         // get rid of the text otherwise we will continue to be called
         debuggerWriteHalfWord(0x9fe20fc, put);
         return;
@@ -71,7 +73,11 @@ void agbPrintFlush()
         s[1] = 0;
 
         if (systemVerbose & VERBOSE_AGBPRINT)
+	{
+#ifdef BKPT_SUPPORT
             dbgOutput(s, 0);
+#endif
+	}
         if (c == '\n')
             break;
     }

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -204,80 +204,100 @@ EVT_HANDLER(wxID_FILE1, "Load recent ROM 1")
 {
     panel->LoadGame(gopts.recent->GetHistoryFile(0));
 
+#ifndef NO_DEBUGGER
     if (gdbBreakOnLoad)
         GDBBreak();
+#endif
 }
 
 EVT_HANDLER(wxID_FILE2, "Load recent ROM 2")
 {
     panel->LoadGame(gopts.recent->GetHistoryFile(1));
 
+#ifndef NO_DEBUGGER
     if (gdbBreakOnLoad)
         GDBBreak();
+#endif
 }
 
 EVT_HANDLER(wxID_FILE3, "Load recent ROM 3")
 {
     panel->LoadGame(gopts.recent->GetHistoryFile(2));
 
+#ifndef NO_DEBUGGER
     if (gdbBreakOnLoad)
         GDBBreak();
+#endif
 }
 
 EVT_HANDLER(wxID_FILE4, "Load recent ROM 4")
 {
     panel->LoadGame(gopts.recent->GetHistoryFile(3));
 
+#ifndef NO_DEBUGGER
     if (gdbBreakOnLoad)
         GDBBreak();
+#endif
 }
 
 EVT_HANDLER(wxID_FILE5, "Load recent ROM 5")
 {
     panel->LoadGame(gopts.recent->GetHistoryFile(4));
 
+#ifndef NO_DEBUGGER
     if (gdbBreakOnLoad)
         GDBBreak();
+#endif
 }
 
 EVT_HANDLER(wxID_FILE6, "Load recent ROM 6")
 {
     panel->LoadGame(gopts.recent->GetHistoryFile(5));
 
+#ifndef NO_DEBUGGER
     if (gdbBreakOnLoad)
         GDBBreak();
+#endif
 }
 
 EVT_HANDLER(wxID_FILE7, "Load recent ROM 7")
 {
     panel->LoadGame(gopts.recent->GetHistoryFile(6));
 
+#ifndef NO_DEBUGGER
     if (gdbBreakOnLoad)
         GDBBreak();
+#endif
 }
 
 EVT_HANDLER(wxID_FILE8, "Load recent ROM 8")
 {
     panel->LoadGame(gopts.recent->GetHistoryFile(7));
 
+#ifndef NO_DEBUGGER
     if (gdbBreakOnLoad)
         GDBBreak();
+#endif
 }
 
 EVT_HANDLER(wxID_FILE9, "Load recent ROM 9")
 {
     panel->LoadGame(gopts.recent->GetHistoryFile(8));
 
+#ifndef NO_DEBUGGER
     if (gdbBreakOnLoad)
         GDBBreak();
+#endif
 }
 
 EVT_HANDLER(wxID_FILE10, "Load recent ROM 10")
 {
     panel->LoadGame(gopts.recent->GetHistoryFile(9));
 
+#ifndef NO_DEBUGGER
     if (gdbBreakOnLoad)
         GDBBreak();
+#endif
 }
 
 static const struct rom_maker {
@@ -2032,6 +2052,7 @@ EVT_HANDLER_MASK(TileViewer, "Tile Viewer...", CMDEN_GB | CMDEN_GBA)
     TileViewer();
 }
 
+#ifndef NO_DEBUGGER
 extern int remotePort;
 
 int GetGDBPort(MainFrame* mf)
@@ -2052,23 +2073,29 @@ int GetGDBPort(MainFrame* mf)
 #endif
         65535, mf);
 }
+#endif
 
 EVT_HANDLER(DebugGDBPort, "Configure port...")
 {
+#ifndef NO_DEBUGGER
     int port_selected = GetGDBPort(this);
 
     if (port_selected != -1) {
         gdbPort = port_selected;
         update_opts();
     }
+#endif
 }
 
 EVT_HANDLER(DebugGDBBreakOnLoad, "Break on load")
 {
+#ifndef NO_DEBUGGER
     GetMenuOptionInt("DebugGDBBreakOnLoad", gdbBreakOnLoad, 1);
     update_opts();
+#endif
 }
 
+#ifndef NO_DEBUGGER
 void MainFrame::GDBBreak()
 {
     ModalPause mp;
@@ -2147,14 +2174,18 @@ void MainFrame::GDBBreak()
         }
     }
 }
+#endif
 
 EVT_HANDLER_MASK(DebugGDBBreak, "Break into GDB", CMDEN_NGDB_GBA | CMDEN_GDB)
 {
+#ifndef NO_DEBUGGER
     GDBBreak();
+#endif
 }
 
 EVT_HANDLER_MASK(DebugGDBDisconnect, "Disconnect GDB", CMDEN_GDB)
 {
+#ifndef NO_DEBUGGER
     debugger = false;
     dbgMain = NULL;
     dbgSignal = NULL;
@@ -2164,6 +2195,7 @@ EVT_HANDLER_MASK(DebugGDBDisconnect, "Disconnect GDB", CMDEN_GDB)
     cmd_enable &= ~CMDEN_GDB;
     cmd_enable |= CMDEN_NGDB_GBA | CMDEN_NGDB_ANY;
     enable_menus();
+#endif
 }
 
 // Options menu

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2816,6 +2816,20 @@ bool MainFrame::BindControls()
             }
 
 #endif
+#ifdef NO_DEBUGGER
+
+	    if (cmdtab[i].cmd_id == XRCID("DebugGDBBreak") || cmdtab[i].cmd_id == XRCID("DebugGDBDisconnect") || cmdtab[i].cmd_id == XRCID("DebugGDBBreakOnLoad") || cmdtab[i].cmd_id == XRCID("DebugGDBPort"))
+	    {
+		if (mi)
+		{
+		    mi->GetMenu()->Enable(mi->GetId(), false);
+		    //mi->GetMenu()->Remove(mi);
+		}
+		cmdtab[i].cmd_id = XRCID("NOOP");
+                cmdtab[i].mi = NULL;
+                continue;
+	    }
+#endif
 
             if (mi) {
                 // wxgtk provides no way to retrieve stock label/accel
@@ -2889,6 +2903,12 @@ bool MainFrame::BindControls()
                 }
             }
         }
+
+#ifdef NO_DEBUGGER
+        // remove this item from the menu completely
+        wxMenuItem* gdbmi = XRCITEM("GDBMenu");
+        gdbmi->GetMenu()->Remove(gdbmi);
+#endif
 
         // if a recent menu is present, save its location
         wxMenuItem* recentmi = XRCITEM("RecentMenu");

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -503,9 +503,12 @@ void GameArea::UnloadGame(bool destruct)
 #endif
     systemStopGameRecording();
     systemStopGamePlayback();
+
+#ifndef NO_DEBUGGER
     debugger = false;
     remoteCleanUp();
     mf->cmd_enable |= CMDEN_NGDB_ANY;
+#endif
 
     if (loaded == IMAGE_GB) {
         gbCleanUp();
@@ -955,6 +958,7 @@ void GameArea::OnIdle(wxIdleEvent& event)
         LoadGame(pl);
         MainFrame* mf = wxGetApp().frame;
 
+#ifndef NO_DEBUGGER
         if (gdbBreakOnLoad)
             mf->GDBBreak();
 
@@ -962,6 +966,7 @@ void GameArea::OnIdle(wxIdleEvent& event)
             wxLogError(_("Not a valid GBA cartridge"));
             UnloadGame();
         }
+#endif
     }
 
     // stupid wx doesn't resize to screen size
@@ -1064,6 +1069,7 @@ void GameArea::OnIdle(wxIdleEvent& event)
         HidePointer();
         event.RequestMore();
 
+#ifndef NO_DEBUGGER
         if (debugger) {
             was_paused = true;
             dbgMain();
@@ -1075,6 +1081,7 @@ void GameArea::OnIdle(wxIdleEvent& event)
 
             return;
         }
+#endif
 
         emusys->emuMain(emusys->emuCount);
 #ifndef NO_LINK

--- a/src/wx/sys.cpp
+++ b/src/wx/sys.cpp
@@ -1134,6 +1134,8 @@ void systemOnSoundShutdown()
 {
 }
 
+#ifndef NO_DEBUGGER
+
 extern int (*remoteSendFnc)(char*, int);
 extern int (*remoteRecvFnc)(char*, int);
 extern void (*remoteCleanUpFnc)();
@@ -1297,6 +1299,8 @@ bool debugWaitSocket()
     debug_remote = debug_server->Accept(false);
     return debug_remote != NULL;
 }
+
+#endif
 
 void log(const char* defaultMsg, ...)
 {

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -752,6 +752,7 @@ extern bool GetFADevices(wxArrayString& names, wxArrayString& ids);
 #endif
 #endif
 
+#ifndef NO_DEBUGGER
 extern bool debugger;
 extern void (*dbgMain)();
 extern void (*dbgSignal)(int, int);
@@ -766,6 +767,7 @@ extern const wxString& debugGetSlavePty();
 extern bool debugWaitPty();
 extern bool debugStartListen(int port);
 extern bool debugWaitSocket();
+#endif
 
 // perhaps these functions should not be called systemXXX
 // perhaps they should move to panel.cpp/GameArea

--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -536,7 +536,7 @@
         </object>
       </object>
       <object class="separator"/>
-      <object class="wxMenu">
+      <object class="wxMenu" name="GDBMenu">
         <object class="wxMenuItem" name="DebugGDBBreak">
           <label>_Break into GDB</label>
         </object>


### PR DESCRIPTION
```
We protect all code relevant to disabling this property with either
`BKPT_SUPPORT` or `NO_DEBUGGER`. This is mostly debugging options or
prints scattered around the code.

We also adjust cmake to ignore the specific files surround it, but
allowing the rest of the GUI to work.

- Fix #431.
```

@rkitover  This should work for the compilation. The only decision missing is to know if we prefer to remove the GDB stuff from the menu, or just grey it out. The current solution removes it from the menu, but there is also code scope for the other solution.

The `agbprint` stuff is also a question mark for me, since it uses debugging functions but I have no idea about what it is used for. We need to understand it to know what to do. 