### PR TITLE
Languages

### DIFF
--- a/po/wxvbam/ar.po
+++ b/po/wxvbam/ar.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Arabic (http://www.transifex.com/bgk/vba-m/language/ar/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -51,120 +51,120 @@ msgstr "ملفات GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)
 msgid "Open GBC ROM file"
 msgstr "فتح ملف لعبة GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "غير معروف"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark الاصدار 3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -175,230 +175,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "لا شيء"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -414,11 +430,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -622,92 +638,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -766,99 +786,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "وضع الشاشة الكاملة %dx%d-%d@%d ليس مدعوما ; جار البحث عن أخر."
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -928,12 +948,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1332,7 +1352,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2304,8 +2324,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2582,7 +2602,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2590,7 +2610,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2598,7 +2618,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2606,7 +2626,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2614,11 +2634,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2742,633 +2762,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "الترجمة"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/br.po
+++ b/po/wxvbam/br.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Breton (http://www.transifex.com/bgk/vba-m/language/br/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "Restroù GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*
 msgid "Open GBC ROM file"
 msgstr "Restr Open GBC ROM"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Dianav"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+KAMERA GODELL"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Hini ebet"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Diuzit ur restr Kod Dot"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Diuzit restr ar bateri"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Restr bateri (*.sav)|*.sav|Enrolladur flash (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Emporzhiañ ur restr bateri a ziverko kement c'hoari enrollet (da virviken goude ar skrivadur a zeu). C'hoant ho peus da genderc'hel?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Kadarnaat an emporzhiañ"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Bateri karget %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Fazi en ur gargañ ar bateri %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Diuzit ur restr kod"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Restr Kod Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Restr Kod Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Emporzhiañ ur restr kod a erlerc'hio kement cheats karget. C'hoant ho peus da genderc'hel?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Dibosupl eo digeriñ ar restr %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "N'eo ket degemerus kod ar restr %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Karget eo bet kod ar restr %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Fazi en ur gargañ kod ar restr %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Diuzit ur restr snapshot"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy Snapshot (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Emporzhiañ ur restr snapshot a ziverko kement c'hoari enrollet (da virviken goude ar skrivadur a zeu). C'hoant ho peus da genderc'hel?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Karget eo bet ar restr snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Fazi en ur gargañ ar restr snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Skrivet e-barzh ar c'hoari %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Fazi en ur skrivañ e-barzh ar bateri %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "An enrolladennoù EEPROM n'hallont ket bezañ enrollet"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Snapshot (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Ezporzhiet diouzh VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Enrollañ ar restr snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Fazi en ur enrollañ ar restr snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Diuzit ar restr ezvont"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Skeudennoù PNG|*.png|SkeudennoùBMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Skrivet e-barzh snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "restroù ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Restroù Film VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Diuzit ur restr"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Diuzit ur restr stad"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Restroù enrolladennoù c'hoarioù VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Son lakaet"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Son lazhet"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Ampled: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Lakaat da 0 evit ul lesanv tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Porzh o c'hortoz kevreañ:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Kevreadenn GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "O c'hortoz kevreadennoù war %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "O c'hortoz kevreadennoù war ar porzh %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "O c'hortoz GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulator evit Nitendo Gameboy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Disoñjet\nCopyright (C) 2004-2006 VBA skipailh diorroerien\nCopyright (C) 2007-2017 VBA-M skipailh diorroerien"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Ar program-mañ a zo ur meziant frank anezhañ: gallout a reoc'h e zasparzhañ ha/pe e gemmañ\ndindan termenoù al Lisañs GNU Publik Hollek evel embannet gant\nar Free Software Foundation, pe ar stumm 2 eus al Lisañs, pe\n(diouzh ho tibab) forzh peseurt stumm deuet er-maez diwezhatoc'h.\n\nDasparzhet eo ar program-mañ gant ar spi ma vo servijus da vat,\nmet HEP GWARANT EBET; hep ar gwarant empleget eus\nar C'HALITE KENWERZHEL PE AN AZASADUR D'UN IMPLIJ PERSONEL.\nGwelit al Lisañs GNU Publik Hollek evit kaout muioc'h a vunudoù.\n\nResevet ho peus normalamant un eiladenn deus al Lisañs GNU Publik Hollek\nstag gant ar program-mañ. Ma n'ho peus ket, kit da welet http://www.gnu.org/licenses."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "Oberiant emañ dija al liamm LAN. Diweredekait ar mod liamm evit digevreañ."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Ne vez ket degemeret ar rouedad e mod lec'hel."
 
@@ -621,92 +637,96 @@ msgstr "%d stern = %.2f ms"
 msgid "Default device"
 msgstr "Trobarzhell dre-ziouer"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Mod Urzhiataerel"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "N'eo ket bet kavet an astenn rpi implijadus e-barzh %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Astenn"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Diuzit mar plij un astenn pe ur sil disheñvel"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Fazi en ur ziuziñ an astenn"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "An dra-mañ a netao ar fonuserien termenet gant an implijer. Ha sur oc'h?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Kadarnaat"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Arlun-pennañ nann-kavet"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Panel diskouez-pennañ nann-kavet"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Eilañ lañser ar fonusaer: %s evit %s ha %s ; an hini kentañ a vo gwarnet"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Lañser fonusaer %s evit %s nullañ dre ziouer evit %s ; al lañser a vo gwarnet"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Elfenn al lañser %s nann-talvoudus; o tiverkañ"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kod"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Deskrivadur"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Chomlec'h"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Talvoudegezh kozh"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Talvoudegezh nevez"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Lañser an urzhiadoù"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Urzhiadoù all"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Ostiz JoyBus nann-dalvoudus; o titalvoudekaat"
 
@@ -765,99 +785,99 @@ msgstr "Divarrek da gargañ Game Boy Advance ROM %s"
 msgid " player "
 msgstr "c'hoarier"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Stad karget %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Fazi en ur gargañ ar stad %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Stad enrollet %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Fazi en ur enrollañ ar stad %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Mod Skramm-leun %dx%d-%d@%d nann degemeret; o klask war-lerc'h unan all"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Mod skramm-leun %dx%d-%d@%d nann-degemeret"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Mod reizh: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Diuzit ur mod %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "C'hwitet eo bet da gemm ar mod da %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "N'eo ket ur gartouchenn GBA reizh"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Memor ebet evit punañ"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Fazi en ur skrivañ stad ar punadur"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "Fazi gant memor an deverkoù"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "fazi en ur zeraouekaat ar c'hodek"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "fazi en ur skrivañ ur restr ezvont"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "n'hall ket divinout stumm an ezvont gant anv ar restr"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "fazi programmiñ; oc'h arsav!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Divarrek da gregiñ da enrollañ da %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Fazi en ur enrollañ an aodio/ar video (%s); oc'h arsav"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Fazi gant an enrolladur an aodio (%s); oc'h arsav"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Fazi en ur enrollañ ar video (%s); oc'h arsav"
@@ -927,12 +947,12 @@ msgstr "&Serriñ"
 msgid "Printed"
 msgstr "Moullet"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Fazi en ur zigeriñ al lesanv tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Fazi gant kefluniadur ar socket eus ar servijer (%d)"
@@ -1331,7 +1351,7 @@ msgstr "Ouzhpenn&añ ur c'hod evit truchañ"
 msgid "Edit Cheat"
 msgstr "Kemm ar c'hod"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Doare"
 
@@ -2303,8 +2323,8 @@ msgstr "Checksum:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Klikit war ur vaezienn ha pouezit da c'houde war un douchenn pe fiñvit ar joystick evit ouzhpennañ. Pouezit war an douchenn Distreiñ da ziverkañ an douchenn ouzhpennet da ziwezhañ. Adventit pe klikit e-barzh ha fiñvit ar buker da welet an endalc'had a-bezh ma 'z eo re vihan."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Us"
 
@@ -2589,7 +2609,7 @@ msgstr "Us"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Traoñ"
 
@@ -2597,7 +2617,7 @@ msgstr "Traoñ"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Kleiz"
 
@@ -2605,7 +2625,7 @@ msgstr "Kleiz"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Dehou"
 
@@ -2613,11 +2633,11 @@ msgstr "Dehou"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Diuziñ"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Kregiñ"
 
@@ -2741,634 +2761,658 @@ msgstr "Verbeg"
 msgid "&File"
 msgstr "&Restr"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Digeriñ &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Digeriñ GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Digoret &nevez 'zo"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "Addeoue&rekaat listenn ar re zigoret nevez 'zo"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Skornañ listenn ar re nevez-digoret"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "Tito&uroù diwar-benn ar ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Lenner"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Kargit ar C'hod Dot..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Enrollañ ar C'hod Dot..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "A&r re nevesañ"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "Emg&argañ ar re nevesañ"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Adalek &Restr..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Na cheñchit ket enrolladennoù ar &bateri"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Na cheñchit ket listennoù ar c'hodoù evit &truchañ"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Kargañ ar stad"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&Kartouchenn goshañ"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "D'ar &Restr..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "Enrollañ ar re&str"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "Restr ar &Bateri..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "&Kod ar restr Gameshark...."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Gameshark snapshot..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "Emporzh&iañ"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Ezporzhiañ"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Tapadenn-s&kramm..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Kregiñ da enrollañ ar &son..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Paouez da enrollañ ar s&on"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Kregiñ da enrollañ ar &video"
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Paouez da enrollañ ar v&ideo"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Kregiñ da enrollañ ar &c'hoari..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Paouez da enrollañ ar c'ho&ari"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Enrollañ"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Kregiñ da lenn ar fil&m..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Pa&ouez da lenn ar film..."
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&C'hoari"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulation"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Ehan"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "Stern da-heul"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Punañ"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Gwintañ war-du ar skramm-&leun"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "Mod &Turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "N&a ober van eus ar sternioù"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&Na ober van eus ar BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Auto IPS/UPS/IPF patch"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Ehanañ pa vez dioberiant"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Adlakaat"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Dibarzhioù"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Liamm"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Stagañ gant ur &rouedad Link..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Netra"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Fun"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Difun"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Mod lec'hel"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Liamm d'al loc'hañ"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Hachadur fonus"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Kefluniañ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Video"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Krogit e-barzh ar mod skramm-leun"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr "&1x"
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr "&2x"
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr "&3x"
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr "&4x"
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr "&5x"
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr "&6x"
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&Mirout ar feur uhelder/ledander"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "Sil di&vlinenner"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Mirout ar prenestr e krec'h"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Barenn ar &statud"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Lazhañ an diskwel dreistgoulouet"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Diskwel dreistgoulouet &treuzwelus"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Aodio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr "&Uhelaat al live-son"
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr "&Izelaat al live-son"
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr "&Enaouiñ ar son"
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "Standilhonamaj son ar &GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "Gwelladur ar son &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "Efed son lieskanol &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "Deklikadur ar son &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Enmont"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Tennotomatek"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Kefluniañ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&Horolaj en Amzer Gwirion"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Ober gant ar restr BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Diveugiñ ar voullerez"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "Moullerez &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Krouit ur bajenn a-bezh a-raok diveugiñ"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr " &Enrollañ ezvontoù ar voullerez evel tapadennoù-skramm"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Ober gant ar restr GB BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Ober gant ar restr GBC BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Hollek..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr "&Speedup/Turbo..."
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "&Doseroù..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Berradennoù-&klavier..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "Os&tilhoù"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Kodoù evit truchañ"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Listenn ar &C'hodoù evit truchañ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Kavout kodoù evit truc&hañ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Em-enrollañ/gargañ kodoù evit trucha"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Gweredekaat ar c'hodoù da druchal"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "Ehaniñ e-&barzh GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Kefluniañ ar porzh"
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "Ehaniñ e-&barzh ar c'hargadur"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Digevrea"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Distrollañ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Marilhadur..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Deweler &IO..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Deweler &Kartenn..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Deweler m&emor..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "Deweler &OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Deweler &Livaoueg..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Deweler &tuiloù..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Gwelet ar Gwiskadoù"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Chadenn &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Chadenn &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Chadenn &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Chadenn &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Chadennoù ar &Son"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Sikour"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Danevelliñ ar &Beugoù"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "&Forom sikour VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Troidigezhioù"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
 msgstr "&Distreiñ da arventennoù an uzin..."
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
+msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4
 msgid "Map Viewer"

--- a/po/wxvbam/bs.po
+++ b/po/wxvbam/bs.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Bosnian (http://www.transifex.com/bgk/vba-m/language/bs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/ca.po
+++ b/po/wxvbam/ca.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Catalan (http://www.transifex.com/bgk/vba-m/language/ca/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/ca_ES.po
+++ b/po/wxvbam/ca_ES.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Catalan (Spain) (http://www.transifex.com/bgk/vba-m/language/ca_ES/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/cs.po
+++ b/po/wxvbam/cs.po
@@ -12,9 +12,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Czech (http://www.transifex.com/bgk/vba-m/language/cs/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -54,120 +54,120 @@ msgstr "Soubory GameBoy Color\n(*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*
 msgid "Open GBC ROM file"
 msgstr "Otevřít soubor GBC ROM"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Neznámý"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -178,230 +178,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Žádné"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Vybrat soubor s tečkovým kódem"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "Tečkový kód pro E-čtečku (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Vybrat soubor s baterií"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Soubor s baterií (*.sav)|*.sav|Flashové uložení (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importování souboru s baterií odstraní všechny uložené hry (natvralo po příštím zápise).  Přejete si pokračovat?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Potvrdit import"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Nahrána baterie %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Chyba nahrávání baterie %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Vybrat soubor s kódy"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark soubor s kódy (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark soubor (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Nahrání souboru s kódy nahradí všechny načtené cheaty.  Přejete si pokračovat?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Nelze otevřít soubor %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Nepodporovaný soubor s kódy %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Načten soubor s kódy %s "
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Chyba při nahrávání souboru s kódy %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Vyberte soubor se snímkem"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Snapshoty (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshoty (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy Snapshot (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Nahrání snapshot souboru přepíše všechny uložené hry (permanentně po příštím uložení).  Přejete si pokračovat?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Nahrán soubor se snímkem %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Chyba při nahrávání snapshot souboru %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Zapsána baterie %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Chyba zapisování baterie %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "EEPROM uložení nelze exportovat"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Snapshot (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exportován z VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Soubor snímku %s uložen"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Chyba  ukládání snapshot souboru %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Vyberte výstupní soubor"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG obrázky|*.png|BMP obrázky|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Snímek %s zapsán"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr " soubory ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA video soubory|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Vybrat soubor"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Vybrat uložení"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Soubory VisualBoyAdvance uložení|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Zvuk povolen"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Zvuk zakázán"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Hlasitost: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Nastavte na 0 pro pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Port kde očekávat připojení:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB Připojení"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Připojení očekáváno na %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Připojení očekáváno na portu %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Čekání na GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulátor Nintendo GameBoy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr " Autorská práva (C) 1999-2003 Zapomenuté\nAutorská práva (C) 2004-2006 VBA vývojový tým\nAutorská práva (C) 2007-2017 VBA-M vývojový tým"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -417,11 +433,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Tento program je svobodný software: můžete jej šířit a upravovat podle ustanovení GNU General Public Licence, vydávané Free Software Foundation a to buď podle 2. verze této Licence, nebo (podle vašeho uvážení) kterékoli pozdější verze.\n\nTento program je rozšiřován v naději, že bude užitečný, avšak BEZ JAKÉKOLIV ZÁRUKY. Neposkytují se ani odvozené záruky PRODEJNOSTI anebo VHODNOSTI PRO URČITÝ ÚČEL. Další podrobnosti hledejte v Obecné veřejné licenci GNU.\n\nKopii Obecné veřejné licence GNU jste měli obdržet spolu s tímto programem. Pokud se tak nestalo, najdete ji zde: <http://www.gnu.org/licenses/>."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "LAN spojení je již aktivní. Zakažte režim propojení pro odpojení."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Síť není podporována v místním režimu."
 
@@ -625,92 +641,96 @@ msgstr "%d snímků = %.2f ms"
 msgid "Default device"
 msgstr "Výchozí zařízení"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Režim plochy"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "V %s nenalezeny žádné použitelné zásuvné moduly rpi"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Zásuvný modul"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Vyberte prosím zásuvný modul nebo jiný filtr"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Chyba při výběru zásuvného modulu"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Toto smaže všechny uživatelské zkratky. Jste si jisti?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Potvrdit"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Hlavní ikona nenalezena"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Panel hlavního displeje nenalezen"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Duplictní zkratka nabídky: %s pro %s a %s; ponechána první"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Klávesová zkratka nabídky %s pro %s přepisuje výchozí pro %s ; ponechána zkratka nabídky"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Neplatná položka nabídky %s; odstraňování"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kód"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Popis"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Adresa"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Stará hodnota"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Nová hodnota"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Příkazy nabídky"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Jiné příkazy"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Neplatný hostitel JoyBus; probíhá vypínání"
 
@@ -769,99 +789,99 @@ msgstr "Nelze načíst Game Boy Advance ROM %s"
 msgid " player "
 msgstr " hráč "
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Stav %s načten"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Chyba při načítání stavu %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Stav %s uložen"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Chyba při ukládání stavu %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Režim celé obrazovky %dx%d-%d@%d není podporován; hledá se jiný"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Režim celé obrazovky %dx%d-%d@%d není podporován"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Platný režim: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Zvolen režim %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Nelze změnit režim na %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Není platná karta GBA"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Žádná paměť pro přetočení"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Chyba při zápisu stavu přetočení"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "chyba přidělení paměti"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "chyba při zavádění kodeku"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "chyba při zápisu do výstupního souboru"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "nešlo odhadnout výstupní formát z názvu souboru"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "chyba programování; probíhá ukončování!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Nelze zahájit nahrávání do %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Chyba při nahrávání videa/zvuku (%s); nahrávání ukončeno"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Chyba při nahrávání zvuku (%s); nahrávání ukončeno"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Chyba při nahrávání videa (%s); nahrávání ukončeno"
@@ -931,12 +951,12 @@ msgstr "&Zavřít"
 msgid "Printed"
 msgstr "Vytisknuto"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Chyba při otevírání pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Chyba při nastavování soketu serveru (%d)"
@@ -1335,7 +1355,7 @@ msgstr "&Přidat cheat"
 msgid "Edit Cheat"
 msgstr "Upravit cheat"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Typ"
 
@@ -2307,8 +2327,8 @@ msgstr "Kontrolní součet:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2585,7 +2605,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Nahoru"
 
@@ -2593,7 +2613,7 @@ msgstr "Nahoru"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Dolů"
 
@@ -2601,7 +2621,7 @@ msgstr "Dolů"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Doleva"
 
@@ -2609,7 +2629,7 @@ msgstr "Doleva"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Doprava"
 
@@ -2617,11 +2637,11 @@ msgstr "Doprava"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2745,633 +2765,657 @@ msgstr ""
 msgid "&File"
 msgstr "&Soubor"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Otevřít &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Otevřít GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Otevřít &nedávné"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Resetovat seznam nedávných her"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Uzamknout seznam nedávných her"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "In&formace o ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-čtečka"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Načíst tečkový kód..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Uložit tečkový kód..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "&Nedávné"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&Automaticky načíst nejnovější"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Ze &souboru"
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "&Neměnit seznam cheatů"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Načíst stav"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&Nejstarší pozice"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "&Do souboru ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Uložit stav"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importovat"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "E&xportovat"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "&Zachycení obrazovky..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "&Spustit nahrávání zvuku..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "&Zastavit nahrávání zvuku"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Spustit nahrávání videa..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Zastavit nahrávání v&idea"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Spustit nahrávání &hry..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Zastavit nahrávání h&ry"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Nahrát"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Spustit přehrávání &videa"
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Zastavit přehrávání vi&dea"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Přehrát"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulace"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Pozastavit"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Další snímek"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "&Přetočit"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSynchronizace"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Automaticky přeskakovat snímky"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&Přeskočit BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Automaticky použít záplatu IPS/UPS/IPF"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "Pozastavit při nečinnosti"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Resetovat"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Možnosti"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Propojení"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Zahájit &síťové propojení"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "Žá&dné"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Kabel"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Bezdrátové"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Místní režim"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Propojit při zavedení"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Hack rychlosti"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Nastavení ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Obraz"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Spustit v režimu celé obrazovky"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&Zachovat poměr stran"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr "&Bilineární filtr"
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr "&Okno je vždy v popředí"
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
-msgstr "&Stavový řádek"
-
-#: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
-msgstr "&Zakázat nabídku na obrazovce"
-
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr "&Bilineární filtr"
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr "&Okno je vždy v popředí"
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr "&Stavový řádek"
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr "&Zakázat nabídku na obrazovce"
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Zvuk"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&Interpolace zvuku GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "Vylepšení &zvuku GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Vstup"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Automatická střelba"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Nastavení ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&Opravdové hodiny:"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Použít soubor BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Výpis pro ladění"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&Tiskárna GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Shromáždit celou stránku před vytištěním"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Použít soubor BIOS pro GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Použít soubor BIOS pro GBC"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Obecné..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "&Adresáře ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "&Klávesové zkratky ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Nástroje"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Cheaty"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "&Seznam cheatů"
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "&Najít cheat ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Automaticky ukládat/načíst &cheaty"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Povolit cheaty"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "&Přejít do ladění"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Nastavit port..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Odpojit"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Rozložit..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Záznam..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Prohlížeč &vstupu/výstupu..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Prohlížeč &mapy..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Prohlížeč p&aměti..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Prohlížeč &palety"
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "Zobrazit &vrstvy"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Kanál &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Kanál &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Kanál &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Kanál &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&Zvukové kanály"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Nápověda"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Nahlásit &chyby"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "&Fórum podpory VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Překlady"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/da.po
+++ b/po/wxvbam/da.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Danish (http://www.transifex.com/bgk/vba-m/language/da/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/da_DK.po
+++ b/po/wxvbam/da_DK.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Danish (Denmark) (http://www.transifex.com/bgk/vba-m/language/da_DK/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/de.po
+++ b/po/wxvbam/de.po
@@ -12,9 +12,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: German (http://www.transifex.com/bgk/vba-m/language/de/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -54,120 +54,120 @@ msgstr "GameBoy Color-Dateien (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.
 msgid "Open GBC ROM file"
 msgstr "GBC ROM-Datei öffnen"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -178,230 +178,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Nichts"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Dot Code-Datei auswählen"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Batterie-Datei auswählen"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Batterie-Datei (*.sav)|*.sav|Flash-Speicher (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Das Importieren einer Batterie-Datei löscht alle Speicherstände (nach dem nächsten Schreibvorgang permanent).\nWillst du den Vorgang fortsetzen?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Import bestätigen"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Batterie geladen %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Fehler beim Laden der Batterie %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Code-Datei auswählen"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark Code-Datei (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark Code-Datei (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Das Importieren einer Code-Datei ersetzt alle derzeit geladenen Cheats. Vorgang fortsetzen?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Kann Datei %s nicht öffnen"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Unbekannte Code-Datei %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Code-Datei %s geladen"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Fehler beim Laden der Code-Datei %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Snapshot-Datei auswählen"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Game Boy Snapshot (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Das Importieren einer Snapshot-Datei löscht alle Speicherstände (nach dem nächsten Schreibvorgang permanent).\nWillst du den Vorgang fortsetzen?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Snapshot-Datei %s geladen"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Fehler beim Laden der Snapshot-Datei %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Batterie %s geschrieben"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Fehler beim Schreiben der Batterie %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "EEPROM-Speicherdatei konnte nicht exportiert werden"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark-Snapshot (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exportiert aus VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Snapshot-Datei %s gespeichert"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Fehler beim Speichern der Snapshot-Datei %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Ausgabedatei wählen"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG Bilder|*.png|BMP Bilder|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Snapshot %s geschrieben"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "Dateien ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA Filmdateien|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Datei auswählen"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Savestate auswählen."
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance Speicherstände|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Sound aktiviert"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Sound deaktiviert"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Lautstärke: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Für Pseudo-TTY auf 0 setzen"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Port zum Horchen auf eine Verbindung:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB-Verbindung"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Warte auf Verbindung auf %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Warte auf Verbindung auf Port %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Warte auf GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Nintendo Game Boy (+Color +Advance) Emulator."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA Entwicklerteam\nCopyright (C) 2007-2011 VBA-M Entwicklerteam"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -417,11 +433,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Dieses Programm ist freie Software. Sie können es unter den Bedingungen der GNU General Public License, wie von der Free Software Foundation veröffentlicht, weitergeben und/oder modifizieren, entweder gemäß Version 2 der Lizenz oder (Ihrer Entscheidung nach) jeder späteren Version.\n\nDie Veröffentlichung dieses Programms erfolgt in der Hoffnung, dass es Ihnen von Nutzen sein wird, aber OHNE JEGLICHE GARANTIE, sogar ohne die implizite Garantie der MARKTREIFE oder der VERWENDBARKEIT FÜR EINEN BESTIMMTEN ZWECK. Details finden Sie in der GNU General Public License.\n\nSie sollten ein Exemplar der GNU General Public License zusammen mit diesem Programm erhalten haben. Falls nicht, gehen Sie auf http://www.gnu.de/documents/index.de.html ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "LAN-Link ist bereits aktiv. Deaktivieren Sie den Linkmodus zum Trennen der Verbindung."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Netzwerk wird in lokalem Modus nicht unterstützt."
 
@@ -625,92 +641,96 @@ msgstr "%d Frames = %.2f ms"
 msgid "Default device"
 msgstr "Standardgerät"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Desktopmodus"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Es wurden keine anwendbaren RPI-Plugins in %s gefunden."
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Bitte wähle ein Plugin oder einen anderen Filter aus"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Fehler bei Plugin-Auswahl"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Dies wird alle benutzerdefinierten Schnelltasten zurücksetzen. Fortfahren?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Haupt-Icon nicht gefunden"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Haupt-Display nicht gefunden"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Doppelt belegte Schnelltaste: %s für %s und %s. Erste wird beibehalten."
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Menü-Schnelltaste %s für %s überschreibt Standardzuweisung für %s. Menü wird beibehalten."
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Ungültiges Menüelement %s; wird entfernt."
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Code"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Beschreibung"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Adresse"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Ursprünglicher Wert"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Neuer Wert"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Menükommandos"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Andere Kommandos"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "JoyBus-Host ungültig; wird deaktiviert."
 
@@ -769,99 +789,99 @@ msgstr "Konnte Game Boy Advance ROM %s nicht laden."
 msgid " player "
 msgstr "Spieler"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Savestate %s geladen"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Fehler beim Laden von Savestate %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Savestate %s gespeichert"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Fehler beim Speichern von Savestate %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Vollbildmodus %dx%d-%d@%d wird nicht unterstützt; probiere einen anderen aus."
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Vollbildmodus %dx%d-%d@%d wird nicht unterstützt."
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Gültiger Modus: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Modus %dx%d-%d@%d ausgewählt"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Konnte Anzeigemodus nicht auf %dx%d-%d@%d umstellen."
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Keine gültige GBA-Steckkarte"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Kein freier Speicher für Zurückspuhl-Datei"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Fehler beim Speichern von Zurückspuhl-Datei"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "Fehler bei Speicherzuweisung"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "Fehler bei Initialisierung von Codec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "Fehler beim Schreiben in Ausgabedatei"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "Konnte Ausgabeformat nicht von Dateiendung ableiten"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "Programmierfehler! Abbruch!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Konnte nicht mit Aufnahme nach %s beginnen (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Fehler bei Audio/Video-Aufnahme (%s). Abbruch!"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Fehler bei Audio-Aufnahme (%s). Abbruch!"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Fehler bei Video-Aufnahme (%s). Abbruch!"
@@ -931,12 +951,12 @@ msgstr "S&chließen"
 msgid "Printed"
 msgstr "Ausdruck fertig"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Fehler beim Öffnen von Pseudo-TTY: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Fehler beim Einrichten von Server-Socket (%d)"
@@ -1335,7 +1355,7 @@ msgstr "Che&at hinzufügen"
 msgid "Edit Cheat"
 msgstr "Cheat bearbeiten"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Typ"
 
@@ -2307,8 +2327,8 @@ msgstr "Prüfsumme:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2585,7 +2605,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Klicke auf ein Feld und drücke eine Taste oder bewege einen Stick. Drücke die Rückschritttaste/Backspace, um die zuletzt hinzugefügte Taste zu löschen. Ziehe das Fenster größer oder klicke hinein und bewege den Zeiger, falls nicht alles sichtbar ist."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Oben"
 
@@ -2593,7 +2613,7 @@ msgstr "Oben"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Unten"
 
@@ -2601,7 +2621,7 @@ msgstr "Unten"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Links"
 
@@ -2609,7 +2629,7 @@ msgstr "Links"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Rechts"
 
@@ -2617,11 +2637,11 @@ msgstr "Rechts"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2745,633 +2765,657 @@ msgstr "Ausführlich"
 msgid "&File"
 msgstr "Datei"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "&GB öffnen..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "GB&C öffnen..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Zuletzt verwendet"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "Liste zurücksetzen"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "Liste einfrieren"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ROM-In&formationen..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "Dot-Code &laden..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "Dot-Code &speichern..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Zuletzt verwendete"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "Zuletzte verwendete automatisch laden"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Aus Datei...."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Batteriespeicher nicht verändern"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Cheat-Liste nicht verändern"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "Savestate &laden"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "Ältester Platz"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "In Datei..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Savestate speichern"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&Batteriespeicher..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Gameshark &Code-Datei..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Gameshark-Schnappschuss..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importieren"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Exportieren"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Bildschirma&ufnahme..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Tonaufzeichnung &starten..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "T&onaufzeichnung anhalten"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "&Videoaufzeichnung starten..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Videoaufzeichnungs anhalten"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Spielaufzeichnung starten..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Spiel&aufzeichnung anhalten"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "Aufzeichnen"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Fil&m abspielen..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Film anhalten"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "Abs&pielen"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulation"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Pause"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Nächster Frame"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Zurückspulen"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "&Vollbild umschalten"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Turbo-Modus"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&Vertikale Synchronisation"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Automatisch Frames überspringen"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "BIO&S überspringen"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Automatisch IPS/UPS/IPF-Patches anwenden"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "Bei Inaktivität &pausieren"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Reset"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Optionen"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Link"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "&Netzwerk-Link starten..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Nichts"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "Kabel"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Drahtlos"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Lokaler Modus"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "Beim Booten &Link aufbauen"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Speed-Hack"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "Konfigurieren..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Video"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Im Vollbild starten"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "Bildschi&rmseitenverhältnis beibehalten"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "&Bilinearer Filter"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "Fenster im Vordergrund halten"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "&Statusleiste"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "On-Screen-&Display deaktivieren"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "&Transparentes On-Screen-Display"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Audio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&GBA Ton-Interpolation"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&GB Tonverbesserung"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&GB Surround-Sound-Effekt"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "&GB Klickgeräusche dämpfen"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "Steuerung"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Autofeuer"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Konfigurieren..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "Echtzeituh&r (RTC)"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "BIOS-Datei verwenden"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Debug-Ausdruck"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&GB Drucker"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "Ausdruck hinauszö&gern, bis Seite voll ist"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "Au&sdruck als Screenshot speichern"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "GB BIOS-Datei verwenden"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "GBC BIOS-Datei verwenden"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "All&gemeines..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "Verze&ichnisse..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Tasten&kürzel..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Hilfsmi&ttel"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Cheats"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "&Cheats auflisten..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "C&heat suchen..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Cheats a&utomatisch laden/speichern"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "Ch&eats aktivieren"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "Break in GD&B setzen"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "Port konfigurieren..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "&Break beim Laden"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "Verbin&dung trennen"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Disassemblen..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "Protoko&ll anlegen..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&IO-Anzeige..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Map-Ansicht..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Speicher-Ansicht..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&OAM-Ansicht..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "&Paletten-Ansicht..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Kachel-Ansich&t..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "Ebenen anzeigen"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Kanal &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Kanal &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Kanal &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Kanal &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Tonkanäle"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Hilfe"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Fehler melden"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M Hilfe-&Forum"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Übersetzungen"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/de_DE.po
+++ b/po/wxvbam/de_DE.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: German (Germany) (http://www.transifex.com/bgk/vba-m/language/de_DE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/el.po
+++ b/po/wxvbam/el.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Greek (http://www.transifex.com/bgk/vba-m/language/el/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "Αρχεία GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.ra
 msgid "Open GBC ROM file"
 msgstr "Άνοιγμα αρχείου GBC ROM"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Άγνωστο"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Κανένα"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Επιλογή αρχείου Dot Code"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Επιλογή αρχείου μπαταρίας"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Αρχείο μπαταρίας (*.sav)|*.sav|Αποθήκευση Flash (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Η εισαγωγή αρχείου μπαταρίας θα σβήσει τυχόν αποθηκευμένα παιχνίδια (μόνιμα μετά την επόμενη εγγραφή). Θέλετε να συνεχίσετε;"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Επιβεβαίωση εισαγωγής"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Φορτώθηκε η μπαταρία %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Σφάλμα φόρτωσης μπαταρίας %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Επιλογή αρχείου κωδικών"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Αρχείο κωδικών Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Αρχείο κωδικών Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Η εισαγωγή αρχείου κωδικών θα αντικαταστήσει τυχόν φορτωμένους κωδικούς. Θέλετε να συνεχίσετε;"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Αδυναμία ανοίγματος αρχείου %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Μη υποστηριζόμενο αρχείο κωδικών %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Φορτώθηκε το αρχείο κωδικών %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Σφάλμα φόρτωσης αρχείου κωδικών %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Επιλογή αρχείου στιγμιότυπου"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Στυγμιότυπα GS και PAC (*.sps;*.xps)|*.sps;*.xps|Στυγμιότυπα GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Στυγμιότυπο Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Η εισαγωγή αρχείου στιγμιότυπου θα σβήσει τυχόν αποθηκευμένα παιχνίδια (μόνιμα μετά την επόμενη εγγραφή). Θέλετε να συνεχίσετε;"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Φορτώθηκε το αρχείο στιγμιότυπου %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Σφάλμα φόρτωσης αρχείου στιγμιότυπου %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Εγγραφή μπαταρίας %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Σφάλμα εγγραφής μπαταρίας %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Δεν είναι δυνατή η εξαγωγή αρχείων αποθήκευσης EEPROM"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Στιγμιότυπο Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Εξαγωγή από VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Αποθηκεύτηκε το αρχείο στιγμιότυπου %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Σφάλμα αποθήκευσης αρχείου στιγμιότυπου %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Επιλογή αρχείου εξόδου"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Εικόνες PNG|*.png|Εικόνες BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Εγγραφή στιγμιότυπου %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "αρχεία ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Αρχεία VBA Movie|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Επιλογή αρχείου"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Επιλογή αρχείου κατάστασης"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Αρχεία αποθηκευμένων παιχνιδιών VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Ο ήχος ενεργοποιήθηκε"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Ο ήχος απενεργοποιήθηκε"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Ένταση: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Ορίστε το σε 0 για ψευδο-tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Θύρα για αναμονή σύνδεσης:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Σύνδεση GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Αναμονή για σύνδεση σε %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Αναμονή για σύνδεση στη θύρα %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Αναμονή για GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Εξομοιωτής Nintendo GameBoy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA development team\nCopyright (C) 2007-2017 VBA-M development team"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "This program is free software: you can redistribute it and/or modify\nit under the terms of the GNU General Public License as published by\nthe Free Software Foundation, either version 2 of the License, or\n(at your option) any later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License\nalong with this program.  If not, see http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "Η σύνδεση LAN είναι ήδη ενεργή. Απενεργοποιήστε τη λειτουργία σύνδεσης για να αποσυνδεθείτε."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Το δίκτυο δεν υποστηρίζεται σε τοπική λειτουργία."
 
@@ -621,92 +637,96 @@ msgstr "%d καρέ = %.2f ms"
 msgid "Default device"
 msgstr "Προεπιλεγμένη συσκευή"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Λειτουργία desktop"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Δεν βρέθηκαν χρήσιμες επεκτάσεις rpi στο %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Επέκταση"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Επιλέξτε μια επέκταση ή ένα διαφορετικό φίλτρο"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Σφάλμα επιλογής επέκτασης"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Αυτό θα διαγράψει όλους τους επιταχυντές που ορίστηκαν από τον χρήστη. Είστε σίγουροι;"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Επιβεβαίωση"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Το κύριο εικονίδιο δεν βρέθηκε"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Το πάνελ κύριας προβολής δεν βρέθηκε"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Διπλότυπος επιταχυντής μενού: %s για %s και %s, θα κρατηθεί ο πρώτος"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Ο επιταχυντής μενού %s για %s παρακάμπτει την προεπιλογή για %s, διατηρείται το μενού"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Μη έγκυρο αντικείμενο μενού %s, θα αφαιρεθεί"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Κωδικός"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Περιγραφή"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Διεύθυνση"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Προηγούμενη τιμή"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Νέα τιμή"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Εντολές μενού"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Άλλες εντολές"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Μη έγκυρος JoyBus host, απενεργοποίηση"
 
@@ -765,99 +785,99 @@ msgstr "Αδυναμία φόρτωσης Game Boy Advance ROM %s"
 msgid " player "
 msgstr "παίκτης"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Φορτώθηκε η κατάσταση %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Σφάλμα φόρτωσης κατάστασης %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Αποθηκεύτηκε η κατάσταση %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Σφάλμα αποθήκευσης κατάστασης %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Η λειτουργία πλήρους οθόνης %dx%d-%d@%d δεν υποστηρίζεται, αναζήτηση για άλλη"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Η λειτουργία πλήρους οθόνης %dx%d-%d@%d δεν υποστηρίζεται"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Έγκυρη λειτουργία: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Επιλέχθηκε η λειτουργία %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Αποτυχία αλλαγής λειτουργίας σε %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Μη έγκυρη κασέτα GBA"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Ελλιπής μνήμη για επανάληψη"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Σφάλμα εγγραφής κατάστασης επανάληψης"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "σφάλμα κατανομής μνήμης"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "σφάλμα αρχικοποίησης codec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "σφάλμα εγγραφής σε αρχείο εξόδου"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "αδυναμία υπόθεσης μορφής εξόδου από το όνομα αρχείου"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "προγραμματιστικό σφάλμα, τερματισμός!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Αδυναμία έναρξης εγγραφής σε %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Σφάλμα στην εγγραφή ήχου/βίντεο (%s), τερματισμός"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Σφάλμα στην εγγραφή ήχου (%s), τερματισμός"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Σφάλμα στην εγγραφή βίντεο (%s), τερματισμός"
@@ -927,12 +947,12 @@ msgstr "Κλείσιμο"
 msgid "Printed"
 msgstr "Εκτπώθηκε"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Σφάλμα ανοίγματος ψευδο-tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Σφάλμα ρύθμισης θύρας διακομιστή (%d)"
@@ -1331,7 +1351,7 @@ msgstr "Προσθήκη κωδικού"
 msgid "Edit Cheat"
 msgstr "Επεξεργασία κωδικού"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "Τύπος"
 
@@ -2303,8 +2323,8 @@ msgstr "Άθροισμα ελέγχου:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Κάντε κλικ σε ένα πεδίο και πατήστε ένα πλήκτρο ή μετακινήστε τον μοχλό για προσθήκη. Πατήστε Backspace για να διαγράψετε το τελευταίο πλήκτρο που προστέθηκε. Μεγαλώστε το παράθυρο ή κάντε κλικ εντός και μετακινήστε τον δείκτη για να δείτε όλα τα περιεχόμενα εάν δεν φαίνονται."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Πάνω"
 
@@ -2589,7 +2609,7 @@ msgstr "Πάνω"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Κάτω"
 
@@ -2597,7 +2617,7 @@ msgstr "Κάτω"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Αριστερά"
 
@@ -2605,7 +2625,7 @@ msgstr "Αριστερά"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Δεξιά"
 
@@ -2613,11 +2633,11 @@ msgstr "Δεξιά"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2741,633 +2761,657 @@ msgstr "Αναλυτικά"
 msgid "&File"
 msgstr "Αρχείο"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Άνοιγμα &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Άνοιγμα GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Άνοιγμα πρόσφατου"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "Επαναφορά λίστας πρόσφατων"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "Πάγωμα λίστας πρόσφατων"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "Πληροφορίες ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "Φόρτωση Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "Αποθήκευση Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Πιο πρόσφατα"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "Αυτόματη φόρτωση πιο πρόσφατου"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Από αρχείο ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Χωρίς αλλαγή αποθήκευσης μπαταρίας"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Χωρίς αλλαγή λίστας κωδικών"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "Φόρτωση κατάστασης"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "Παλαιότερη υποδοχή"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Σε αρχείο ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "Αποθήκευση κατάστασης"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "Αρχείο μπαταρίας..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Αρχείο κωδικών Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Στιγμιότυπο Gameshark"
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "Εισαγωγή"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "Εξαγωγή"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Καταγραφή οθόνης..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Έναρξη εγγραφής ήχου..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Διακοπή εγγραφής ήχου"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Έναρξη εγγραφής βίντεο..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Διακοπή εγγραφής βίντεο"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Έναρξη εγγραφής παιχνιδιού..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Διακοπή εγγραφής παιχνιδιού"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "Εγγραφή"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Έναρξη αναπαραγωγής ταινίας..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Διακοπή αναπαραγωγής ταινίας"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "Αναπαραγωγή"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "Εξομοίωση"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "Παύση"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "Επόμενο καρέ"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Επανάληψη"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Εναλλαγή πλήρους οθόνης"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "Λειτουργία τούρμπο"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "Αυτόματη παράλειψη καρέ"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "Παράλειψη BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "Αυτόματη διόρθωση των IPS/UPS/IPF"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "Παύση όταν είναι ανενεργό"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "Επαναφορά"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "Επιλογές"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "Σύνδεση"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Έναρξη σύνδεσης δικτύου ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "Τίποτα"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "Καλώδιο"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "Ασύρματα"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "Τοπική λειτουργία"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "Σύνδεση με την εκκίνηση"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "Αλλαγή ταχύτητας"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "Ρύθμιση ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "Βίντεο"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "Έναρξη σε πλήρη οθόνη"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "Διατήρηση αναλογίας εικόνας"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "Διγραμμικό φίλτρο"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "Διατήρηση παραθύρου στην κορυφή"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Γραμμή κατάστασης"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "Απενεργοποίηση ένδειξης οθόνης"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Διαφανής ένδειξη οθόνης"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "Ήχος"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "Παρεμβολή ήχου &GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "Βελτίωση ήχου &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "Εφέ surround ήχου &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "Αφαίρεση κλικ από ήχο &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "Είσοδος"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "Συνεχόμενα"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Ρύθμιση ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "Ρολόι πραγματικού χρόνου"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "Χρήση αρχείου BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "Εκτύπωση αποσφαλμάτωσης"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "Εκτυπωτής &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "Συλλογή πλήρους σελίδας πριν την εκτύπωση"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "Αποθήκευση εκτυπώσεων ως καταγραφές οθόνης"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "Χρήση αρχείου GB BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "Χρήση αρχείου GBC BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "Γενικά ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "Φάκελοι ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Συντομεύσεις πλήκτρων ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "Εργαλεία"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "Κωδικοί"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Λίστα κωδικών ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Εύρεση κωδικού ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Αυτόματη αποθήκευση/φόρτωση κωδικών"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "Ενεργοποίηση κωδικών"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "Διακοπή και χρήση GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "Ρύθμιση θύρας..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "Διακοπή στην εκκίνηση"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "Αποσύνδεση"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "Αποσυναρμολόγηση..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "Καταγραφή..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Προβολή &IO..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Προβολή &Map..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Προβολή μνήμης..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "Προβολή &OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Προβολή παλέτας..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Προβολή πλακιδίων..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "Προβολή επιπέδων"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Κανάλι &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Κανάλι &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Κανάλι &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Κανάλι &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Άμεσος ήχος &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Άμεσος ήχος &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Κανάλια ήχου"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "Βοήθεια"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Αναφορά σφαλμάτων"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "Φόρουμ υποστήριξης VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Μεταφράσεις"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/el_GR.po
+++ b/po/wxvbam/el_GR.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Greek (Greece) (http://www.transifex.com/bgk/vba-m/language/el_GR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/en_BR.po
+++ b/po/wxvbam/en_BR.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: English (Brazil) (http://www.transifex.com/bgk/vba-m/language/en_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/en_GB.po
+++ b/po/wxvbam/en_GB.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: English (United Kingdom) (http://www.transifex.com/bgk/vba-m/language/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/en_US.po
+++ b/po/wxvbam/en_US.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: English (United States) (http://www.transifex.com/bgk/vba-m/language/en_US/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es.po
+++ b/po/wxvbam/es.po
@@ -14,9 +14,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (http://www.transifex.com/bgk/vba-m/language/es/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,120 +56,120 @@ msgstr "Archivos de GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar
 msgid "Open GBC ROM file"
 msgstr "Abrir archivo ROM de GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CÁMARA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -180,230 +180,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Ninguno"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Seleccionar archivo de Código de Puntos"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "Código de Puntos e-Reader (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Seleccionar archivo de batería"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Archivo de batería (*.sav)|*.sav|Guardado rápido (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "La importación de un archivo de batería, borrará todos los juegos guardados (permanentemente después de la siguiente escritura). ¿Quieres continuar?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Confirmar importación"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Batería cargada %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Error cargando batería %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Seleccionar archivo de código"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Archivo de Código Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Archivo de Código Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "La importación de un archivo de código reemplazará cualquiera de los trucos cargados. ¿Quieres continuar?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "No se puede abrir el archivo %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Archivo de código no soportado %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Archivo de código cargado %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Error cargando archivo de código %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Seleccionar archivo de instantánea"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Instantáneas de GS y PAC (*.sps;*.xps)|*.sps;*.xps|Instantáneas de GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Instantánea de Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "La importación de un archivo de instantánea borrará todos los juegos guardados (permanentemente después de la siguiente escritura). ¿Quieres continuar?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Archivo de instantánea cargado %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Error cargando archivo de instantánea %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Batería escrita %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Error escribiendo batería %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "guardados EEPROM no pueden ser exportados"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Instantánea de Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exportado desde VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Archivo de instantánea guardado %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Error guardando archivo de instantánea %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Seleccionar archivo de salida"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "imágenes PNG|*.png|imágenes BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Instantánea escrita %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "archivos ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Archivos de películas VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Seleccionar archivo"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Seleccionar archivo de estado"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Archivos de juego guardado de VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Sonido activado"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Sonido desactivado"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volumen: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Establecer a 0 para pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Puerto para esperar por conexión:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Conexión GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Esperando por conexión en %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Esperando por conexión en puerto %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Esperando por GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulador de Nintendo GameBoy (+Color+Advance)"
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Derechos de autor (C) 1999-2003 Forgotten\nDerechos de autor (C) 2004-2006 equipo de desarrollo VBA\nDerechos de autor (C) 2007-2017 equipo de desarrollo VBA-M"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -419,11 +435,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Este programa es software libre: puedes redistribuirlo y/o modificarlo\nbajo los términos de Licencia Pública General de GNU como aparece publicado en\nla Fundación de Software Libre (Free Software Foundation), sea la versión 2 de esta Licencia, o\n(según su elección) cualquier versión posterior.\n\nEste programa es distribuido con la esperanza de que será útil,\npero SIN NINGUNA GARANTÍA; sin ni siquiera la garantía implícita de\nCOMERCIALIZACIÓN o APTITUD DE USO PARA UN PROPÓSITO EN PARTICULAR.  Lea\nLa Licencia Pública General de GNU para más detalles.\n\nUsted debería haber recibido una copia de la Licencia General Pública de GNU\njunto con este programa.  En caso contrario, vea http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "el enlace LAN ya esta activo. Desactivar modo de enlace para desconectar."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "La Red no esta soportada en modo local."
 
@@ -627,92 +643,96 @@ msgstr "%d cuadros = %.2f ms"
 msgid "Default device"
 msgstr "Dispositivo predeterminado"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Modo escritorio"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "No se encontraron complementos rpi usables en %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Complemento"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Por favor seleccione un complemento o un filtro diferente"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Error de selección de complemento"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Esto va a limpiar todos los aceleradores definidos por el usuario. ¿Estás seguro?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Icono principal no encontrado"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Panel de pantalla principal no encontrado"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Duplicar acelerador de menú: %s para %s y %s; manteniendo el primero"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Acelerador de menú %s para %s anula el predeterminado para %s ; manteniendo el primero"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Elemento del menú inválido %s; eliminando"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Código"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Descripción"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Dirección"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Valor Antiguo"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Valor Nuevo"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Comandos del menú"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Otros comandos"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "host de JoyBus inválido; desactivando"
 
@@ -771,99 +791,99 @@ msgstr "No se puede cargar ROM de Game Boy Advance %s"
 msgid " player "
 msgstr "jugador"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Estado cargado %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Error cargando estado %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Estado guardado %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Error guardando estado %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Modo de pantalla completa %dx%d-%d@%d no soportado; buscando algún otro"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Modo de pantalla completa %dx%d-%d@%d no soportado"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Modo válido: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Elegir modo %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Fallo al cambiar el modo a %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "No es un cartucho de GBA válido"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "No hay memoria para rebobinar"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Error escribiendo estado de rebobinado"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "error de asignación de memoria"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "error inicializando códec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "error escribiendo al archivo de salida"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "no se puede adivinar el formato de salida desde el nombre de archivo"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "error programando; ¡abortando!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "No es posible empezar a grabar a %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Error en la grabación de audio/vídeo (%s); abortando"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Error en la grabación de audio (%s); abortando"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Error en la grabación de vídeo (%s); abortando"
@@ -933,12 +953,12 @@ msgstr "&Cerrar"
 msgid "Printed"
 msgstr "Impreso"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Error abriendo pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Error configurando el enchufe del servidor (%d)"
@@ -1337,7 +1357,7 @@ msgstr "&Agregar truco"
 msgid "Edit Cheat"
 msgstr "Editar Truco"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Tipo"
 
@@ -2309,8 +2329,8 @@ msgstr "Suma de comprobación:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2587,7 +2607,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Haz clic en un campo y pulsa una tecla o mueve el joystick para agregar. Presione la tecla de retroceso para borrar última tecla añadida. Cambia el tamaño de la ventana o haz clic en el interior y mueve el puntero para ver todo el contenido, si es demasiado pequeño."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Arriba"
 
@@ -2595,7 +2615,7 @@ msgstr "Arriba"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Abajo"
 
@@ -2603,7 +2623,7 @@ msgstr "Abajo"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Izquierda"
 
@@ -2611,7 +2631,7 @@ msgstr "Izquierda"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Derecha"
 
@@ -2619,11 +2639,11 @@ msgstr "Derecha"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2747,633 +2767,657 @@ msgstr "Verboso"
 msgid "&File"
 msgstr "&Archivo"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Abrir &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Abrir GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Abrir recie&nte"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Reiniciar lista reciente"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Congelar lista reciente"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "In&formación del ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Cargar Código de Puntos..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Guardar Código de Puntos..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Mas &reciente"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&Auto cargar el más reciente"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Desde &Archivo ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "No cambiar guardados de &batería"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "No cambiar lista de &trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Cargar estado"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&Ranura mas antigua"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Al &Archivo ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Guardar estado"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "Archivo de &batería..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "archivo de &código Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "instantánea de Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importar"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Exportar"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Capt&ura de pantalla..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Iniciar grabación de &sonido..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Detener grabación de s&onido"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Iniciar grabación de &vídeo..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Detener grabación de v&ídeo"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Iniciar grabación del &juego..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Detener grabación del j&uego"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "Grabar"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Iniciar reproducción de &película..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Detener reproducción de p&elícula"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Reproducir"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulación"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Pausar"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Siguiente cuadro"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Rebobinar"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Activar &pantalla completa"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "Modo &turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Auto saltar cuadros"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&Saltar BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Auto parchar IPS/UPS/IPF"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Pausar cuando esté inactivo"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Reiniciar"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Opciones"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Enlace"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Iniciar &Enlace de Red ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Nada"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Cable"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Inalámbrica"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "Modo &local"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Enlace al arrancar"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Hack de velocidad"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Configurar ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Vídeo"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Iniciar en pantalla completa"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&Mantener relación de aspecto"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "Filtro &bilineal"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Mantener la ventana por encima"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "&Barra de estado"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Desactivar visualización en pantalla"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "&Visualización en pantalla transparente"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Audio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "interpolación de sonido &GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "mejora de sonido &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "efecto de sonido envolvente &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "eliminación de clics de sonido &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Entrada"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Autodisparo"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Configurar ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "Reloj de &tiempo real"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Usar archivo BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Impresión de depuración"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "impresora &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Reunir una página completa antes de imprimirla"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Guardar impresiones como capturas de pantalla"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Usar archivo BIOS de GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Usar archivo BIOS de GBC"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&General ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "D&irectorios ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Atajos de &Tecla ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Herramientas"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Listar &trucos ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Encontrar t&ruco ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Guardar/Cargar trucos a&utomáticamente"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Activar trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "&Detenerse en el GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Configurar puerto..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "&Detenerse al cargar"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Desconectar"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Desensamblar..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Registrando..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Visor de &IO..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Visor de &Mapa..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Visor de M&emoria..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "Visor &OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Visor de &Paleta..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "&Visor de Tile..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Ver Capas"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Canal &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Canal &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Canal &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Canal 4&"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Canales de &Sonido"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Ayuda"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Reportar &Errores"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "&Foro de Soporte VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Traducciones"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_419.po
+++ b/po/wxvbam/es_419.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (Latin America) (http://www.transifex.com/bgk/vba-m/language/es_419/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr "Abrir ROM de GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr "Ninguno"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Selecciona Archivo de Batería"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Si importas un archivo de batería se borraran los juegos guardados(Permanentemente antes de la escritura)¿Quieres Continuar?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Confirmar importe"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Batería Cargada %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Error cargando la batería %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Selecciona Archivo de Código"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Archivo de Código de Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Archivo de Código de Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Importando un Código de Archivo remplazarás cualquier truco cargado ¿Quieres continuar?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "No se puede abrir el archivo %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Archivo no soportado %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Archivo cargado %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Error cargando Archivo %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2589,7 +2609,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2597,7 +2617,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2605,7 +2625,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2613,11 +2633,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_AR.po
+++ b/po/wxvbam/es_AR.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (Argentina) (http://www.transifex.com/bgk/vba-m/language/es_AR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "Archivos GameBoy Color\n(*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|
 msgid "Open GBC ROM file"
 msgstr "Abrir archivo ROM GameBoy Color"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2589,7 +2609,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2597,7 +2617,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2605,7 +2625,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2613,11 +2633,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_CL.po
+++ b/po/wxvbam/es_CL.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (Chile) (http://www.transifex.com/bgk/vba-m/language/es_CL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_CO.po
+++ b/po/wxvbam/es_CO.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (Colombia) (http://www.transifex.com/bgk/vba-m/language/es_CO/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_CR.po
+++ b/po/wxvbam/es_CR.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (Costa Rica) (http://www.transifex.com/bgk/vba-m/language/es_CR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_ES.po
+++ b/po/wxvbam/es_ES.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (Spain) (http://www.transifex.com/bgk/vba-m/language/es_ES/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -51,120 +51,120 @@ msgstr "Ficheros de GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar
 msgid "Open GBC ROM file"
 msgstr "Abrir ROM de GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -175,230 +175,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Ninguno"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Seleccionar fichero de batería"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Fichero de batería (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importar un fichero de batería borrará cualquier partida guardada (permanentemente después de la siguiente escritura). ¿Desea continuar?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Confirmar importado"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Batería %s cargada"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Error cargando la batería %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Seleccionar fichero de código"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Fichero de Código Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Fichero de Código Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Importar un fichero de código remplazará cualquier truco cargado. ¿Desea continuar?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "No se puede abrir el fichero %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Fichero de código %s no soportado"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Fichero de código %s cargado"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Error cargando el fichero de código %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Selecciona fichero de instantánea"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Instantánea de Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exportado de VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Sonido activado"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Sonido desactivado"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volumen: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulador de Nintendo GameBoy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -414,11 +430,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -622,92 +638,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Modo escritorio"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Valor antiguo"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Valor nuevo"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -766,99 +786,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "No es un cartucho de GBA valido"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -928,12 +948,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1332,7 +1352,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr "Editar truco"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2304,8 +2324,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2582,7 +2602,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2590,7 +2610,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2598,7 +2618,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2606,7 +2626,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2614,11 +2634,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2742,633 +2762,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Activar trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_MX.po
+++ b/po/wxvbam/es_MX.po
@@ -13,9 +13,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (Mexico) (http://www.transifex.com/bgk/vba-m/language/es_MX/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,120 +55,120 @@ msgstr "Archivos de GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar
 msgid "Open GBC ROM file"
 msgstr "Abrir archivo ROM de GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Desconocido"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "CÁMARA ROM+POCKET"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -179,230 +179,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Ninguno"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Seleccionar archivo punto código"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e.Reader punto código "
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Seleccionar archivo de partida"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Archivo de partida (*.sav)|*.sav|Guardado en flash (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importar un archivo de partida borrará cualquier juego guardado (permanentemente después de la siguiente escritura). ¿Quieres continuar?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Confirmar"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Partida cargada %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Error al cargar partida %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Selecciona archivo de truco"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Archivo de código Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Archivo de código Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Importar un archivo de código reemplazará cualquie código cargado. ¿Quieres continuar?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "No se puede abrir el archivo %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Archivo de código %s no soportado"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Archivo de código %s cargado"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Error al cargar el archivo de código %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Seleccionar archivo de captura"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Instantaneas de GS y PAC (*.sps;*.xps)|*.sps;*.xps|Instantáneas de GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Instantánea de Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importar un archivo de instantánea borrará cualquier juego guardado (permanentemente después de la siguiente escritura). ¿Quieres continuar?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Archivo de instantánea %s cargado"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Error al cargar el archivo de instantánea %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Batería %s escrita"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Error al escribir en batería %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "No se pueden exportar las partidas guardadas EEPROM"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Instantánea de Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exportado desde VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Archivo de instantánea %s guardado"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Error al guardar el archivo de instantánea %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Seleccionar archivo de salida"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Imágenes PNG|*.png|Imágenes BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Instantánea %s escrita"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "archivos ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Archivos de película VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Seleccionar archivo"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Seleccionar archivo de estado"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Archivos de juego guardado de VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Sonido Habilitado"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Sonido inhabilitado"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volumen: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Poner en 0 para pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Puerto de espera para conexión:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Conexión GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Esperando conexión en %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Esperando conexión en el puerto %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Esperando GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulador de Nintendo GameBoy (+Color+Advance)"
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Derechos Reservados (C) 1999-2003 Olvidado\nDerechos Reservados (C) 2004-2006 VBA Equipo de Desarrollo\nDerechos Reservados (C) 2007-2017 VBA-M Equipo de Desarrollo"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -418,11 +434,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Este programa es software libre: puedes redistribuirlo o modificarlo\nbajo de la Licencia Pública General GNU como lo publica \nla Fundación de Software Libre, ya sea la versión 2 de la licencia, o (a tu elección) cualquier versión más reciente.\n\nEste programa se distribuye con  la esperanza de que será útil,\npero SIN GARANTÍA ALGUNA; aun sin garantía implícita de MERCANTIBILIDAD o CONVENIENCIA PARA UN PROPÓSITO EN PARTICULAR. Consulta la\nLicencia Pública General GNU para más detalles.\n\nDeberías haber recibido una copia de la Licencia Pública General GNU \njunto con este programa. Si no, consulta http://www.gnu.org/licenses."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "El enlace LAN ya está activo. Inhabilita el modo enlace para desconectar."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "La red no es soportada en modo local."
 
@@ -626,92 +642,96 @@ msgstr "%d cuadros = %.2f ms"
 msgid "Default device"
 msgstr "Dispositivo predeterminado"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Modo de escritorio"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Complementos rpi no utilizables encontrados en %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Complemento"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Elige un complemento o un filtro diferente, por favor"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Error de elección de complemento"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Esto borrará todos los aceleradores definidos por el usuario. ¿Estás seguro?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Icono principal no encontrado"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Pantalla principal no encontrada"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Acelerador de menú duplicado. %s para %s y %s; conservando el primero"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Acelerador de menú %s para %s anula al predeterminado para %s; manteniendo el menú"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Objeto de menú inválido %s; removiendo"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Código"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Descripción"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Dirección"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Valor Antiguo"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Valor Nuevo"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Comandos de menú"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Otros comandos"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Host de JoyBus inválido; inhabilitando"
 
@@ -770,99 +790,99 @@ msgstr "Incapaz de cargar ROM de Game Boy Advance %s"
 msgid " player "
 msgstr "jugador"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Estado %s cargado"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Error al cargar el estado %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Estado %s guardado"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Error al guardar el estado %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Modo de pantalla completa %dx%d-%d@%d no soportado; buscando otro"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Modo de pantalla completa %dx%d-%d@%d no soportado"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Modo válido: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Modo elegido %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Fallo al cambiar el modo a %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "No es un cartucho GBA válido"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "No hay memoria para rebobinar"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Error al escribir en estado de rebobinado"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "error de asignación de memoria"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "error al iniciar códec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "error al escribir en archivo de salida"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "no se puede averiguar formato de salida desde el nombre de archivo"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "error de programación; ¡abortando!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Incapaz de iniciar a grabar a %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Error en grabación de audio/video (%s); abortando"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Error en grabación de audio (%s); abortando"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Error en grabación de video (%s); abortando"
@@ -932,12 +952,12 @@ msgstr "&Cerrar"
 msgid "Printed"
 msgstr "Impreso"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Error al abrir pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Error al configurar socket del servidor (%d)"
@@ -1336,7 +1356,7 @@ msgstr "&Agregar truco"
 msgid "Edit Cheat"
 msgstr "Modificar truco"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Tipo"
 
@@ -2308,8 +2328,8 @@ msgstr "Suma de comprobación:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2586,7 +2606,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Haz clic en un campo y presiona una tecla o mueve la palanca para agregar. Pulsa retroceso para borrar la ultima tecla añadida. Redimensiona la ventana o haz clic dentro y mueve el puntero para ver todo el contenido si es muy pequeño."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Arriba"
 
@@ -2594,7 +2614,7 @@ msgstr "Arriba"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Abajo"
 
@@ -2602,7 +2622,7 @@ msgstr "Abajo"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Izquierda"
 
@@ -2610,7 +2630,7 @@ msgstr "Izquierda"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Derecha"
 
@@ -2618,11 +2638,11 @@ msgstr "Derecha"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2746,633 +2766,657 @@ msgstr "Verboso"
 msgid "&File"
 msgstr "&Archivo"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Abrir &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Abrir GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Abrir reciente"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "Borrar lista de recientes"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "Congelar lista de recientes"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "Información de la ROM"
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Cargar Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Guardar Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Más reciente"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "Cargar automáticamente el más reciente "
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "10"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Desde el archivo.."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "No cambiar y guardar partida"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "No cambiar y lista de trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "Cargar estado"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "Cargar estado más antigua"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Al archivo..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "Guardar estado"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "Archivo de partida"
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Archivo de Gameshark y trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Gameshark snapshot..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "Importar"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "Exportar"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Capturar pantalla"
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Comenzar a grabar el sonido"
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Dejar de grabar el sonido"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Comenzar a grabar el video"
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Dejar de grabar el video"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Comenzar de grabar el juego"
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Dejar de grabar el juego"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "Grabar"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Empezar a reproducir película..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Dejar de reproducir película"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "Jugar"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "Emulacion"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "Pausa"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "Siguiente frame"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Rebobinar"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Cambiar a pantalla completa"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "Modo turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "Saltear automáticamente los frames"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "Saltar BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "Parchar automáticamente IPS/UPS/IPF"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "Pausar cuando estas inactivo"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "Reiniciar"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "Opciones"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "Enlace "
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Comenzar enlace a la red"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "Nada"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "Cable"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "Inalambrico"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "GameBoy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "Modo local"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "Enlazar para arrancar"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "Configurar..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "Video"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "Iniciar en pantalla completa"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "Mantener radio de aspecto"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "Filtro Bilineal"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "Mantener ventana al frente"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Barra de estado"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "Desactivar mostrar en pantalla"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Mostrar en pantalla transparente"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "Audio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "GBA interpolación de sonido"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "GB mejora de sonido"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "GB efecto de sonido surround"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "Controles"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Configuracion"
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "Reloj en tiempo real"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "Usar archivo BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "Depurar impresión"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "GB Impresora"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "Reunir una página completa antes de imprimir"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "Guardar impresiones como capturas de pantalla"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "Usar archivo BIOS de GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "Usar archivo BIOS de GBC"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "General"
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "Directorios"
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Atajos de Teclas"
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "Herramientas"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "Trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Lista de trucos..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Encontrar truco..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Guardar/Cargar trucos automáticamente"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "Activar Trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "Configurar puerto..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "Desconectar"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "Ver Capas"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Canal 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Canal 2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Canal 3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Canal 4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Sonido Directo A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Sonido Directo B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Canales de Sonido"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "Ayuda"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Reportes Y Errores"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M Foro y Soporte"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Traducciones"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_PE.po
+++ b/po/wxvbam/es_PE.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (Peru) (http://www.transifex.com/bgk/vba-m/language/es_PE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_PR.po
+++ b/po/wxvbam/es_PR.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (Puerto Rico) (http://www.transifex.com/bgk/vba-m/language/es_PR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_US.po
+++ b/po/wxvbam/es_US.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (United States) (http://www.transifex.com/bgk/vba-m/language/es_US/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/es_VE.po
+++ b/po/wxvbam/es_VE.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Spanish (Venezuela) (http://www.transifex.com/bgk/vba-m/language/es_VE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/fa.po
+++ b/po/wxvbam/fa.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Persian (http://www.transifex.com/bgk/vba-m/language/fa/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr "اجرای فایل بازی گیم بوی کالر"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "ناشناخته"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "انتخاب فایل باتری"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "انتخاب فایل"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "صدا فعال شد"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "صدا غیر فعال شد"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "حالت دسکتاپ"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "تایید"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "توضیح"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "آدرس"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr "بازیکن"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "فایل ذخیره شده"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "خطا در ذخیره کردن بازی"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "بالا"
 
@@ -2589,7 +2609,7 @@ msgstr "بالا"
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "پایین"
 
@@ -2597,7 +2617,7 @@ msgstr "پایین"
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "چپ"
 
@@ -2605,7 +2625,7 @@ msgstr "چپ"
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "راست"
 
@@ -2613,11 +2633,11 @@ msgstr "راست"
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "سلکت (انتخاب)"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "استارت"
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/fil.po
+++ b/po/wxvbam/fil.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Filipino (http://www.transifex.com/bgk/vba-m/language/fil/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/fr.po
+++ b/po/wxvbam/fr.po
@@ -19,9 +19,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: French (http://www.transifex.com/bgk/vba-m/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -61,120 +61,120 @@ msgstr "Fichiers GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*
 msgid "Open GBC ROM file"
 msgstr "Ouvrir un fichier ROM GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -185,230 +185,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Aucun"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Sélectionner un fichier Dot Code"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Sélectionner une sauvegarde native"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Sauvegarde native (*.sav)|*.sav|Sauvegarde Flash (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "En important une sauvegarde native, toutes les sauvegardes de jeu seront supprimées (de manière permanente après la prochaine écriture). Voulez-vous continuer ?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Confirmer l'importation"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Sauvegarde native %s chargée"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Erreur durant le chargement de la sauvegarde native %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Sélectionner le fichier de codes de triche"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Fichier de codes de triche Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Fichier de codes de triche Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "En important un fichier code, tous les codes de triche seront remplacés. Voulez-vous continuer ?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Impossible d'ouvrir le fichier %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Fichier de codes de triche %s non supporté"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Fichier de codes de triche %s chargé"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Erreur durant le chargement du fichier de codes de triches %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Sélectionner un fichier d'instantané"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Instantanés GS & PAC (*.sps;*.xps)|*.sps;*.xps|Instantanés GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Instantané Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "En important un instantané, toutes les sauvegardes de jeu seront supprimées (de manière permanente après la prochaine écriture). Voulez-vous continuer ?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Instantané %s chargé"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Erreur durant le chargement de l'instantané %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Sauvegarde native %s écrite"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Erreur durant l'écriture de la sauvegarde native %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Les sauvegardes EEPROM ne peuvent pas être exportées"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Instantané Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exporté depuis VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Instantané %s sauvegardé"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Erreur durant la sauvegarde de l'instantané %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Sélectionner le fichier de sortie"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Images PNG|*.png|Images BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Instantané %s écrit"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "fichiers ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Fichiers VBA Movie|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Sélectionner le fichier"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Sélectionner le fichier d'état"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Fichiers de sauvegarde de jeu VisualBoyAdvance |*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Son activé"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Son désactivé"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volume : %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Instancier à 0 pour pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Port à attendre pour la connexion :"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Connexion GBD"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "En attente de la connexion à %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "En attente de la connexion sur le port %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "En attente de GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Émulateur Nintendo GameBoy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA development team\nCopyright (C) 2007-2017 VBA-M development team"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -424,11 +440,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "This program is free software: you can redistribute it and/or modify\nit under the terms of the GNU General Public License as published by\nthe Free Software Foundation, either version 2 of the License, or\n(at your option) any later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License\nalong with this program.  If not, see http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "La connexion LAN est déjà active. Désactiver le mode Link pour se déconnecter."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Réseau non supporté en mode local."
 
@@ -632,92 +648,96 @@ msgstr "%d images = %.2f ms"
 msgid "Default device"
 msgstr "Périphérique par défaut"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Mode bureau"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Extension rpi utilisable non trouvée dans %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Extension"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "S'il-vous-plaît sélectionner une extension ou un filtre différent"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Erreur de sélection d'extension"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Ceci nettoiera tous les accélérateurs définis par l'utilisateur. Etes-vous sûr ?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Icône principale non trouvée"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Panel d'affichage principal non trouvé"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Dupliquer le menu d'accélérateur : %s pour %s et %s; le premier conservé"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Menu d'accélérateur %s pour %s annule par défaut pour %s ; menu conservé"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Élément du menu %s non valide; suppression"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Code"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Description"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Adresse"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Ancienne valeur"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Nouvelle valeur"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Menu de commandes"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Autres commandes"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Hôte JoyBus non valide; désactivation"
 
@@ -776,99 +796,99 @@ msgstr "Impossible de charger la ROM Game Boy Advance %s"
 msgid " player "
 msgstr "joueur"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "État %s chargé"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Erreur durant le chargement de l'état %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "État %s chargé"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Erreur durant la sauvegarde de l'état %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Mode plein écran %dx%d-%d@%d non supporté ; à la recherche d'un autre"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Mode plein écran %dx%d-%d@%d non supporté"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Mode valide : %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Mode %dx%d-%d@%d choisi"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Echec du changement de mode à %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Cartouche GBA non valide"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Mémoire insuffisante pour le rembobinage"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Erreur durant l'écriture de l'état du rembobinage"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "Erreur d'allocation mémoire"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "Erreur durant l'initialisation du codec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "Erreur durant l'écriture du fichier de sortie"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "Ne peut pas deviner l'extension du nom du fichier de sortie"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "Erreur de programmation : interruption immédiate !"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Impossible de démarrer l'enregistrement à %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Erreur durant l'enregistrement audio/vidéo (%s) : interruption immédiate !"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Erreur durant l'enregistrement audio (%s) ; interruption immédiate !"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Erreur durant l'enregistrement vidéo (%s) ; interruption immédiate !"
@@ -938,12 +958,12 @@ msgstr "&Fermer"
 msgid "Printed"
 msgstr "Imprimé"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Erreur durant l'ouverture de pseudo tty : %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Erreur de la configuration du socket du serveur (%d)"
@@ -1342,7 +1362,7 @@ msgstr "&Ajouter un code de triche"
 msgid "Edit Cheat"
 msgstr "&Modifier le code de triche"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Type"
 
@@ -2314,8 +2334,8 @@ msgstr "Checksum :"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2592,7 +2612,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Cliquez sur un champ et pressez une touche ou bougez le joystick pour ajouter. Pressez la touche Retour Arrière pour effacer la dernière touche ajoutée. Redimensionnez la fenêtre ou cliquez à l'intérieur et bougez le pointeur pour voir le contenu entier si trop petit."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Haut"
 
@@ -2600,7 +2620,7 @@ msgstr "Haut"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Bas"
 
@@ -2608,7 +2628,7 @@ msgstr "Bas"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Gauche"
 
@@ -2616,7 +2636,7 @@ msgstr "Gauche"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Droite"
 
@@ -2624,11 +2644,11 @@ msgstr "Droite"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2752,633 +2772,657 @@ msgstr "Verbeux"
 msgid "&File"
 msgstr "&Fichier"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "&Ouvrir GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Ouvrir GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Ouvrir réce&nt"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Réinitialiser la liste récente"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Figer la liste récente"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "In&formations de la ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Charger le Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Sauvegarder le Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Le plus &récent"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&Charger automatiquement le plus récent"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Depuis le &fichier..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Ne pas changer la &sauvegarde native"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Ne pas changer la liste de &codes de triche"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Charger l'état"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&Emplacement le plus vieux"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Dans le &fichier..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Sauvegarder l'état"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&Fichier de sauvegarde native..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Fichier de &code Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Instantané Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importer"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Exporter"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "&Capture d'écran"
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Démarrer l'enregistrement &audio..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Arrêter l'enregistrement a&udio"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Démarrer l'enregistrement &vidéo..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Arrêter l'enregistrement v&idéo"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Démarrer l'enregistrement du &jeu..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Arrêter l'enregistrement du j&eu"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Enregistrer"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "&Démarrer la lecture de l'enregistrement..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "&Arrêter la lecture de l'enregistrement"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Jouer"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Émulation"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Pause"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Image suivante"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Rem&bobiner"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "&Basculer en mode plein écran"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Mode Turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&Synchronisation verticale"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Ignorer automatiquement les images"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&Ignorer le BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Patch IPS/UPS/IPF automatique"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "%Mettre en pause lorsque inactif"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Réinitialiser"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Options"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Lier"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Démarrer une &connexion Link"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Aucun"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Câble"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Sans fil"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Mode local"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "%Connexion Link au démarrage"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Speed hack"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Configurer..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Vidéo"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Démarrer en plein écran"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&Conserver le rapport hauteur/largeur d'image"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "&Filtre bilinéaire"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Toujours visible"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "&Barre d'état"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Désactiver l'affichage à l'écran"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "&Affichage à l'écran transparent"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Audio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&Échantillonnage audio GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&Amélioration audio GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&Effet son multicanal GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "&Correction du craquement audio GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Entrée"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Tir automatique"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Configurer..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&Horloge temps réel (RTC)"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Utiliser le fichier BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Déboguer l'imprimante"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&Imprimante GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Créer une page complète avant l'impression"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Sauvegarder les sorties de l'imprimante comme des captures d'écran"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Utiliser le fichier BIOS de GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Utiliser le fichier BIOS de GBC"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Général..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "&Dossiers..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "&Raccourcis clavier..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Outils"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Codes de triche"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Lister les &codes de triche..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Trouver un c&ode de triche..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Sauvegarder/charger les codes de triche a&utomatiquement"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Activer les codes de triche"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "&Ouvrir GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Configurer le port..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "&Pause au chargement"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Déconnecter"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GBD"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Désassembler..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Enregistrement..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Visualiseur de &IO..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Visualiseur de &carte..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Visualiseur de m&émoire..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "Visualiseur de &OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Visualiseur de &palette..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Visualiseur de &tuile..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Voir les couches"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Canal &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Canal &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Canal &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Canal &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&Canaux audio"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Aide"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Rapporter un ou plusieurs &bugs"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "&Forum d'aide VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Traductions"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/fr_CA.po
+++ b/po/wxvbam/fr_CA.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: French (Canada) (http://www.transifex.com/bgk/vba-m/language/fr_CA/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/fr_FR.po
+++ b/po/wxvbam/fr_FR.po
@@ -13,9 +13,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: French (France) (http://www.transifex.com/bgk/vba-m/language/fr_FR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,120 +55,120 @@ msgstr "Fichiers GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*
 msgid "Open GBC ROM file"
 msgstr "Ouvrir un Fichier ROM GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM "
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2 "
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT "
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MBC2+BATT "
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM "
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT "
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT "
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3 "
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT "
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5 "
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM "
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT "
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE "
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM "
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT "
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT "
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "Game Génie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0 "
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA "
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5 "
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3 "
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1 "
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -179,230 +179,246 @@ msgstr "ROM+HuC-1 "
 msgid "None"
 msgstr "Aucun"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Choisir le fichier Code Dot"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "Code Dot e-Reader (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Choisir un fichier batterie"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Fichier Batterie (*.sav)|*.sav|Sauvegarde Flash (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "L'importation d'un fichier batterie effacera tous les jeux sauvegardés (et de manière définitive après l'écriture suivante). Souhaitez-vous continuer ?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Confirmer l'importation"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Batterie chargée %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Erreur de chargement de la batterie %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Sélectionner un fichier code"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Fichier Code Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Fichier Code Gameshark (*.gcf)|*.gcf "
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "L'importation d'un fichier code remplacera tous les codes de triche chargés. Souhaitez-vous continuer ?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Ne peut pas ouvrir le fichier %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Fichier code non supporté %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Chargement d'un fichier code %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Erreur de chargement du fichier code %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Sélectionner une copie d'écran"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Copies d'Écran GS & PAC (*.sps;*.xps)|*.sps;*.xps|Copies d'Écran GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Copies d'Écran Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "L'importation d'un fichier de copie d'écran effacera toutes les sauvegardes de jeux (et ce de manière définitive après l'écriture suivante). Souhaitez-vous continuer ?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Copie d'écran chargée %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Erreur de chargement du fichier de copie d'écran %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Écriture de la batterie %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Erreur d'écriture sur la batterie %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Les sauvegardes de l'EEPROM ne peuvent pas être exportées"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Copies d'Écran Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exporté depuis VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Fichier de copie d'écran sauvegardé %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Erreur de sauvegarde du fichier de copie d'écran %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Sélectionner le fichier de sortie"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Images PNG|*.png|Images BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Écriture de la copie d'écran %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr " fichiers ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Fichiers Film VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Sélectionner un fichier"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Sélectionner un fichier d'état"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Fichiers de sauvegardes VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Son activé"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Son désactivé"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volume : %d %%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Mettre sur 0 pour le pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Port en attente de connexion :"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Connexion GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "En attente de connexion sur %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "En attente de connexion sur le port %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "En attente de GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Émulateur Nintendo GameBoy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 Équipe de développement de VBA\nCopyright (C) 2007-2017 Équipe de développement de VBA-M"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -418,11 +434,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Ce programme est un logiciel libre : vous pouvez le redistribuer et/ou le modifier sous les conditions de la GNU General Public License telle qu'elle est publiée par la Free Software Foundation, soit la version 2 de la Licence, ou (selon votre choix) toute autre version supérieure.\n\nCe programme est distribué dans l'espoir qu'il sera utile, mais SANS AUCUNE GARANTIE ; sans même l'implication de la garantie d'une COMMERCIALISATION ou LORS D'UN USAGE EN PARTICULIER. Consultez les conditions de la \nLicence GNU General Public pour plus de détails.\n\nVous devez avoir reçu une copie de la Licence GNU General Public License avec ce programme, si non, consultez le site  http://www.gnu.org/licenses."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "Le lien LAN est déjà actif. Désactiver le mode Lien pour se déconnecter."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Le réseau n'est pas supporté en mode local."
 
@@ -626,92 +642,96 @@ msgstr "%d images = %.2f ms"
 msgid "Default device"
 msgstr "Périphérique par défaut"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Mode Bureau"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Aucun plugin RPI utilisable n'a été trouvé dans %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Module externe"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Veuillez sélectionner un module externe ou un filtre différent"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Erreur de sélection du module externe"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Ceci videra tous les accélérateurs définis par l'utilisateur. Êtes-vous sûr ?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "L'icône principal n'a pas été trouvé"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "L'onglet d'affichage principal n'a pas été trouvé"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Dupliquer le menu accélérateur : %s pour %s et %s; garde le premier"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Menu accélérateur %s pour %s annuler par défaut pour %s ; garde le menu"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Objet menu invalide %s; suppression"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Code"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Déscription"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Adresse"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Ancienne valeur"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Nouvelle valeur"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Commandes du menu"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Autres commandes"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Hôte JoyBus invalide ; désactivation"
 
@@ -770,99 +790,99 @@ msgstr "Ne peut pas charger la ROM Game Boy Advance %s"
 msgid " player "
 msgstr "joueur"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "État chargé %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Erreur de chargement d'état %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "État sauvegardé %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Erreur de sauvegarde d'état %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Mode plein écran %dx%d-%d@%d non supporté ; recherche d'un autre mode"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Le mode plein écran %dx%d-%d@%d non supporté"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Mode valide : %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Choisir un mode %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "A échoué pour le changement de mode vers %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "N'est pas une cartouche GBA valide"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Pas de mémoire pour le rembobinage"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Erreur d'écriture pour l'état de rembobinage"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "erreur d'allocation de la mémoire"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "erreur d'initialisation du codec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "erreur d'écriture du fichier de sortie"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "ne peut pas deviner le format de sortie du nom de fichier"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "erreur de programmation ; arrêt !"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Ne peut pas commencer l'enregistrement de %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Erreur dans l'enregistrement audio/vidéo (%s); arrêt"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Erreur dans l'enregistrement audio (%s) ; arrêt"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Erreur dans l'enregistrement vidéo (%s) ; arrêt"
@@ -932,12 +952,12 @@ msgstr "&Fermer"
 msgid "Printed"
 msgstr "Imprimé"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Erreur de l'ouverture du pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Erreur du paramétrage du socket du serveur (%d)"
@@ -1336,7 +1356,7 @@ msgstr "&Ajouter un code de triche"
 msgid "Edit Cheat"
 msgstr "Éditer un code de triche"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Type"
 
@@ -2308,8 +2328,8 @@ msgstr "Checksum :"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2586,7 +2606,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Cliquer sur un champ et presser une touche ou bouger l'analogique pour ajouter. Presser la touche « retour arrière » pour effacer la dernière touche ajoutée. Redimensionner la fenêtre ou cliquer à l'intérieur et bouger le pointeur pour voir les contenus en entier si trop petit."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Haut"
 
@@ -2594,7 +2614,7 @@ msgstr "Haut"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Bas"
 
@@ -2602,7 +2622,7 @@ msgstr "Bas"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Gauche"
 
@@ -2610,7 +2630,7 @@ msgstr "Gauche"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Droite"
 
@@ -2618,11 +2638,11 @@ msgstr "Droite"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2746,634 +2766,658 @@ msgstr "Verbose"
 msgid "&File"
 msgstr "&Fichier"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Ouvrir &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Ouvrir GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Ouvrir jeu réce&nt"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Redémarrer la liste récente"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Geler la liste récente"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "In&formation sur la ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Charger un code Dot..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Sauvegarder un code Dot..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Le plus &récent"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "Charger &automatiquement le plus récent"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Depuis le &fichier..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Ne pas changer la sauvegarde de la &batterie"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Ne pas changer la liste de &codes de triche"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Charger un état"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "Emplacement le &plus ancien"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Vers le &fichier..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Sauvegarder un état"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "Fichier &batterie..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Fichier &code Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Copie d'écran &Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importer"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Exporter"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Capt&ure d'Ecran..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Démarrer l'enregistrement du &son..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Arrêter l'enregistrement du s&on"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Démarrer l'enregistrement &vidéo..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Arrêter l'enregistrement v&idéo"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Démarrer l'enregistrement du &jeu..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Arrêter l'enregistrement du j&eu"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Enregistrer"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Démarrer la lecture du &film..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Arrêter la lecture du f&ilm"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Jouer"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Émulation"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Pause"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Image suivante"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Re&mbobiner"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Basculer en &plein écran"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Mode turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "Saut d'images &automatique"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "Pa&sser le BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "Patch IPS/UPS/IPF &automatique"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Pause quand inactif"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Redémarrer"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Options"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Link"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Démarrer le Link en &réseau..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "Rie&n"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Câble"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Sans fil"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "Mode &local"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Link au démarrage"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "Hack pour la vite&sse"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Configurer..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Vidéo"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Démarrer en plein écran"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "Conse&rver les proportions"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "Filtre &bilinéaire"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Garder la fenêtre en premier plan"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Barre de &statut"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Désactiver l'affichage à l'écran"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Affichage &transparent à l'écran"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Audio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr "Augmenter le volume"
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr "Baisser le volume"
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "Interpolation du son de la &GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "Amélioration du son de la &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "Effet de son surround pour la &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "Décliquer le son de la &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Contrôleur"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "Tir &automatique"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Configurer..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "Horloge en temps &réel"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Utiliser le fichier BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "Imprimer le &débug"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "Imprimante &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Assembler une page complète avant d'imprimer"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Sauvegarder les sorties d'impression en tant que captures d'écrans"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Utiliser le fichier BIOS GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Utiliser le fichier BIOS GBC"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Général..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "Réperto&ires..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Raccourcis des &touches..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "Ou&tils"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Codes de triche"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Liste de &codes de triche..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Trouver un c&ode de triche..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Sauvegarder/charger a&utomatiquement les codes de triche"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Activer les codes de triche"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "&Rupture dans le GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Configurer le port..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "&Rupture au chargement"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Déconnecter"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Désassembler..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Journalisation..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Visualiseur &ES..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Visualiseur &MAP..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Visualiseur de mémoir&e..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "Visualiseur &OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Visualiseur de &palette..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Visualiseur de &tuile..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Visualiseur de couches"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Canal &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Canal &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Canal &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Canal &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Canaux &son"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Aide"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Rapporter des &bogues"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "&Forum de support pour VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Traductions"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
 msgstr "Réinitialisation"
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
+msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4
 msgid "Map Viewer"

--- a/po/wxvbam/gl.po
+++ b/po/wxvbam/gl.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Galician (http://www.transifex.com/bgk/vba-m/language/gl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -51,120 +51,120 @@ msgstr "Ficheiros de GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.ra
 msgid "Open GBC ROM file"
 msgstr "Abrir ficheiro ROM de GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Descoñecido"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -175,230 +175,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Ningún"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Seleccionar ficheiro de Código de Puntos"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "Código de Puntos e-Reader (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Seleccione o ficheiro de batería"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Ficheiro de batería (*.sav)|*.sav|Gardado rápido (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "A importación dun ficheiro de batería, borrará tódalas partidas gardadas (permanentemente despois da seguinte escritura). Queres continuar?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Confirmar importación"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Batería cargada %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Erro cargando batería %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Seleccione ficheiro de código"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Ficheiro de Código GameShark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Ficheiro de Código GameShark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "A importación dun ficheiro de código sustituirá calquera truco cargado. Queres continuar?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Non se pode abrir o ficheiro %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Ficheiro de código non soportado %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Ficheiro de código cargado %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Erro cargando ficheiro de código %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Seleccionar ficheiro de instantánea"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Instantáneas de GS e PAC (*.sps;*.xps)|*.sps;*.xps|Instantáneas de GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Instantánea de Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "A importación dun ficheiro de instantánea borrará tódolos xogos gardados (permanentemente despois da seguinte escritura). Queres continuar?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Ficheiro de instantánea cargado %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Erro cargando ficheiro de instantánea %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Batería escrita %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Erro escribindo batería %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "gardados EEPROM non poden ser exportados"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Instantánea de Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exportado dende VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Ficheiro de instantánea gardado %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Erro gardando ficheiro de instantánea %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Seleccione o ficheiro de saída"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Imaxes PNG|*.png|Imaxes BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Instantánea escrita %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr " ficheiros ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Ficheiros de película VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Seleccione un ficheiro"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Seleccione o ficheiro de estado"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Ficheiros de gardado do xogo VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Son activado"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Son desactivado"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volume: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Establecer a 0 para pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Porto para agardar por conexión:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Conexión GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Agardando por conexión en %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Agardando por conexión en porto %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Agardando por GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulador de Nintendo GameBoy (+Color+Advance) ."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Dereitos do autor (C) 1999-2003 Forgotten\nDereits do autor (C) 2004-2006 equipo de desenvolvemento VBA\nDereits do autor (C) 2007-2017 equipo de desenvolvemento VBA-M"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -414,11 +430,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -622,92 +638,96 @@ msgstr "%d cadros = %.2f ms"
 msgid "Default device"
 msgstr "Dispositivo predeterminado"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Modo escritorio"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Complemento"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Código"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Descrición"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Enderezo"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Valor antigo"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Novo valor"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Menú de comandos"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Outros comandos"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -766,99 +786,99 @@ msgstr ""
 msgid " player "
 msgstr "xogador"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Estado cargado %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Erro cargando estado %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Estado gardado %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Erro gardando estado %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Modo pantalla completa %dx%d-%d@%d non soportado"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Modo valido : %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "Erro  ao iniciar codec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -928,12 +948,12 @@ msgstr "&Pechar"
 msgid "Printed"
 msgstr "Impreso"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1332,7 +1352,7 @@ msgstr "Engadir truco"
 msgid "Edit Cheat"
 msgstr "Editar truco"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Tipo"
 
@@ -2304,8 +2324,8 @@ msgstr ""
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2582,7 +2602,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Arriba"
 
@@ -2590,7 +2610,7 @@ msgstr "Arriba"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Abaixo"
 
@@ -2598,7 +2618,7 @@ msgstr "Abaixo"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Esquerda"
 
@@ -2606,7 +2626,7 @@ msgstr "Esquerda"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Dereita"
 
@@ -2614,11 +2634,11 @@ msgstr "Dereita"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2742,633 +2762,657 @@ msgstr ""
 msgid "&File"
 msgstr "&Ficheiro"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Abrir &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Abrir GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Abrir rece&nte"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Reseiniciar lista recente"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "In&formación da ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Dende &ficheiro ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Cargar estado"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&Rañura máis antiga"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Ao &ficheiro ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Gardar estado"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&Ficheiro de batería..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Ficheiro de &código GameShark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Instantánea de Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importar"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Exportar"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Captura de pant&alla..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Gravar"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Reproducir"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulación"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "Pausar"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Seguinte fotograma"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Rebo&binar"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Activar &pantalla completa"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Modo turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Auto saltar cadros"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&Saltar BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Reiniciar"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Opcións"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Ligazón"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Nada"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Cable"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Sen fíos"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Modo local"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Configurar ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Vídeo"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "Iniciar en pantalla completa"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr "&Filtro bilinear"
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
-msgstr "&Barra de estado"
-
-#: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
-msgstr ""
-
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr "&Filtro bilinear"
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr "&Barra de estado"
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Audio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Entrada"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Disparo automático"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Configurar ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&Reloxo en tempo real"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Usar ficheiro BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Imprimir depurador"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "Impresora &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Usar ficheiro BIOS de Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Usar ficheiro BIOS de Game Boy Color"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Xeral ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "D&irectorios ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "&Atallos de Tecla..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Ferramentas"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Lista de &cheats ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "G&ardado/Cargado automático de trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Activar trucos"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Configurar porto"
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Desconectar"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Rexistro"
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&Visor de entrada e saída..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Visor de mapa..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "&Visor de memoria..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&Visor de OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "&Visor de Paleta..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "&Visor de título..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Canle &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Canle &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Canle &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Canle &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Canles de &Son"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Axuda"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Reportar &erros"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "&Foro de Soporte VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Traducións"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/haw.po
+++ b/po/wxvbam/haw.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Hawaiian (http://www.transifex.com/bgk/vba-m/language/haw/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/he.po
+++ b/po/wxvbam/he.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Hebrew (http://www.transifex.com/bgk/vba-m/language/he/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/he_IL.po
+++ b/po/wxvbam/he_IL.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Hebrew (Israel) (http://www.transifex.com/bgk/vba-m/language/he_IL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/hr.po
+++ b/po/wxvbam/hr.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Croatian (http://www.transifex.com/bgk/vba-m/language/hr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr "Ništa"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Gore"
 
@@ -2588,7 +2608,7 @@ msgstr "Gore"
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Dolje"
 
@@ -2596,7 +2616,7 @@ msgstr "Dolje"
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Lijevo"
 
@@ -2604,7 +2624,7 @@ msgstr "Lijevo"
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Desno"
 
@@ -2612,11 +2632,11 @@ msgstr "Desno"
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/hu.po
+++ b/po/wxvbam/hu.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-21 14:24+0000\n"
-"Last-Translator: Model T800\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Hungarian (http://www.transifex.com/bgk/vba-m/language/hu/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -51,120 +51,120 @@ msgstr "GameBoy Color Fájlok (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.
 msgid "Open GBC ROM file"
 msgstr "GBC ROM fájl megnyitása"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -175,230 +175,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Nincs"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Válassz Dot Code fájlt"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Válassz battery fájlt"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Battery fájl (*.sav)|*.sav|Flash mentés (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Egy battery fájl importálása töröl minden játékállás mentést (a következő írás után végleg).\nBiztosan ezt akarod?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Importálás megerősítése"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "%s battery betöltve"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "% battery betöltése sikertelen"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Válassz code fájlt"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark Code Fájl (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark Code Fájl (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Egy code fájl importálása minden betöltött csalást lecserél. Biztosan folytatod?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "A %s megnyitása nem lehetséges"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "A %s nem támogatott code fájl"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "%s code fájl betöltve"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "A %s code fájl betöltése sikertelen"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Válassz pillanatkép fájlt"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Pillanatkép (*.sps;*.xps)|*.sps;*.xps|GameShark SP Pillanatkép (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy Pillanatkép (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Egy pillanatkép importálása töröl minden játékállás mentést (a következő írás után végleg).\nBiztosan folytatod?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "A %s pillanatkép fájl betöltve"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "A %s pillanatkép fájl betöltése sikertelen"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "%s battery megírva"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "A %s battery írása sikertelen"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Az EEPROM mentések nem exportálhatók"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Pillanatkép (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exportálva a VisualBoyAdvance-M-ből"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "A %s pillanatkép fájl mentve"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "A %s pillanatkép fájl mentése sikertelen"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Válassz kimeneti fájlt"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG képek|*.png|BMP képek|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "A %s pillanatkép kiírva"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr " fájlok ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA Mozgókép fájlok|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Válassz fájlt"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Válassz mentett játékállást"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance játékmentés fájlok|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Hang bekapcsolva"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Hang kikapcsolva"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Hangerő: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Ál-TTY-hez állítsd 0-ra"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Kapcsolatokhoz figyelt port:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB Kapcsolat"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Várakozás a kapcsolódásra itt: %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Kapcsolódás kezdeményezése a %d porton"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Várakozás a GDB-re"
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Nintendo GameBoy (+Color+Advance) emulátor."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA fejlesztői csapat\nCopyright (C) 2007-2017 VBA-M fejlesztői csapat"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -414,11 +430,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Ez a program ingyenes alkalmazás: terjesztheti és/vagy módosíthatja\na Free Software Foundation által kiadott GNU Általános Nyilvános\nLincenc előírásaival összhangban, legyen szó annak második, vagy\n(tetszés szerinti) bármely későbbi változatáról.\n\nA program azért készült, hogy remélhetőleg hasznos legyen, de nincs\nSEMMIFÉLE GARANCIA rá, még a feltételezhető HELYES MŰKÖDÉSRE és arra\nsem, hogy bármely EGYEDI CÉLNAK megfelel. További részletekért\ntekintse meg a GNU Általános Nyilvános Lincenct.\n\nA programhoz mellékelve kell legyen a Licenc egy példánya. Ha\nmégsem, itt megtalálja: http://gnu.hu/gpl.html ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "A LAN összeköttetés már aktív. Kapcsold ki az összekötés módot a bontáshoz."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Helyi módban hálózat nem támogatott."
 
@@ -622,92 +638,96 @@ msgstr "%d képkocka = %.2f ms"
 msgid "Default device"
 msgstr "Alapértelmezett eszköz"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Asztali mód"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "A %s helyen nincs használható RPI bővítmény"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Bővítmény"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Válassz bővítményt, vagy másféle szűrőt"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Hiba a bővítmény választásnál"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Ez eltávolít minden felhasználói gyorsítót. Biztosan vagy benne?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Megerősít"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "A főikon nem található"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "A főkijelző nem található"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "A %s menü-gyorsgomb duplán csatolt: %s és %s; az első lesz megtartva"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "A %s menü-gyorsgomb ehhez: %s, felülírja az eredetit ehhez: %s ; menü megtartása"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "A %s érvénytelen menüelem; eltávolítás"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kód"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Leírás"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Cím"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Régi Érték"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Új Érték"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Menü parancsok"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Egyéb parancsok"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "A JoyBus gazda érvénytelen; letiltás"
 
@@ -766,99 +786,99 @@ msgstr "A %s Game Boy Advance ROM nem tölthető be"
 msgid " player "
 msgstr " játékos "
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "A %s játékállás betöltve"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Hiba a %s játékállás betöltésekor"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "A %s játékállás mentve"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Hiba a %s játékállás mentésekor"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "A teljesképernyős mód %dx%d-%d@%d nem támogatott; másik keresése"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "A teljesképernyős mód %dx%d-%d@%d nem támogatott"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Érvényes mód: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "%dx%d-%d@%d mód választva"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Nem sikerült %dx%d-%d@%d módra váltani"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Érvénytelen GBA bővítőkártya"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Visszajátszáshoz kevés a memória"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Hiba a visszajátszás-állás írásakor"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "memóriakioszási hiba"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "hiba a kodek inicializálásnál"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "hiba a kimeneti fájl írásakor"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "a fájlnévből nem állapítható meg a kimenet formátuma"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "programhiba; megszakítás!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Nem lehet megkezdeni a rögzítést ide: %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Hiba a hang/videó rögzítésekor (%s); megszakítás"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Hiba a hangrögzítéskor (%s); megszakítás"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Hiba a videórögzítéskor (%s); megszakítás"
@@ -928,12 +948,12 @@ msgstr "Bezár"
 msgid "Printed"
 msgstr "Kinyomtatva"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Hiba az ál-TTY megnyitásakor: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Hiba a szerver socket beállításakor (%d)"
@@ -1332,7 +1352,7 @@ msgstr "Csalás hozzáadás"
 msgid "Edit Cheat"
 msgstr "Csalás Szerkesztés"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Típus"
 
@@ -2304,8 +2324,8 @@ msgstr "Ellenőrző:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2582,7 +2602,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Hozzáadáshoz kattints egy mezőre, majd nyomj egy gombot, vagy mozgasd a joystickot.  Az utoljára hozzáadott kulcs törléséhez nyomj backspace-t.  Ha túl kicsi az ablak, méretezd át, vagy kattints bele és mozgasd a mutatót az összes tartalom megtekintéséhez."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Fel"
 
@@ -2590,7 +2610,7 @@ msgstr "Fel"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Le"
 
@@ -2598,7 +2618,7 @@ msgstr "Le"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Balra"
 
@@ -2606,7 +2626,7 @@ msgstr "Balra"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Jobbra"
 
@@ -2614,11 +2634,11 @@ msgstr "Jobbra"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2742,634 +2762,658 @@ msgstr "Részletek"
 msgid "&File"
 msgstr "&Fájl"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "&GB megnyitása..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "GB&C megnyitása..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Legutóbbiak meg&nyitása"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "Lista tö&rlése"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "Lista be&fagyasztása"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ROM adatai..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "Dot Kód betö&ltése..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "Dot Kód menté&se..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Legutolsó"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "Legutolsó automata betöltése"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "&Fájlból ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "&Battery mentés változatlan marad"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "&Csaláslista változatlan marad"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "Játéká&llás betöltése"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "Legkorábbi helyére"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "&Fájlba ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "Játékállás menté&se"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&Battery fájl..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Gameshark kódfájl..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Gameshark pillanatkép..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importálás"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Exportálás"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Képernyőkép mentése..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Hangrögzítés indítá&sa..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Hangr&ögzítés megállítása"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "&Videórögzítés indítása..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Videórögzítés megállítása"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Játék felvételének indítása..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Játékfelvétel leállítása"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Rögzítés"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Felvétel visszajátszása..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Visszajátszás leállítása"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "Lejátszás"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulálás"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "Szünet"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "Következő képkocka"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Visszatekerés"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Váltás teljes képernyőre"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Turbo mód"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "Függőleges szinkronizálás"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Automata képkocka átugrás"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "BIOS átugrá&sa"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Automata IPS/UPS/IPF javítás"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "Szünet ha inaktív"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Visszaállít"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "Beállítás&ok"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Link"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Hálózati kapcsolat kezdeményezés..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "Nincs"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "Kábeles"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "Vezetéknélküli"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "He&lyi mód"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "Kapcso&lódás indításkor"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Sebesség hack"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "Konfigurálás ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Videó"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "Indítá&s teljes képernyőn"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr "&Skálázott átméretezés"
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr "&1x"
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr "&2x"
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr "&3x"
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr "&4x"
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr "&5x"
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr "&6x"
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "Méretarány megő&rzése"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "&Bilineáris szűrő"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "Abla&k mindig legfelül"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Állapot&sor"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "Képben kijelzés letiltása"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Képben kijelzés át&tetszően"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "H&ang"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr "Hangosítás"
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr "Halkítás"
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr "Hang ki/be"
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&GBA hangkiegészítés"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&GB hangkiemelés"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&GB surround hangeffektus"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "&GB kattogó hang tompítása"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "Bevite&l"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Auto-tűz"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr "&Auto-Tartás"
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr "Fel"
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr "Le"
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr "Ba&lra"
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr "Jobb&ra"
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr "&Select"
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr "&Start"
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Konfigurálás ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "Valósidejű Ó&ra (RTC)"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "BIOS fájl használata"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "Hibakeresés nyomtatás"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&GB nyomtató"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "Nyomtatás csak a teljes oldal me&glétekor"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "Nyomtatás menté&se képernyőképként"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "GB BIOS fájl használata"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "GBC BIOS fájl használata"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "Általános ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr "Gyor&sítás / Turbo ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "Könyvtárak ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Gyorsbillentyű&k ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "Eszközök"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Csalások"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "&Csalások listázása ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Csalások keresése ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Csalások automata mentése/betöltése"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "Csalások &engedélyezése"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "GD&B feltörése"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "Port konfigurálás..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "Szünet terheléskor"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "Lecsatlakozás"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "Visszafejtés..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "Nap&lózás..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&IO Betekintő..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Térkép Megtekintő..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "M&emória Vizsgáló..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&OAM Nézegető..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Szín&paletta Betekintő..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Csempe Meg&tekintő..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "Képrétegek"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Csatorna &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Csatorna &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Csatorna &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Csatorna &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Hang&csatornák"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "Súgó"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Hibák jelentése"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M Támogatási &Fórum"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Fordítások"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
 msgstr "Alaphelyzet Visszaállítás..."
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
+msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4
 msgid "Map Viewer"

--- a/po/wxvbam/hu_HU.po
+++ b/po/wxvbam/hu_HU.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-21 14:24+0000\n"
-"Last-Translator: Model T800\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Hungarian (Hungary) (http://www.transifex.com/bgk/vba-m/language/hu_HU/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -52,120 +52,120 @@ msgstr "GameBoy Color Fájlok (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.
 msgid "Open GBC ROM file"
 msgstr "GBC ROM fájl megnyitása"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Ismeretlen"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -176,230 +176,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Nincs"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Válassz Dot Code fájlt"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Válassz battery fájlt"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Battery fájl (*.sav)|*.sav|Flash mentés (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Egy battery fájl importálása töröl minden játékállás mentést (a következő írás után végleg).\nBiztosan ezt akarod?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Importálás megerősítése"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "%s battery betöltve"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "% battery betöltése sikertelen"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Válassz code fájlt"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark Code Fájl (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark Code Fájl (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Egy code fájl importálása minden betöltött csalást lecserél. Biztosan folytatod?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "A %s megnyitása nem lehetséges"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "A %s nem támogatott code fájl"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "%s code fájl betöltve"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "A %s code fájl betöltése sikertelen"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Válassz pillanatkép fájlt"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Pillanatkép (*.sps;*.xps)|*.sps;*.xps|GameShark SP Pillanatkép (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy Pillanatkép (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Egy pillanatkép importálása töröl minden játékállás mentést (a következő írás után végleg).\nBiztosan folytatod?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "A %s pillanatkép fájl betöltve"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "A %s pillanatkép fájl betöltése sikertelen"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "%s battery megírva"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "A %s battery írása sikertelen"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Az EEPROM mentések nem exportálhatók"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Pillanatkép (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exportálva a VisualBoyAdvance-M-ből"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "A %s pillanatkép fájl mentve"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "A %s pillanatkép fájl mentése sikertelen"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Válassz kimeneti fájlt"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG képek|*.png|BMP képek|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "A %s pillanatkép kiírva"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr " fájlok ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA Mozgókép fájlok|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Válassz fájlt"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Válassz mentett játékállást"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance játékmentés fájlok|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Hang bekapcsolva"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Hang kikapcsolva"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Hangerő: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Ál-TTY-hez állítsd 0-ra"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Kapcsolatokhoz figyelt port:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB Kapcsolat"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Várakozás a kapcsolódásra itt: %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Kapcsolódás kezdeményezése a %d porton"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Várakozás a GDB-re"
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Nintendo GameBoy (+Color+Advance) emulátor."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA fejlesztői csapat\nCopyright (C) 2007-2017 VBA-M fejlesztői csapat"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -415,11 +431,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Ez a program ingyenes alkalmazás: terjesztheti és/vagy módosíthatja\na Free Software Foundation által kiadott GNU Általános Nyilvános\nLincenc előírásaival összhangban, legyen szó annak második, vagy\n(tetszés szerinti) bármely későbbi változatáról.\n\nA program azért készült, hogy remélhetőleg hasznos legyen, de nincs\nSEMMIFÉLE GARANCIA rá, még a feltételezhető HELYES MŰKÖDÉSRE és arra\nsem, hogy bármely EGYEDI CÉLNAK megfelel. További részletekért\ntekintse meg a GNU Általános Nyilvános Lincenct.\n\nA programhoz mellékelve kell legyen a Licenc egy példánya. Ha\nmégsem, itt megtalálja: http://gnu.hu/gpl.html ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "A LAN összeköttetés már aktív. Kapcsold ki az összekötés módot a bontáshoz."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Helyi módban hálózat nem támogatott."
 
@@ -623,92 +639,96 @@ msgstr "%d képkocka = %.2f ms"
 msgid "Default device"
 msgstr "Alapértelmezett eszköz"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Asztali mód"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "A %s helyen nincs használható RPI bővítmény"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Bővítmény"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Válassz bővítményt, vagy másféle szűrőt"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Hiba a bővítmény választásnál"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Ez eltávolít minden felhasználói gyorsítót. Biztosan vagy benne?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Megerősít"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "A főikon nem található"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "A főkijelző nem található"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "A %s menü-gyorsgomb duplán csatolt: %s és %s; az első lesz megtartva"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "A %s menü-gyorsgomb ehhez: %s, felülírja az eredetit ehhez: %s ; menü megtartása"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "A %s érvénytelen menüelem; eltávolítás"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kód"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Leírás"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Cím"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Régi Érték"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Új Érték"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Menü parancsok"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Egyéb parancsok"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "A JoyBus gazda érvénytelen; letiltás"
 
@@ -767,99 +787,99 @@ msgstr "A %s Game Boy Advance ROM nem tölthető be"
 msgid " player "
 msgstr " játékos "
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "A %s játékállás betöltve"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Hiba a %s játékállás betöltésekor"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "A %s játékállás mentve"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Hiba a %s játékállás mentésekor"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "A teljesképernyős mód %dx%d-%d@%d nem támogatott; másik keresése"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "A teljesképernyős mód %dx%d-%d@%d nem támogatott"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Érvényes mód: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "%dx%d-%d@%d mód választva"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Nem sikerült %dx%d-%d@%d módra váltani"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Érvénytelen GBA bővítőkártya"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Visszajátszáshoz kevés a memória"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Hiba a visszajátszás-állás írásakor"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "memóriakioszási hiba"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "hiba a kodek inicializálásnál"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "hiba a kimeneti fájl írásakor"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "a fájlnévből nem állapítható meg a kimenet formátuma"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "programhiba; megszakítás!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Nem lehet megkezdeni a rögzítést ide: %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Hiba a hang/videó rögzítésekor (%s); megszakítás"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Hiba a hangrögzítéskor (%s); megszakítás"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Hiba a videórögzítéskor (%s); megszakítás"
@@ -929,12 +949,12 @@ msgstr "Bezár"
 msgid "Printed"
 msgstr "Kinyomtatva"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Hiba az ál-TTY megnyitásakor: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Hiba a szerver socket beállításakor (%d)"
@@ -1333,7 +1353,7 @@ msgstr "Csalás hozzáadás"
 msgid "Edit Cheat"
 msgstr "Csalás Szerkesztés"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Típus"
 
@@ -2305,8 +2325,8 @@ msgstr "Ellenőrző:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2583,7 +2603,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Hozzáadáshoz kattints egy mezőre, majd nyomj egy gombot, vagy mozgasd a joystickot.  Az utoljára hozzáadott kulcs törléséhez nyomj backspace-t.  Ha túl kicsi az ablak, méretezd át, vagy kattints bele és mozgasd a mutatót az összes tartalom megtekintéséhez."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Fel"
 
@@ -2591,7 +2611,7 @@ msgstr "Fel"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Le"
 
@@ -2599,7 +2619,7 @@ msgstr "Le"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Balra"
 
@@ -2607,7 +2627,7 @@ msgstr "Balra"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Jobbra"
 
@@ -2615,11 +2635,11 @@ msgstr "Jobbra"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2743,634 +2763,658 @@ msgstr "Részletek"
 msgid "&File"
 msgstr "&Fájl"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "&GB megnyitása..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "GB&C megnyitása..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Legutóbbiak meg&nyitása"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "Lista tö&rlése"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "Lista be&fagyasztása"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ROM adatai..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "Dot Kód betö&ltése..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "Dot Kód menté&se..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Legutolsó"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "Legutolsó automata betöltése"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "&Fájlból ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "&Battery mentés változatlan marad"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "&Csaláslista változatlan marad"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "Játéká&llás betöltése"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "Legkorábbi helyére"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "&Fájlba ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "Játékállás menté&se"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&Battery fájl..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Gameshark kódfájl..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Gameshark pillanatkép..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importálás"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Exportálás"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Képernyőkép mentése..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Hangrögzítés indítá&sa..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Hangr&ögzítés megállítása"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "&Videórögzítés indítása..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Videórögzítés megállítása"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Játék felvételének indítása..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Játékfelvétel leállítása"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Rögzítés"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Felvétel visszajátszása..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Visszajátszás leállítása"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "Lejátszás"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulálás"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "Szünet"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "Következő képkocka"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Visszatekerés"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Váltás teljes képernyőre"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Turbo mód"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "Függőleges szinkronizálás"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Automata képkocka átugrás"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "BIOS átugrá&sa"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Automata IPS/UPS/IPF javítás"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "Szünet ha inaktív"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Visszaállít"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "Beállítás&ok"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Link"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Hálózati kapcsolat kezdeményezés..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "Nincs"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "Kábeles"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "Vezetéknélküli"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "He&lyi mód"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "Kapcso&lódás indításkor"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Sebesség hack"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "Konfigurálás ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Videó"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "Indítá&s teljes képernyőn"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr "&Skálázott átméretezés"
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr "&1x"
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr "&2x"
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr "&3x"
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr "&4x"
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr "&5x"
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr "&6x"
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "Méretarány megő&rzése"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "&Bilineáris szűrő"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "Abla&k mindig legfelül"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Állapot&sor"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "Képben kijelzés letiltása"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Képben kijelzés át&tetszően"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "H&ang"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr "Hangosítás"
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr "Halkítás"
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr "Hang ki/be"
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&GBA hangkiegészítés"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&GB hangkiemelés"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&GB surround hangeffektus"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "&GB kattogó hang tompítása"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "Bevite&l"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Auto-tűz"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr "&Auto-Tartás"
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr "Fel"
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr "Le"
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr "Ba&lra"
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr "Jobb&ra"
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr "&Select"
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr "&Start"
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Konfigurálás ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "Valósidejű Ó&ra (RTC)"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "BIOS fájl használata"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "Hibakeresés nyomtatás"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&GB nyomtató"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "Nyomtatás csak a teljes oldal me&glétekor"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "Nyomtatás menté&se képernyőképként"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "GB BIOS fájl használata"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "GBC BIOS fájl használata"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "Általános ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr "Gyor&sítás / Turbo ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "Könyvtárak ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Gyorsbillentyű&k ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "Eszközök"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Csalások"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "&Csalások listázása ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Csalások keresése ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Csalások automata mentése/betöltése"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "Csalások &engedélyezése"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "GD&B feltörése"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "Port konfigurálás..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "Szünet terheléskor"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "Lecsatlakozás"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "Visszafejtés..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "Nap&lózás..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&IO Betekintő..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Térkép Megtekintő..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "M&emória Vizsgáló..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&OAM Nézegető..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Szín&paletta Betekintő..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Csempe Meg&tekintő..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "Képrétegek"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Csatorna &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Csatorna &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Csatorna &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Csatorna &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Hang&csatornák"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "Súgó"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Hibák jelentése"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M Támogatási &Fórum"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Fordítások"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
 msgstr "Alaphelyzet Visszaállítás..."
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
+msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4
 msgid "Map Viewer"

--- a/po/wxvbam/id.po
+++ b/po/wxvbam/id.po
@@ -5,13 +5,15 @@
 # Translators:
 # aquatorrent, 2015
 # Chizuru <saiber.one1@gmail.com>, 2015
+# Jeremy Belpois <jeremy.belpois.einstein@gmail.com>, 2019
+# Jeremy Belpois <jeremy.belpois.einstein@gmail.com>, 2019
 msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Indonesian (http://www.transifex.com/bgk/vba-m/language/id/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -51,120 +53,120 @@ msgstr "File GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg
 msgid "Open GBC ROM file"
 msgstr "Buka file GBC ROM"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Tak diketahui"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -175,230 +177,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Tidak ada"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Pilih file Dot Code"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "Dot Code e-Reader (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Pilih file baterai"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "File baterai (*.sav)|*.sav|Simpanan Flash (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Mengimpor file baterai akan menghapus simpanan permainan (secara permanen setelah penyimpanan ini dilakukan). Apakah anda ingin melanjutkan?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Konfirmasi untuk mengimpor"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Baterai yang dimuat %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Terjadi kesalahan dalam memuat baterai %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Pilih file kode"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "File Kode Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "File Kode Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Mengimpor file kode akan menimpa cheat yang sudah dimuat. Apakah anda ingin melanjutkan?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Tidak dapat membuka file %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "File kode tidak didukung %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "File kode yang dimuat %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Terjadi kesalahan dalam memuat file kode %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Pilih file snapshot"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Snapshot GS & PAC (*.sps;*.xps)|*.sps;*.xps|Snapshot GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Snapshot Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Mengimpor file snapshot akan menghapus simpanan permainan (secara permanen setelah penyimpanan ini dilakukan). Apakah anda ingin melanjutkan?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "File snapshot yang dimuat %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Terjadi kesalahan dalam memuat file snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Menyimpan baterai %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Terjadi kesalahan dalam menyimpan baterai %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Simpanan EEPROM tidak dapat diekspor"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Snapshot Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Diekspor dari VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "File snapshot yang disimpan %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Terjadi kesalahan dalam meyimpan file snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Pilih file keluaran"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Gambar PNG|*.png|Gambar BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Menyimpan snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "file ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "File Film VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Pilih file"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Pilih file state"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "File simpanan permainan VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Nyalakan suara"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Matikan suara"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volume: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Ubah ke 0 untuk pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr " Port untuk menunggu koneksi:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Koneksi GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Menunggu koneksi pada %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Menunggu koneksi pada port %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Menunggu GDB"
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulator Nintendo GameBoy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
-msgstr ""
+msgstr "Hak Cipta © 1999-2003 Forgotten\nHak Cipta © 2004-2006 Tim pengembangan VBA\nHak Cipta © 2007-2017 Tim pengembangan VBA-M"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -414,11 +432,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Program ini termasuk dalam perangkat lunak bebas: anda dapat mendistribusikan ulang dan/atau merubah\nprogram ini sesuai dengan GNU General Public License yang telah dipublikasikan oleh\nFree Software Foundation, baik menurut Lisensi versi 2, maupun\n(sesuai dengan pilihan anda) versi lainnya yang lebih baru.\n\nProgram ini didistribusikan dengan harapan bahwa program ini akan dapat berguna,\nnamun program ini didistribusikan TANPA JAMINAN APAPUN; bahkan dengan jaminan untuk DIPERJUAL BELIKAN ataupun AKAN SESUAI UNTUK TUJUAN TERTENTU sekalipun. Lihat\nGNU General Public License untuk informasi lebih lanjut.\n\nAnda dapat memperoleh salinan dari GNU General Public License\nbersama dengan program ini. Jika anda tidak memperolehnya, anda dapat melihatnya di http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "Hubungan LAN sudah aktif. Putuskan mode hubung untuk memutuskan hubungan."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Fitur jaringan tidak didukung dalam mode lokal."
 
@@ -464,19 +482,19 @@ msgstr "dsbSecondary->Lock() gagal: %08x"
 
 #: ../src/wx/faudio.cpp:32
 msgid "FAudio: Enumerating devices failed!"
-msgstr ""
+msgstr "FAudio: Penyebutan perangkat gagal!"
 
 #: ../src/wx/faudio.cpp:67 ../src/wx/faudio.cpp:352
 msgid "The FAudio interface failed to initialize!"
-msgstr ""
+msgstr "Antarmuka FAudio gagal dijalankan!"
 
 #: ../src/wx/faudio.cpp:384
 msgid "FAudio: Creating mastering voice failed!"
-msgstr ""
+msgstr "FAudio: Penciptaan suara master gagal!"
 
 #: ../src/wx/faudio.cpp:395
 msgid "FAudio: Creating source voice failed!"
-msgstr ""
+msgstr "FAudio: Penciptaan suara sumber gagal!"
 
 #: ../src/wx/gfxviewers.cpp:1141
 msgid "Select output file and type"
@@ -622,92 +640,96 @@ msgstr "%d frame = %.2f ms"
 msgid "Default device"
 msgstr "Perangkat default"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Mode desktop"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Tidak menemukan plugin rpi yang dapat digunakan di %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Tolong pilih plugin atau filter yang berbeda"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Terjadi kesalahan pada pemilihan plugin"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Ini akan mengosongkan semua pemercepat yang telah diatur oleh pengguna. Apakah anda yakin?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Konfirmasi"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Ikon utama tidak ditemukan"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Panel layar utama tidak ditemukan"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Menu pemercepat terduplikasi: %s untuk %s dan %s; menyimpan menu pertama"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Menu pemercepat %s untuk %s menimpa menu default untuk %s ; menggunakan menu"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Menu item %s tidak valid; menghapus"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kode"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Deskripsi"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Alamat"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Nilai Lama"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Nilai Baru"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Perintah menu"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Perintah lainnya"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Host JoyBus tidak valid; menonaktifkan"
 
@@ -725,7 +747,7 @@ msgstr "Nilai %d tidak valid untuk pilihan %s; nilai yang valid adalah %d - %d"
 #: ../src/wx/opts.cpp:879
 #, c-format
 msgid "Invalid value %f for option %s; valid values are %f - %f"
-msgstr ""
+msgstr "Nilai %f salah untuk pilihan %s; nilai yang benar adalah %f - %f"
 
 #: ../src/wx/opts.cpp:648 ../src/wx/opts.cpp:669 ../src/wx/opts.cpp:948
 #: ../src/wx/opts.cpp:974
@@ -766,99 +788,99 @@ msgstr "Tidak dapat memuat ROM Game Boy Advance %s"
 msgid " player "
 msgstr "pemain"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "State yang dimuat %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Terjadi kesalahan dalam memuat state %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "State yang disimpan %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Terjadi kesalahan dalam menyimpan state %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Mode layar penuh %dx%d-%d@%d tidak didukung; mencari mode yang lain"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Mode layar penuh %dx%d-%d@%d tidak didukung"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Mode yang valid: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Pilih mode %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Gagal merubah mode ke %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Bukan merupakan cartridge GBA yang valid"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Tidak ada memori untuk memuat state mundur"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Terjadi kesalahan dalam menyimpan state mundur"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "terjadi kesalahan dalam mengalokasikan memori"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "terjadi kesalahan dalam menginisialisasikan codec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "terjadi kesalahan dalam menyimpan file keluaran"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "tidak dapat menebak format keluaran dari nama file"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "terjadi kesalama dalam pemrograman; membatalkan perintah!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Tidak dapat memulai rekaman ke %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Terjadi kesalahan dalam merekam audio/video (%s); membatalkan perintah"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Terjadi kesalahan dalam merekam audio (%s); membatalkan perintah"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Terjadi kesalahan dalam merekam video (%s); membatalkan perintah"
@@ -928,12 +950,12 @@ msgstr "&Keluar"
 msgid "Printed"
 msgstr "Tercetak"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Terjadi kesalahan dalam membuka pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Terjadi kesalahan dalam mempersiapkan socket server (%d)"
@@ -1028,7 +1050,7 @@ msgstr "B:"
 
 #: ../src/wx/wxvbam.cpp:203
 msgid "visualboyadvance-m"
-msgstr ""
+msgstr "visualboyadvance-m"
 
 #: ../src/wx/wxvbam.cpp:417
 msgid "Could not create main window"
@@ -1147,7 +1169,7 @@ msgstr "CTRL"
 
 #: ../src/wx/widgets/keyedit.cpp:108 ../src/wx/widgets/keyedit.cpp:233
 msgid "RAWCTRL"
-msgstr ""
+msgstr "RAWCTRL"
 
 #: ../src/wx/widgets/keyedit.cpp:122 ../src/wx/widgets/keyedit.cpp:200
 msgid "Meta-"
@@ -1155,7 +1177,7 @@ msgstr "Meta-"
 
 #: ../src/wx/widgets/keyedit.cpp:127 ../src/wx/widgets/keyedit.cpp:128
 msgid "Num"
-msgstr ""
+msgstr "Num"
 
 #: ../src/wx/widgets/keyedit.cpp:201
 msgid "Meta+"
@@ -1163,15 +1185,15 @@ msgstr "Meta+"
 
 #: ../src/wx/widgets/keyedit.cpp:234
 msgid "RAW_CTRL"
-msgstr ""
+msgstr "RAW_CTRL"
 
 #: ../src/wx/widgets/keyedit.cpp:235
 msgid "RAWCONTROL"
-msgstr ""
+msgstr "RAWCONTROL"
 
 #: ../src/wx/widgets/keyedit.cpp:236
 msgid "RAW_CONTROL"
-msgstr ""
+msgstr "RAW_CONTROL"
 
 #: ../src/wx/widgets/keyedit.cpp:240
 msgid "CONTROL"
@@ -1332,7 +1354,7 @@ msgstr "&Tambah cheat"
 msgid "Edit Cheat"
 msgstr "Atur Cheat"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Tipe"
 
@@ -1579,7 +1601,7 @@ msgstr "Simpel"
 
 #: ../src/wx/xrc/DisplayConfig.xrc:40
 msgid "Quartz2D"
-msgstr ""
+msgstr "Quartz2D"
 
 #: ../src/wx/xrc/DisplayConfig.xrc:47
 msgid "OpenGL"
@@ -1595,7 +1617,7 @@ msgstr "Filter"
 
 #: ../src/wx/xrc/DisplayConfig.xrc:79
 msgid "Display filter :"
-msgstr ""
+msgstr "Penyaring layar:"
 
 #: ../src/wx/xrc/DisplayConfig.xrc:86
 msgid "2xSaI"
@@ -1679,7 +1701,7 @@ msgstr "xBRZ 5x"
 
 #: ../src/wx/xrc/DisplayConfig.xrc:106
 msgid "xBRZ 6x"
-msgstr ""
+msgstr "xBRZ 6x"
 
 #: ../src/wx/xrc/DisplayConfig.xrc:115
 msgid "Plugin :"
@@ -1826,12 +1848,12 @@ msgstr "File Bios"
 
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:115
 msgid "Current BIOS file :"
-msgstr ""
+msgstr "Berkas BIOS saat ini :"
 
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:122
 #: ../src/wx/xrc/GameBoyConfig.xrc:138 ../src/wx/xrc/GameBoyConfig.xrc:159
 msgid "(None)"
-msgstr ""
+msgstr "(Tidak ada)"
 
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:136
 #: ../src/wx/xrc/GameBoyConfig.xrc:168
@@ -1938,7 +1960,7 @@ msgstr "System"
 
 #: ../src/wx/xrc/GameBoyConfig.xrc:84
 msgid "GB Boot &ROM file :"
-msgstr ""
+msgstr "Berkas GB Boot & ROM :"
 
 #: ../src/wx/xrc/GameBoyConfig.xrc:91 ../src/wx/xrc/GameBoyConfig.xrc:113
 msgid "Select A File"
@@ -1950,11 +1972,11 @@ msgstr "File Boot ROM &GBC :"
 
 #: ../src/wx/xrc/GameBoyConfig.xrc:131
 msgid "Current GB BIOS file :"
-msgstr ""
+msgstr "Berkas BIOS GB saat ini :"
 
 #: ../src/wx/xrc/GameBoyConfig.xrc:152
 msgid "Current GBC BIOS file :"
-msgstr ""
+msgstr "Berkas BIOS GBC saat ini :"
 
 #: ../src/wx/xrc/GameBoyConfig.xrc:186
 msgid "User 1"
@@ -2304,8 +2326,8 @@ msgstr "Checksum:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2392,7 +2414,7 @@ msgstr "50%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:155 ../src/wx/xrc/SpeedupConfig.xrc:48
 msgid "75%"
-msgstr ""
+msgstr "75%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:156 ../src/wx/xrc/SoundConfig.xrc:45
 #: ../src/wx/xrc/SpeedupConfig.xrc:49
@@ -2401,7 +2423,7 @@ msgstr "100%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:157 ../src/wx/xrc/SpeedupConfig.xrc:50
 msgid "125%"
-msgstr ""
+msgstr "125%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:158 ../src/wx/xrc/SpeedupConfig.xrc:51
 msgid "150%"
@@ -2409,7 +2431,7 @@ msgstr "150%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:159 ../src/wx/xrc/SpeedupConfig.xrc:52
 msgid "175%"
-msgstr ""
+msgstr "175%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:160 ../src/wx/xrc/SpeedupConfig.xrc:53
 msgid "200%"
@@ -2417,67 +2439,67 @@ msgstr "200%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:161 ../src/wx/xrc/SpeedupConfig.xrc:54
 msgid "225%"
-msgstr ""
+msgstr "225%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:162 ../src/wx/xrc/SpeedupConfig.xrc:55
 msgid "250%"
-msgstr ""
+msgstr "250%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:163 ../src/wx/xrc/SpeedupConfig.xrc:56
 msgid "275%"
-msgstr ""
+msgstr "275%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:164 ../src/wx/xrc/SpeedupConfig.xrc:57
 msgid "300%"
-msgstr ""
+msgstr "300%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:165 ../src/wx/xrc/SpeedupConfig.xrc:58
 msgid "325%"
-msgstr ""
+msgstr "325%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:166 ../src/wx/xrc/SpeedupConfig.xrc:59
 msgid "350%"
-msgstr ""
+msgstr "350%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:167 ../src/wx/xrc/SpeedupConfig.xrc:60
 msgid "375%"
-msgstr ""
+msgstr "375%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:168 ../src/wx/xrc/SpeedupConfig.xrc:61
 msgid "400%"
-msgstr ""
+msgstr "400%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:169 ../src/wx/xrc/SpeedupConfig.xrc:62
 msgid "425%"
-msgstr ""
+msgstr "425%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:170 ../src/wx/xrc/SpeedupConfig.xrc:63
 msgid "450%"
-msgstr ""
+msgstr "450%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:171 ../src/wx/xrc/SpeedupConfig.xrc:64
 msgid "475%"
-msgstr ""
+msgstr "475%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:172 ../src/wx/xrc/SpeedupConfig.xrc:65
 msgid "500%"
-msgstr ""
+msgstr "500%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:173 ../src/wx/xrc/SpeedupConfig.xrc:66
 msgid "525%"
-msgstr ""
+msgstr "525%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:174 ../src/wx/xrc/SpeedupConfig.xrc:67
 msgid "550%"
-msgstr ""
+msgstr "550%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:175 ../src/wx/xrc/SpeedupConfig.xrc:68
 msgid "575%"
-msgstr ""
+msgstr "575%"
 
 #: ../src/wx/xrc/GeneralConfig.xrc:176 ../src/wx/xrc/SpeedupConfig.xrc:69
 msgid "600%"
-msgstr ""
+msgstr "600%"
 
 #: ../src/wx/xrc/IOViewer.xrc:4
 msgid "IO Viewer"
@@ -2582,7 +2604,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Klik kolom lalu tekan tombol atau gerakkan joystick untuk menambahkan tombol. Tekan backspace untuk menghapus tombol yang terakhir ditambahkan. Perbesar window atau klik di dalamnya lalu gerakkan pointer untuk melihat seluruh konten jika konten terlalu kecil."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Atas"
 
@@ -2590,7 +2612,7 @@ msgstr "Atas"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Bawah"
 
@@ -2598,7 +2620,7 @@ msgstr "Bawah"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Kiri"
 
@@ -2606,7 +2628,7 @@ msgstr "Kiri"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Kanan"
 
@@ -2614,11 +2636,11 @@ msgstr "Kanan"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2676,7 +2698,7 @@ msgstr "Default"
 
 #: ../src/wx/xrc/JoyPanel.xrc:529
 msgid "Clear All"
-msgstr ""
+msgstr "Bersihkan Semua"
 
 #: ../src/wx/xrc/LinkConfig.xrc:4
 msgid "Link configuration"
@@ -2742,633 +2764,657 @@ msgstr "Verbose"
 msgid "&File"
 msgstr "&File"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Buka &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Buka GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Buka yang ter&akhir dibuka"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Hapus daftar terbaru"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Bekukan daftar terbaru"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "Informasi RO&M..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Muat Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Simpan Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Ter&baru"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&Muat otomatis yang terbaru"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Dari &File ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Jangan ubah simpanan &baterai"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Jangan ubah daftar &cheat"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Muat state"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&Slot terlama"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Ke &File ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Simpan state"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&File baterai..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "File &kode Gameshark"
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Snapshot Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Impor"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Ekspor"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Simpan gam&bar..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Memulai &rekaman suara..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Hentikan re&kaman suara"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Memulai &rekaman video..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Hentikan re&kaman video"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Memulai &rekaman permainan..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Hentikan re&kaman permainan"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Rekam"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Mulai mainkan &film..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Berhenti memainkan fi&lm"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Mainkan"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Tiruan"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Hentikan"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Frame berikutnya"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Pu&tar balik"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Toggle &layar penuh"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Mode turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Lewati frame secara otomatis"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&Lewati BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Patch IPS/UPS/IPF secara otomatis"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Hentikan ketika tidak aktif"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Muat ulang"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Pilihan"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Hubungan"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Memulai &Hubungan Jaringan ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Tidak menggunakan apapun"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Kabel"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Nirkabel"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Mode lokal"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Hubungkan saat booting"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Hack kecepatan"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Konfigurasi ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Video"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Buka dengan layar penuh"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:301
-msgid "&1x"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:304
-msgid "&2x"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:307
-msgid "&3x"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:310
-msgid "&4x"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:313
-msgid "&5x"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:316
-msgid "&6x"
-msgstr ""
+msgstr "&Penyesuaian ukuran"
 
 #: ../src/wx/xrc/MainMenu.xrc:320
+msgid "&1x"
+msgstr "&1x"
+
+#: ../src/wx/xrc/MainMenu.xrc:323
+msgid "&2x"
+msgstr "&2x"
+
+#: ../src/wx/xrc/MainMenu.xrc:326
+msgid "&3x"
+msgstr "&3x"
+
+#: ../src/wx/xrc/MainMenu.xrc:329
+msgid "&4x"
+msgstr "&4x"
+
+#: ../src/wx/xrc/MainMenu.xrc:332
+msgid "&5x"
+msgstr "&5x"
+
+#: ../src/wx/xrc/MainMenu.xrc:335
+msgid "&6x"
+msgstr "&6x"
+
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&Pertahankan rasio aspek"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "&Filter bilinear"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Pastikan window paling atas"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "&Baris menu"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Non aktifkan tampilan pada layar"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "&Tampilan transparan pada layar"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Audio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
-msgstr ""
+msgstr "&Tingkatkan volume"
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
-msgstr ""
+msgstr "&Kurangi volume"
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
-msgstr ""
+msgstr "&Jungkit suara"
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&Interpolasi suara GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&Peningkatan suara GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&GB surround sound effect"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "&GB sound declicking"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Input"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Tekan otomatis"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
-msgstr ""
+msgstr "&Tahan otomatis"
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Konfigurasi ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&Waktu sebenarnya"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Gunakan file BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Debug cetakan"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&Printer GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Kumpulkan halaman penuh sebelum mencetak"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Simpan cetakan sebagai screen capture"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Gunakan file GB BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Gunakan file GBC BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Umum ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
-msgstr ""
+msgstr "&Percepat / Turbo ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "D&irektori ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "&Shortcut Tombol ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Alat"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Cheat"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Daftar &cheat ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Cari c&heat ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Simpan/muat cheat secara o&tomatis"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "Aktifkan cheat"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "&Pisahkan ke dalam GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Konfigurasi port..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "&Pisahkan ketika memuat"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Putuskan hubungan"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Membongkar..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Membuat log..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&Tampilan IO..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Tampilan Map..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "T&ampilan Memori..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&Tampilan OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "&Tampilan Palet..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "&Tampilan Tile..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Lihat Layer"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Kanal &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Kanal &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Kanal &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Kanal &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Suara Langsung &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Suara Langsung &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&Kanal Suara"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Bantuan"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Laporkan &Bug"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "Dukungan &Forum VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Terjemahan"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr "&Reset Pabrik..."
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4
@@ -3554,7 +3600,7 @@ msgstr "XAudio2"
 
 #: ../src/wx/xrc/SoundConfig.xrc:132
 msgid "FAudio"
-msgstr ""
+msgstr "FAudio"
 
 #: ../src/wx/xrc/SoundConfig.xrc:146
 msgid "Device"
@@ -3602,127 +3648,127 @@ msgstr "Filter suara"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:4
 msgid "SpeedUp / Turbo Settings"
-msgstr ""
+msgstr "Pengaturan Pemercepat / Turbo"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:9
 msgid "Speedup Throttle"
-msgstr ""
+msgstr "Tuas Pemercepat"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:84
 msgid "Speedup Frame Skip"
-msgstr ""
+msgstr "Pemercepat Frame Skip"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:102
 msgid "# of frames:"
-msgstr ""
+msgstr "# jumlah frame:"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:121
 msgid "1"
-msgstr ""
+msgstr "1"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:125
 msgid "5"
-msgstr ""
+msgstr "5"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:126
 msgid "6"
-msgstr ""
+msgstr "6"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:127
 msgid "7"
-msgstr ""
+msgstr "7"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:128
 msgid "8"
-msgstr ""
+msgstr "8"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:129
 msgid "9"
-msgstr ""
+msgstr "9"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:130
 msgid "10"
-msgstr ""
+msgstr "10"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:131
 msgid "11"
-msgstr ""
+msgstr "11"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:132
 msgid "12"
-msgstr ""
+msgstr "12"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:133
 msgid "13"
-msgstr ""
+msgstr "13"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:134
 msgid "14"
-msgstr ""
+msgstr "14"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:135
 msgid "15"
-msgstr ""
+msgstr "15"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:136
 msgid "16"
-msgstr ""
+msgstr "16"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:137
 msgid "17"
-msgstr ""
+msgstr "17"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:138
 msgid "18"
-msgstr ""
+msgstr "18"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:139
 msgid "19"
-msgstr ""
+msgstr "19"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:140
 msgid "20"
-msgstr ""
+msgstr "20"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:141
 msgid "21"
-msgstr ""
+msgstr "21"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:142
 msgid "22"
-msgstr ""
+msgstr "22"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:143
 msgid "23"
-msgstr ""
+msgstr "23"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:144
 msgid "24"
-msgstr ""
+msgstr "24"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:145
 msgid "25"
-msgstr ""
+msgstr "25"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:146
 msgid "26"
-msgstr ""
+msgstr "26"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:147
 msgid "27"
-msgstr ""
+msgstr "27"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:148
 msgid "28"
-msgstr ""
+msgstr "28"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:149
 msgid "29"
-msgstr ""
+msgstr "29"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:150
 msgid "30"
-msgstr ""
+msgstr "30"
 
 #: ../src/wx/xrc/TileViewer.xrc:4
 msgid "Tile Viewer"

--- a/po/wxvbam/id_ID.po
+++ b/po/wxvbam/id_ID.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Indonesian (Indonesia) (http://www.transifex.com/bgk/vba-m/language/id_ID/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "Berkas GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.d
 msgid "Open GBC ROM file"
 msgstr "Buka berkas GBC ROM"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Tidak diketahui"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr "Kosong"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Pilih berkas Dot Code"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Pilih berkas baterai"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Berkas baterai (*.sav)|*.sav|Penyimpanan Flash (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Mengimport berkas baterai akan menghapus hasil penyimpanan permainan (secara permanen setelah penulisan).  Apa anda mau melanjutkan?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Konfirmasi import"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Memuat baterai %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Gagal memuat baterai %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Pilih berkas code"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Berkas Kode Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Berkas Kode Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Mengimport berkas kode akan mengganti cheats yang sudah ada. Apa Anda ingin melanjutkan?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Tidak bisa membuka berkas %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Kode berkas tidak didukung %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Memuat berkas kode %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Gagal memuat berkas kode %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Pilih berkas snapshot"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Mengimpor berkas snapshot akan menghapus seluruh hasil peyimpanan game (secara permanen setelah ditulis). Apa Anda ingin melanjutkan?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Memuat berkas snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Gagal memuat berkas snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Menulis baterai %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Gagal menulis baterai %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Penyimpanan EEPROM tidak bisa diekspor"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Diekspor dari VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Menyimpan berkas snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Gagal menyimpan berkas snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Pilih berkas output"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Tulis snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr " berkas ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Pilih berkas"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2589,7 +2609,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2597,7 +2617,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2605,7 +2625,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2613,11 +2633,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/it.po
+++ b/po/wxvbam/it.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Italian (http://www.transifex.com/bgk/vba-m/language/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "GameBoy Color Files (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dm
 msgid "Open GBC ROM file"
 msgstr "Apri GBC ROM file"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr "Nessuno"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Su"
 
@@ -2589,7 +2609,7 @@ msgstr "Su"
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Giù"
 
@@ -2597,7 +2617,7 @@ msgstr "Giù"
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Sinistra"
 
@@ -2605,7 +2625,7 @@ msgstr "Sinistra"
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Destra"
 
@@ -2613,11 +2633,11 @@ msgstr "Destra"
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/it_IT.po
+++ b/po/wxvbam/it_IT.po
@@ -13,9 +13,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Italian (Italy) (http://www.transifex.com/bgk/vba-m/language/it_IT/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,120 +55,120 @@ msgstr "File GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg
 msgid "Open GBC ROM file"
 msgstr "Apri file GBC ROM"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Sconosciuto"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT "
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -179,230 +179,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Vuoto"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Scegliere file Dot Code"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Scegliere file battery"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "File Battery (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importare un file battery cancellerà qualsiasi gioco salvato (permanentemente dopo la prossima scrittura). Continuare?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Conferma importazione"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Batteria %s caricata"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Errore caricamento %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Scegliere file code"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr " File Gameshark Code (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "File codici Gameshark  (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Importare un file codici rimpiazzera qualunque trucco caricato. Continuare?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Impossibile aprire file %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "File codici %s non supportato"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "File codici 5s caricato"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Errore Caricamento file codice %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Seleziona file snapshot"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy Snapshot (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "L'importazione di un file di snapshot cancellerà tutti i giochi salvati (permanentemente dopo la prossima scrittura). Vuoi continuare?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Caricato file snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Errore nel caricare la snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Batteria scritta %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Errore nello scrivere la batteria %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "I salvataggi della EEPROM non possono essere esportati"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Snapshot (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Esportati da VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Salvato lo snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Errore nel salvare lo snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Seleziona il file di destinazione"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Immagini PNG|*.png|Immagini BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Scritta snapshot %S"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "file ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA Movie files|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Seleziona file"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Seleziona file di stato"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "File di salvataggio di VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Suono abilitato"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Suono disabilitato"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volume: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Imposta a 0 per pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Porta in attesa della connessione:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Connessione GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Aspetto la connessione a %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Aspetto la connessione sulla porta %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Aspetto GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Nintendo GameBoy (+Color+Advance) emulator."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA development team\nCopyright (C) 2007-2017 VBA-M development team"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -418,11 +434,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Questo programma è un software gratuito: puoi ridistribuirlo e/o modificarlo\nsotto i termini della GNU General Public License pubblicata dalla\nFree Software Foundation, sia la versione due della licenza, o\n(a tua scelta) una qualunque versione successiva.\n\nQuesto programma è distribuito nella speranza che sia utile,\nma SENZA ALCUNA GARANZIA; senza nemmeno l'implicita garanzia di\nRESO o RIMBORSO.\nGuarda la GNU General Public License per maggiori dettagli.\n\nDovresti aver ricevuto una copia della GNU General Public License\nassieme a questo programma. Se no, guarda http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "Il collegamento LAN è già attivo. Disabilitare la modalità link per disconnetterlo."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "La rete non è supportata in modalità locale."
 
@@ -626,92 +642,96 @@ msgstr "%d frame = %.2f ms"
 msgid "Default device"
 msgstr "Device predefinito"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Modalità desktop"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Non sono stati trovati plugin rpi utilizzabili in %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Per favore scegli un plugin od un filtro differente"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Selezione del plugin errata"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Questo cancellerà tutti gli acceleratori scelti dal'utente. Sei sicuro?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Conferma"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Icona principale non trovata"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Pannello dello schermo principale non trovato"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Acceleratore del menu doppione: %s per %s e %s; tengo il primo"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Acceleratore del menu %s per %s sovrascrive quello di base per %s ; mantengo il menu"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Oggetto menu invalido %s; lo rimuovo"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Codice"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Descrizione"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Indirizzo"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Vecchio valore"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Nuovo valore"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Menu comandi"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Altri comandi"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Host JoyBus invalido; lo disabilito"
 
@@ -770,99 +790,99 @@ msgstr "Non posso caricare la Game Boy Advance ROM %s"
 msgid " player "
 msgstr "giocatore"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Caricare lo stato %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Errore nel caricare lo stato %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Stato salvato %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Errore nel salvare lo stato %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Modalità schermo intero %dx%d-%d@%d non supportata; guardo per un'altra"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Modalità schermo intero %dx%d-%d@%d  non supportata"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Modalità valida: %dx%d-%d@%d "
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Modalità scelta %dx%d-%d@%d "
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Ho fallito nel cambiate modalità da %dx%d-%d@%d "
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Non è una cartuccia GBA valida"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Non c'è un salvataggio da caricare"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Errore nel salvare lo stato"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "Errore nell'allocazione della memoria"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "errore nell'inizializzazione del codec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "errore nella scrittura del file di destinazione"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "non posso indovinare il formato di destinazione dal nome del file"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "errore di programmazione; annullamento in corso!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Impossibile iniziare a registrare %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Errore con audio/video registrazione (%s); interruzione"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Errore con registrazione audio (%s); interruzione"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Errore con registrazione video (%s); interruzione"
@@ -932,12 +952,12 @@ msgstr "&chiuso"
 msgid "Printed"
 msgstr "Stampato"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "l'apertura di pseudo tty Errore: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "errore di impostazione del socket server (%d)"
@@ -1336,7 +1356,7 @@ msgstr "&Aggiungi codice"
 msgid "Edit Cheat"
 msgstr "Modifica Codice"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Tipo"
 
@@ -2308,8 +2328,8 @@ msgstr "Checksum:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2586,7 +2606,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Fai click su un campo e premi un tasto o muovi il joystick per aggiungere. Premi Backspace per annullare l'ultimo tasto aggiunto. Ridimensiona la finestra o fai click all'interno e muovi il puntatore per vedere tutto il contenuto se è troppo piccolo."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Su"
 
@@ -2594,7 +2614,7 @@ msgstr "Su"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Giù"
 
@@ -2602,7 +2622,7 @@ msgstr "Giù"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Sinistra"
 
@@ -2610,7 +2630,7 @@ msgstr "Sinistra"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Destra"
 
@@ -2618,11 +2638,11 @@ msgstr "Destra"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2746,633 +2766,657 @@ msgstr "Verboso"
 msgid "&File"
 msgstr "&File"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Apri ROM &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Apri ROM GB&C"
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Apri ROM rece&nte"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Pulisci lista ROM recenti"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Blocca lista ROM recenti"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "Info ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Carica Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Salva Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Più &recente"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&Autocarica il più recente"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Da &File..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Non cambiare il &salvataggio a batteria"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Non cambiare lista di &codici"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Carica stato"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&Slot più vecchio"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "A &File"
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Salva stato"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&File batteria..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "File &codici GameShark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Snapshot Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importa"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Esporta"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Cattura sche&rmo"
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Inizia registrazione &suono..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Ferma registrazione s&uono"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Inizia registrazione &video..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Ferma registrazione v&ideo"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Inizia registrazione &gioco..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Ferma registrazione g&ioco"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Registra"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Riproduci &filmato..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Ferma il f&ilmato"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Riproduci"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulazione"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Pausa"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Prossimo frame"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Ri&avvogimento"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Schermo &intero"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "Modalità &turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Salta frame automaticamente"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&Salta BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Patch automatica IPS/UPS/IPF"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Pausa quando inattivo"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Reset"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Opzioni"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Link"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Inizia Link &Network ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Niente"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Cavo"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Wireless"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Modalità Locale"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Link all'avvio"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Speed hack"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Configura ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Video"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Avvia a schermo intero"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&Mantieni rapporto d'aspetto"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "&Filtro Bilineare"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Sempre in primo piano"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "&Barra di stato"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Disabilita OSD"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "&OSD Trasparente"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Audio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&Interpolazione suono GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&Milgioramento suono GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&Effetto surround suoni GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "&Suono declicking GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Input"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Fuoco automatico"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Configura ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&RTC"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Usa file BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Stampa debug"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&Stampante GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Ottieni pagina intera prima di stampare"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Salva stampati come catture di schermo"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Usa file BIOS GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Usa file BIOS GBC"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Generale..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "C&artelle ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "&Scorciatoie da Tastiera ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Strumenti"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Trucchi"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Lista &trucchi ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Trova t&rucco ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Salva/Carica automaticamente trucchi"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Abilita trucchi"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "&Entra in GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Configura porta..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "&Ferma al caricamento"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Disconnetti"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Disassembla..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Logging..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&Visualizzatore IO..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Visualizzatore Mappa..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "V&isualizzatore Memoria..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&Visore OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "&Visualizzatore Tavolozza..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "&Visualizatore Tile..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Mostra Piani"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Canale &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Canale &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Canale &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Canale &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Suono Diretto &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Suono Diretto &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&Canali Suono"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Aiuto"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Segnalazione &Bug"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "&Forum di Supporto VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Traduzione"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/ja.po
+++ b/po/wxvbam/ja.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Japanese (http://www.transifex.com/bgk/vba-m/language/ja/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -53,120 +53,120 @@ msgstr "ゲームボーイカラーファイル (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.
 msgid "Open GBC ROM file"
 msgstr "ゲームボーイカラーのROMファイルを開く"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "不明"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+ポケットカメラ"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -177,230 +177,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "なし"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "ドットコードファイルを選択"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "カードe ドットコードファイル (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "バッテリーファイルを選択"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "バッテリーファイル (*.sav) | *. sav|フラッシュセーブファイル (*.dat) | * .dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "バッテリーファイルをインポートすると、(上書き後は永久に)保存されているセーブデータは全て消去されます。続行しますか？"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "取り込みを確認"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "バッテリーファイル %s を読み込みました"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "%sのバッテリー読み込みエラーが発生しました"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "コードファイルを選択"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark コードファイル (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark コードファイル (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "コードファイルを取り込むと読み込んだ全てのチートが置き換えられます。続行しますか？"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "ファイル %s を開けません"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "サポートされていないコードファイル %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "コードファイル %s を読み込みました"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "コードファイル %s を読み込み中にエラー"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "スナップショットファイルを選択"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC スナップショット (*.sps;*.xps)|*.sps;*.xps|GameShark SP スナップショット (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr " ゲームボーイスナップショット (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "スナップショットファイルを読み込むと、(上書き後は永久に)保存されているセーブデータは全て消去されます。続行しますか？"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "スナップショットファイル %s を読み込みました"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "スナップショットファイル %s を読み込み中にエラー"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "記録しました%s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "記録に失敗しました%s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "EEPROMセーブはエクスポートできません"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark スナップショット (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "VisualBoyAdvance-Mからエクスポート"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "スナップショットファイル %s を保存しました"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "スナップショットファイル %s を保存中にエラー"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "出力ファイルを選択"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG画像|*.png|BMP画像|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "スナップショット %s を書き出しました"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "ファイル ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA動画ファイル|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "ファイルを選択"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "状態ファイルを選択"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance セーブゲームファイル|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "音声を有効化"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "音声を無効化"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "音量： %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "%s への接続を待機中"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "ポート %d での接続を待機中"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Nintendo GameBoy (+Color+Advance) emulator."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA development team\nCopyright (C) 2007-2017 VBA-M development team"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -416,11 +432,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "This program is free software: you can redistribute it and/or modify\nit under the terms of the GNU General Public License as published by\nthe Free Software Foundation, either version 2 of the License, or\n(at your option) any later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License\nalong with this program.  If not, see http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "LANリンクはすでに動作中です。切断するにはリンクモードを無効にします。"
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "ネットワークはローカルモードではサポートされません。"
 
@@ -624,92 +640,96 @@ msgstr "%d フレーム = %.2f ms"
 msgid "Default device"
 msgstr "既定のデバイス"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "デスクトップ画面モード"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "プラグイン"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "プラグインや別の動画フィルターを選択してください"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "プラグイン選択エラー"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "全てのユーザー定義のアクセラレータを消去します。よろしいですね？"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "承認"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "メインアイコンが見つかりません"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "コード"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "説明"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "アドレス"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "以前の値"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "新しい値"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "メニューコマンド"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "その他のコマンド"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "JoyBusホストが無効です。使用停止"
 
@@ -768,99 +788,99 @@ msgstr "ゲームボーイアドバンスROM %s を読み込むことが出来�
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "有効なGBAカートリッジではありません"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "巻き戻しのためのメモリが有りません"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "巻き戻し状態を書き出し中にエラー"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "メモリ確保エラー"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "出力ファイルへの書き出し中にエラー"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "ファイル名から出力形式を推定できません"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "プログラミングエラー。異常終了しました！"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "録音・録画中にエラー (%s) 、中断しています"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "録音中にエラー (%s) 、中断しています"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "録画中にエラー (%s) 、中断しています"
@@ -930,12 +950,12 @@ msgstr "ROMを閉じる(&C)"
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1334,7 +1354,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr "チートを編集"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2306,8 +2326,8 @@ msgstr ""
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2584,7 +2604,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "上"
 
@@ -2592,7 +2612,7 @@ msgstr "上"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "下"
 
@@ -2600,7 +2620,7 @@ msgstr "下"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "左"
 
@@ -2608,7 +2628,7 @@ msgstr "左"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "右"
 
@@ -2616,11 +2636,11 @@ msgstr "右"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "セレクト"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "スタート"
 
@@ -2744,633 +2764,657 @@ msgstr "ログレベル"
 msgid "&File"
 msgstr "ファイル(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "GB ROMファイルを開く...(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "GBC ROMファイルを開く...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "最近開いたファイル(&n)"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "最近開いたファイルのリストを消去(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "最近開いたファイルのリストを固定(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ゲームROM情報...(&f)"
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "カードeリーダー(&e)"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "ドットコードの読込...(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "ドットコードの保存...(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "最新のステート(&r)"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "起動時に最新のステートをロード(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "ファイルからロード...(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "ステートロード(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "ファイルに保存...(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "ステートセーブ(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "インポート(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "エクスポート(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "スクリーンショット...(&u)"
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "サウンドの記録を開始...(&s)"
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "サウンドの記録を停止(&o)"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "録画を開始...(&v)"
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "録画を停止...(&i)"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "記録(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "再開"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "エミュレーション(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "一時停止"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "次のフレーム"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "垂直同期（VSync）(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "自動フレームスキップ(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "BIOSの起動を省略(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "IPS/UPS/IPF パッチを自動で適用(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "非アクティブ時にポーズ(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "リセット(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "設定(O&)"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "通信(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "通信を開始...(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "なし(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "通信ケーブル(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "ワイヤレスアダプタ(&W)"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "ゲームキューブ(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "ゲームボーイ(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "起動時に通信を開始(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Speed hack"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "設定...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "描画(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "全画面表示で開始(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "アスペクト比を固定(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "ウィンドウを常に最前面に表示(&K)"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "ステータスバーを表示(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "OSDを無効化(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "OSDを透過させて表示(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "サウンド(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "入力(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "ボタンの連射(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "ゲームボーイアドバンス(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "設定..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "BIOSファイルを使用(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "接続 ポケットプリンタ(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "GB BIOSファイルを使用(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "GBC BIOSファイルを使用(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "VBA本体の設定...(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "フォルダの設定...(&i)"
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "ホットキーの設定...(&K)"
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "ツール(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "チート(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "チートリストを表示...(&c)"
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "チートサーチ...(&h)"
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "チートの保存/読込を自動で行う(&u)"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "チートの有効化(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "切断"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "ログウィンドウ...(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&IO Viewer..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Map Viewer..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "M&emory Viewer..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&OAM Viewer..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "&Palette Viewer..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "&Tile Viewer..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&View Layers"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Channel &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Channel &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Channel &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Channel &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&Sound Channels"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "ヘルプ(&H)"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "バグの報告(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "サポートフォーラム"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "翻訳に参加"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/ja_JP.po
+++ b/po/wxvbam/ja_JP.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Japanese (Japan) (http://www.transifex.com/bgk/vba-m/language/ja_JP/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "GameBoy Colorファイル (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar
 msgid "Open GBC ROM file"
 msgstr "GBC ROMファイルを開く"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "サウンド有効"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "サウンド無効"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "プラグイン"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr "プレイヤー"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "GBAの正しいカートリッジではありません"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr "&閉じる"
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2589,7 +2609,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2597,7 +2617,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2605,7 +2625,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2613,11 +2633,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&リセット"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&オプション"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&設定 ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&ビデオ"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
-msgstr "&ステータスバー"
-
-#: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
-msgstr ""
-
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr "&ステータスバー"
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&オーディオ"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&入力"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "設定 ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "&ショートカットキー"
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&ツール"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&チート"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&チートの有効化"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&ヘルプ"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "翻訳"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/jv.po
+++ b/po/wxvbam/jv.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Javanese (http://www.transifex.com/bgk/vba-m/language/jv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "Berkas GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.d
 msgid "Open GBC ROM file"
 msgstr "Bukak GBC ROM"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Mbuh"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr "Raono"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Nduwur"
 
@@ -2589,7 +2609,7 @@ msgstr "Nduwur"
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Ngisor"
 
@@ -2597,7 +2617,7 @@ msgstr "Ngisor"
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Ngiwo"
 
@@ -2605,7 +2625,7 @@ msgstr "Ngiwo"
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Nengen"
 
@@ -2613,11 +2633,11 @@ msgstr "Nengen"
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/ko.po
+++ b/po/wxvbam/ko.po
@@ -10,9 +10,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Korean (http://www.transifex.com/bgk/vba-m/language/ko/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -52,120 +52,120 @@ msgstr "게임 보이 컬러 파일  (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.
 msgid "Open GBC ROM file"
 msgstr "게임 보이 컬러 ROM 파일을 열기"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "알 수 없음"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "게임 지니"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "게임 샤크 V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -176,230 +176,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "없음"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "닷 코드 파일을 선택"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-리더 닷 코드 (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "배터리 파일을 선택"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "배터리 파일 (*.sav)|*.sav|플래시 세이브 (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "배터리 파일 가져올 시 저장된 게임을 지울 수도 있습니다. (다음 쓰기 후에 영구적으로) 계속 하시겠습니까?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "가져오기 승인"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "%s 배터리를 불러옴"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "%s 배터리 불러오기 오류"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "코드 파일을 선택"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "게임 샤크 코드 파일 (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "게임 샤크 코드 파일 (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "코드 파일 가져오기 시 이미 불러온 치트를 지울 수도 있습니다. 계속 하시겠습니까?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "%s 파일을 열 수 없음"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "%s 코드 파일을 지원하지 않음"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "%s 코드 파일을 불러옴"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "%s 코드 파일 불러오기 오류"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "스냅샷 파일을 선택 "
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC 스냅샷 (*.sps;*.xps)|*.sps;*.xps|게임샤크 SP 스냅샷 (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "게임 보이 스냅샷 (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "스냅샷 파일 가져오기 시 이미 저장된 게임을 지울 수도 있습니다 (다음 기록 이후 영구적으로). 계속 하시겠습니까?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "%s 스냅샷 파일을 불러옴"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "%s 스냅샷 파일 불러오기 오류"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "%s 배터리가 기록됨"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "%s 배터리 기록 오류"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "EEPROM 저장 방식은 내보낼 수 없음"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "게임 샤크 스냅샷 (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "VisualBoyAdvance-M으로부터 내보내짐"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "%s 스냅샷 파일이 저장됨"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "%s 스냅샷 파일 저장 오류"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "출력 파일을 선택"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG 이미지|*.png|BMP 이미지|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "%s 스냅샷이 기록됨"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "파일 ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA 리플레이 파일|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "파일 선택"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "상태 저장 파일을 선택"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance 상태 저장 파일|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "소리 켜짐"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "소리 꺼짐"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "음량: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "가상 Teletypewriter를 0으로 설정"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "연결 대기용 포트:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB 연결"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "%s로 연결 대기 중"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "%d 포트로 연결 대기 중"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "GDB 대기 중..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "닌텐도 게임 보이 (+컬러+어드밴스) 에뮬레이터"
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA 개발팀\nCopyright (C) 2007-2017 VBA-M 개발팀"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -415,11 +431,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "이 프로그램은 자유 소프트웨어입니다. 소프트웨어의 피양도자는 자유\n소프트웨어 재단이 공표한 GNU 일반 공중 사용 허가서 2판 또는 그\n이후 판을 임의로 선택해서, 그 규정에 따라 프로그램을 개작하거나 \n재배포할 수 있습니다. \n\n이 프로그램은 유용하게 사용될 수 있으리라는 희망에서 배포되고\n있지만, 특정한 목적에 맞는 적합성 여부나 판매용으로 사용할 수 \n있으리라는 묵시적인 보증을 포함한 어떠한 형태의 보증도 제공하지 \n않습니다. 보다 자세한 사항에 대해서는 GNU 일반 공중 사용 허가서를\n참고하시기 바랍니다.\n\nGNU 일반 공중 사용 허가서는 이 프로그램과 함께 제공됩니다. 만약,\n이 문서가 누락되어 있다면 http://www.gnu.org/licenses 를\n참조 바랍니다."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "LAN 연결이 이미 활성화 상태입니다. 연결해체를 위해 연결 모드를 비활성화 하십시오."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "로컬 모드에서는 네트워크가 지원되지 않습니다."
 
@@ -623,92 +639,96 @@ msgstr "%d 프레임 = %.2f ms"
 msgid "Default device"
 msgstr "기본 장치"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "데스크탑 모드"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "%s에서 사용가능한 rpi 플러그인을 찾을 수 없음"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "플러그인"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "플러그인이나 다른 필터를 선택하십시오"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "플러그인 선택 오류"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "모든 사용자 정의 가속기를 지우게 됩니다. 지우시겠습니까?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "승인"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "메인 아이콘을 찾을 수 없음"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "메인 디스플레이 패널을 찾을 수 없음"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "메뉴 가속기 복제: %s 는 %s 와 %s용; 첫 번째 유지"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "%s 메뉴 가속기 (%s에 대해) 는 %s에 대한 초기값을 덮어씌움 ; 메뉴 유지"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "무효한 %s 메뉴 항목 ; 제거"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "코드"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "설명"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "주소"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "이전 값"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "새 값"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "메뉴 명령"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "그 외 명령"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "조이버스 호스트 무효; 비활성화"
 
@@ -767,99 +787,99 @@ msgstr "%s 게임 보이 어드밴스 ROM을 불러올 수 없음"
 msgid " player "
 msgstr " 사용자 "
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "상태 %s 불러옴"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "상태 %s 불러오기 오류"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "상태 %s 저장됨"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "상태 %s 저장 오류"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "전체화면 모드 %dx%d-%d@%d 는 지원되지 않음; 다른 해상도 찾기"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "전체화면 모드 %dx%d-%d@%d 는 지원되지 않음"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "유효한 모드: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "선택된 모드 %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "%dx%d-%d@%d 모드로 변경 실패함"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "유효한 GBA 카트리지가 아님"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "되감기 메모리 없음"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "되감기 상태 쓰기 오류"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "메모리 할당 오류"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "코덱 초기화 오류"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "출력 파일 쓰기 오류"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "파일명에서 출력포맷을 알 수 없습니다."
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "프로그래밍 오류; 종료합니다!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "%s (%s)부터 기록을 시작할 수 없습니다."
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "(%s) 에서 오디오/비디오 녹화 오류; 종료합니다."
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "(%s) 에서 오디오 녹음 오류; 종료합니다."
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "(%s) 에서 비디오 녹화 오류; 종료합니다."
@@ -929,12 +949,12 @@ msgstr "닫기(&C)"
 msgid "Printed"
 msgstr "인쇄됨"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "가상 tty %s를 열 수 없습니다."
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "서버 소켓 셋업 에러 (%d)"
@@ -1333,7 +1353,7 @@ msgstr "치트 추가(&A)"
 msgid "Edit Cheat"
 msgstr "치트 편집"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "형식(&T)"
 
@@ -2305,8 +2325,8 @@ msgstr "체크섬:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2583,7 +2603,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "필드를 클릭하고, 추가할 키를 누르거나 조이스틱을 조작하세요. 마지막으로 추가되었던 키를 삭제하려면 백스페이스를 누르세요. 창이 작아서 잘 안보인다면, 창 크기를 키우거나 창 안쪽을 클릭하고 포인터를 움직이세요."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "상"
 
@@ -2591,7 +2611,7 @@ msgstr "상"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "하"
 
@@ -2599,7 +2619,7 @@ msgstr "하"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "좌"
 
@@ -2607,7 +2627,7 @@ msgstr "좌"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "우"
 
@@ -2615,11 +2635,11 @@ msgstr "우"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "셀렉트"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "스타트"
 
@@ -2743,633 +2763,657 @@ msgstr "상세"
 msgid "&File"
 msgstr "파일(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "게임 보이 열기(&G)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "게임 보이 컬러 열기(&C)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "최근 ROM 열기(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "최근 목록 지우기(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "최근 목록 고정(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ROM 정보(&F)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-리더"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "닷 코드 불러오기(&L)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "닷 코드 저장(&S)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "가장 최근 롬(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "가장 최근 롬 자동 불러오기(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "파일 찾아보기(&F)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "배터리 세이브 변경하지 않기(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "치트 목록 변경하지 않기(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "상태 불러오기(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "가장 오래된 슬롯(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "파일로 저장(&F)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "상태 저장(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "배터리 파일(&B)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "게임샤크 코드 파일(&C)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "게임샤크 스냅샷(&G)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "가져오기(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "내보내기(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "스크린 캡쳐(&U)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "녹음 시작(&S)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "녹음 중지(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "동영상 녹화 시작(&V)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "동영상 녹화 중지(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "리플레이 기록 시작(&G)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "리플레이 기록 중지(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "기록(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "리플레이 재생 시작(&M)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "리플레이 재생 정지(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "재생(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "에뮬레이션(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "일시정지(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "다음 프레임(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "되감기(&W)"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "전체화면 전환(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "터보 모드(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "수직동기(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "프레임 생략 자동(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "BIOS 생략(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "자동 IPS/UPS/IPF 패치(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "창이 비활성일 때 일시정지(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "리셋(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "옵션(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "연결(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "네트워크 연결 시작(&N)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "없음(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "케이블(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "무선(&W)"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "게임 큐브(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "게임 보이(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "로컬 모드(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "기동할 때 연결(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "스피드 핵(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "구성설정(&C)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "동영상(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "전체화면으로 시작(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "화면비율 유지(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "바이리니어 필터(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "창 항상 맨 위(&K)"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "상태 표시줄(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "화면 상 표시 안 함(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "화면 상 표시를 투명화(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "오디오(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&GBA 소리 수정"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&GB 소리 향상"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&GB 입체 음향 효과"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "&GB 소리 잡음제거"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "입력(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "연사(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "게임 보이 어드밴스(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "구성설정..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "실시간 시계(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "BIOS 파일을 사용(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "디버그 프린트(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "게임 보이 프린터(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "출력 전 모든 페이지를 모으기(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "스크린 캡쳐로 저장하기(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "게임 보이 BIOS 파일을 사용(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "게임 보이 컬러 BIOS 파일을 사용(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "일반(&G)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "디렉토리(&I)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "단축키(&K)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "도구(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "치트(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "치트 목록(&C)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "치트 찾기(&H)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "치트 자동으로 저장/불러오기(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "치트 사용(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "GDB로 브레이크(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "포트 구성(&C)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "로드 시 브레이크(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "연결 끊기(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "디스어셈블(&D)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "기록(&L)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "입출력 뷰어(&I)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "맵 뷰어(&M)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "메모리 뷰어(&E)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "OAM 뷰어(&O)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "팔레트 뷰어(&P)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "타일 뷰어(&T)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "개체(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "창 0(&W)"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "창 1(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "개체 창(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "레이어 보기(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "채널 &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "채널 &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "채널 &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "채널 &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "다이렉트 사운드 &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "다이렉트 사운드 &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "사운드 채널(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "도움말(&H)"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "버그 제보(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M 지원 포럼(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "번역하기"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/ko_KR.po
+++ b/po/wxvbam/ko_KR.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-27 16:23+0000\n"
-"Last-Translator: park seungbin <parksengbin48@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Korean (Korea) (http://www.transifex.com/bgk/vba-m/language/ko_KR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "게임보이 컬러 파일 (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.ra
 msgid "Open GBC ROM file"
 msgstr "게임보이컬러 롬 파일 열기"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "롬"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "배터리 파일을 가져오면 저장된 게임이 모두 지워집니다. 계속하시겠습니까?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "가져오기 확인"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "%s를 로드한 배터리"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "코드파일 선택"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "%s파일을 열수 없습니다"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "스냅샷 파일 선택"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "게임보이 스넵샷 (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "로드중 %s 스넵샷 파일 에러"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "%s스넵샷 저장완료 "
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "스넵샷%s저장 중 에러"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "출력파일 선택"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "파일("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "파일 선택"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "소리 켜기"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "소리 끄기"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB 연결"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "포트%d에 연결중이니 기다려주세요"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "닌텐도 게임보이(+컬러+어드벤스) 에뮬레이터입니다."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "로컬 모드에서는 네트워크가 지원되지 않음."
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "데스크탑 모드"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "플러그인"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "플러그인 선택 오류"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "확인"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "코드"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "서술"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "주소"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "오래된 값"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "새로운 값"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr "플레이어"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2589,7 +2609,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2597,7 +2617,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2605,7 +2625,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2613,11 +2633,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/ms_MY.po
+++ b/po/wxvbam/ms_MY.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Malay (Malaysia) (http://www.transifex.com/bgk/vba-m/language/ms_MY/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "Fail GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg
 msgid "Open GBC ROM file"
 msgstr "Buka fail ROM GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Tidak diketahui"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Tiada"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Pilih fail Dot Code"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Pilih fail bateri"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Fail bateri (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Mengimport fail bateri akan memadam mana-mana permainan tersimpan (secara kekal selepas penulisan berikutnya). Anda mahu teruskan?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Sahkan pengimportan"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Memuatkan bateri %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Raat memuatkan bateri %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Pilih fail kod"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Fail Kod Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Fail Kod Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Mengimport fail kod akan gantikan mana-mana tipuan yang dimuatkan. Anda mahu teruskan?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Tidak dapat membuka fail %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Fail kod %s tidak disokong"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Memuatkan fail kod %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Raat memuatkan fail kod %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Pilih fail petikan"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Petikan GS & PAC (*.sps;*.xps)|*.sps;*.xps|Petikan SP GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Petikan Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Mengimport fail petikan akan memadam mana-mana permainan tersimpan (secara kekal selepas penulisan berikutnya). Anda mahu teruskan?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Fail petikan %s dimuatkan"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Ralat memuatkan fail petikan %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Tulis bateri %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Ralat menulis bateri %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Simpan EEPROM tidak dapat dieksport"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Petikan Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Dieksport dari VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Fail petikan tersimpan %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Ralat menyimpan fail petikan %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Pilih fail output"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "imej PNG|*.png|imej BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Tulis petikan %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr " fail ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "fail Cereka VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Pilih fail"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Pilih fail keadaan"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Fail permainan tersimpan VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Bunyi dibenarkan"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Bunyi dilumpuhkan"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volum: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Tetapkan 0 untuk tty pseudo"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Port menunggu sambungan:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Sambungan GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Menunggu sambungan pada %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Menunggu sambungan pada port %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Menunggu GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulator Nintendo GameBoy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Hakcipta (C) 1999-2003 Forgotten\nHakcipta (C) 2004-2006 Pasukan pembangunan VBA\nHakcipta (C) 2007-2017 Pasukan pembangunan VBA-M"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Program ini adalah perisian bebas: anda boleh edar semula ia dan/atau\nubahsuai ia di bawah terma Lesen Awam Am GNU sepertimana yang disiarkan\noleh Free Software Foundation. sama ada versi 2 dari Lesen, atau (mengikut\npilihan anda) mana-mana versi terkemudian.\n\nProgram ini diedar dengan harapan ia berguna, tetapi TANPA APA JUA\nJAMINAN; dan juga jaminan daripada KEBOLEHPASARAN atau KESESUAIAN\nATAS APA JUA TUJUAN. Sila rujuk Lesen Awam Am GNU untuk maklumat\nlanjut.\n\nAnda seharusnya menerima satu salinan Lesen Awam Am GNU bersama\n-sama program ini. Jika tiada, sila rujuk http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "Pautan LAN sudah aktif. Lumpuhkan mod paut untuk putuskan."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Rangkaian tidak disokong dalam mod setempat."
 
@@ -621,92 +637,96 @@ msgstr "%d bingkai = %.2f ms"
 msgid "Default device"
 msgstr "Peranti lalai"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Mod desktop"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Tiada pemalam rpi boleh guna ditemui dalam %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Pemalam"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Sila pilih satu pemalam atau penapis lain"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Ralat pemilihan pemalam"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Ini akan mengosongkan semua pemecut ditakrif-pengguna. Anda pasti?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Sahkan"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Ikon utama tidak ditemui"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Panel paparan utama tidak ditemui"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Pemecut menu pendua: %s bagi%s dan%s; kekalkan yang pertama"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Pemecut menu %s untuk %s membatalkan lalai bagi %s ; kekalkan menu"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Item menu %s tidak sah; dibuang"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kod"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Keterangan"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Alamat"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Nilai Lama"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Nilai Baharu"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Perintah menu"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Perintah lain"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Hos JoyBus tidak sah; dilumpuhkan"
 
@@ -765,99 +785,99 @@ msgstr "Tidak boleh memuatkan ROM Game Boy Advance %s"
 msgid " player "
 msgstr "pemain"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Keadaan %s dimuatkan"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Ralat memuatkan keadaan %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Keadaan terimpan %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Ralat menyimpan keadaan %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Mod skrin penuh %dx%d-%d@%d tidak disokong; cari yang lain"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Mod skrin penuh %dx%d-%d@%d tidak disokong"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Mod sah: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Mod pilihan %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Gagal mengubah mod ke %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Bukan katrij GBA yang sah"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Tiada ingatan untuk dimandirkan"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Ralat menulis keadaan mandir"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "ralat peruntukan ingatan"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "ralat mengawalkan kodeks"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "ralat menulis ke fail output"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "tidak dapat teka format output dari nama fail"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "ralat pengaturcaraan; dihenti paksa!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Tidak dapat memulakan rakaman pada %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Ralat dalam rakaman audio/video (%s); dihenti paksa"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Ralat dalam rakaman (%s); dihenti paksa"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Ralat dalam rakaman video (%s); dihenti paksa"
@@ -927,12 +947,12 @@ msgstr "&Tutup"
 msgid "Printed"
 msgstr "Dicetak"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Ralat membuka tty pseudo: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Ralat menetapkan soket pelayan (%d)"
@@ -1331,7 +1351,7 @@ msgstr "&Tambah menipu"
 msgid "Edit Cheat"
 msgstr "Sunting Menipu"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Jenis"
 
@@ -2303,8 +2323,8 @@ msgstr "Hasil tambah semak:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Klik pada medan dan tekan kekunci atau gerakkan kayu ria untuk tambah. Ketik backspace untuk memadam kekunci terakhir yang ditambah. Saiz semula tetingkap atau klik di dalam dan gerakkan penuding untuk melihat keseluruhan kandungan jika terlalu kecil."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Naik"
 
@@ -2589,7 +2609,7 @@ msgstr "Naik"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Turun"
 
@@ -2597,7 +2617,7 @@ msgstr "Turun"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Kiri"
 
@@ -2605,7 +2625,7 @@ msgstr "Kiri"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Kanan"
 
@@ -2613,11 +2633,11 @@ msgstr "Kanan"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Pilih"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Mula"
 
@@ -2741,633 +2761,657 @@ msgstr "Berjela"
 msgid "&File"
 msgstr "&Fail"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Buka &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Buka GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Buka ba&ru-baru ini"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Tetap semula senarai baru-baru ini"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Kaku senarai baru-baru ini"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "Ma&klumat ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Muat Kod Dot..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Simpan Kod Dot..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Te&rbaharu"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&Auto muat terbaharu"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Dari &Fail ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Jangan ubah simpan &bateri"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Jangan ubah senarai &menipu"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Muat keadaan"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "Slot te&rlama"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Ke &Fail ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Simpan keadaan"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "Fail &bateri..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Fail &kod Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Petikan &Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Import"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Eksport"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Tan&gkapan skrin..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Mulakan rakaman &bunyi..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Henti rakaman &bunyi"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Mulakan rakaman &video..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Henti rakaman v&ideo"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Mulakan rakaman &permainan..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Henti rakaman p&ermainan"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Rakam"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Mula memainkan &cereka..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Henti memainkan c&ereka"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Main"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulasi"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Jeda"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "Bingkai b&erikutnya"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "&Mandir"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Togol skrin &penuh"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "Mod &turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Auto langkau bingkai"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&Langkau BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Auto tampalan IPS/UPS/IPF"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Jeda jika tidak aktif"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Tetap semula"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Pilihan"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Pautan"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Mula Pautan &Rangkaian ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Tiada Apa-Apa"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Kabel"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "Tanpa &Wayar"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "Mod &setempat"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Paut ketika but"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Godam kelajuan"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Konfigure ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Video"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Mula dalam sktin penuh"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&Kekal nisbah bidang"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "Penapis &dwilinear"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Kekalkan tetingkap di atas"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Palang &Status"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Lumpuhkan paparan atas-skrin"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Paparan atas-skrin &lutsinar"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Audio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "Interpolasi bunyi &GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "Penambahbaikan bunyi &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "Kesan bunyi keliling &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "Nyahklik bunyi &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Input"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Autotembak"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Konfigure ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "Waktu masa-n&yata"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Guse fail BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Nyahpepijat cetak"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "Pencetak &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Himpun halaman penuh sebelum mencetak"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Simpan cetakan sebagai tangkapan skrin"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Guna fail BIOS GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Guna fail BIOS GBC"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Am ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "D&irektori ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Pintasan &Kekunci ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Alatan"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Menipu"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Senarai &menipu ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Cari &tipu ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Simpan/muat tipu secara a&utomatik"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "B&enarkan menipu"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "Pe&cah menjadi GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Konfigur port..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "P&ech ketika muat"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "P&utuskan"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Nyahhimpun"
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "Peng&elogan"
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Pelihat &IO"
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Pelihat P&eta..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Pelihat &Ingatan..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "Pelihat &OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Pelihat &Palet..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Pelihat &Jubin..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Lihat Lapisan"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Saluran &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Saluran &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Saluran &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Saluran &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Saluran &Bunyi"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Bantuan"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Lapor P&epijat"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "&Forum Sokongan VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Terjemahan"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/nb.po
+++ b/po/wxvbam/nb.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Norwegian Bokmål (http://www.transifex.com/bgk/vba-m/language/nb/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -53,120 +53,120 @@ msgstr "GameBoy Color-filer (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dm
 msgid "Open GBC ROM file"
 msgstr "Åpne GBC ROM-fil"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Ukjent"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -177,230 +177,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Ingen"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Velg Dot Code fil"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Velg batterifil"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Batterifil (*.sav)|*.sav|Lagret Flash (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importering av en batterifil vil slette alle lagrede spill (permanent etter neste lagring). Vil du fortsette?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Bekreft importering"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Lastet batteri %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Feil under lasting av batteri %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Velg kodefil"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark kodefile (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark kodefil (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Importering av en kodefil vil erstatte alle aktive koder. Vil du fortsette?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Kunne ikke åpne fil %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Kodefilen %s er ikke støttet"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Lastet kodefil %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Feil under lasting av kodefil %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Velg snapshot-fil"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy Snapshot (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importering av et snapshot vil fjerne alle lagrede spill (permanent etter neste lagring). Vil du fortsette?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Lastet snapshot-fil %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Feil under lasting av snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Lagret batteri %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Feil under lagring av batteri %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "EEPROM lagringer kan ikke bli eksportert"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Snapshot (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Eksportert fra VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Lagret snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Feil under lagring av snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Velg ut-fil"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG bilder |*.png|BMP bilder |*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Skrev snapsot %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "filer ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA Filmfiler |*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Velg fil"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Velg statusfil"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance lagret spill |*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Lyd er på"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Lyd er av"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volum: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Set til 0 for pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Vent på tilkobling på port:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB Tilkobling"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Venter på tilkobling på %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Venter på tilkobling på port %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Venter på GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Nintendo GameBoy (+Color+Advance) emulator."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Kopirett © 1999-2003 Forgotten\nKopirett © 2004-2006 VBA utviklingslag\nKopirett © 2007-2017 VBA-M utviklingslag"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -416,11 +432,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Dette programmet er basert på åpen kildekode:  Du kan redistribuere den, \nog/eller modifisere under vilkårene som beskrevet i GNU General Public License \nslik den er publisert av \"the Free Software Foundation\", enten versjon 2 \nav lisensen, eller (som følge av ditt valg) en hvilken som helst senere versjon.\n\nDette programmet er blitt distribuert i håp om at det vil være til nytte \nfor deg, men UTEN NOEN FORM FOR GARANTI; selv uten en eventuell \nimplisert garanti som følge av VIDERESALG eller \nEGNETHET FOR ET BESTEMT FORMÅL. \nDet henvises til GNU General Public License for en mer detaljert beskrivelse.\n\nDu skal ha mottatt en kopi av GNU General Public License\nsammen \nmed dette programmet,  hvis ikke dette er tilfellet, \nse http://www.gnu.org/licenses .\n\n-----\n\nImportant note from translator: This is a free translation into Norwegian \nfor the convenience to the end user. It is not accurate, \nand thus the original disclaimer in English (below) is regarded \nas the correct to use in any eventual legal matter.\n\n-----\n\nThis program is free software: you can redistribute it and/or modify \nit under the terms of the GNU General Public License as published \nby the Free Software Foundation, either version 2 of the License, \nor (at your option) any later version.  \n\nThis program is distributed in the hope that it will be useful, \nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the \nGNU General Public License for more details.\n\nYou should have received a copy of \nthe GNU General Public License\nalong with this program. If not, see \nhttp://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "LAN linken er allerede aktiv. Deaktivér link-modus for å koble fra."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Nettverk er ikke støttet i lokalmodus."
 
@@ -624,92 +640,96 @@ msgstr "%d bilder = %.2f ms"
 msgid "Default device"
 msgstr "Standard enhet"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Skrivebordsmodus"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Ingen brukbare rpi plugins funnet i %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Velg en plugin eller et annet filter"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Feil under valg av plugin"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Dette vil fjerne alle brukerdefinerte akseleratorer. Er du sikker?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Bekreft"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Hovedikon ikke funnet"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Primært visningspanel ikke funnet"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Overflødig menyakselerator: %s for %s og %s; bruker første"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Menyakseleratoren %s for %s overstyrer standarden for %s ; beholder meny"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Ugyldig menyvalg %s; fjernes"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kode"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Beskrivelse"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Adresse"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Gammel verdi"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Ny verdi"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Menyvalg"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Andre valg"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "JoyBus vert ugyldig; deaktiveres"
 
@@ -768,99 +788,99 @@ msgstr "Kunne ikke laste Game Boy Advance ROM %s"
 msgid " player "
 msgstr "avspiller"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Lastet tilstand %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Kunne ikke laste tilstand %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Lagret tilstand %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Feil under lagring av tilstand %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Fullskjermsmodusen %dx%d-%d@%d er ikke støttet; leter etter alternativ"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Fullskjermsmodusen %dx%d-%d@%d er ikke støttet"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Gyldig modus: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Valgte modus %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Kunne ikke bytte til modus %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Ikke en gyldig GBA kassett"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Intet minne for tilbakespoling"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Feil under skriving av tilbakespolingstilstand"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "minneallokeringsfeil"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "feil under initialisering av kodek"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "feil under skriving av ut-fil"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "kunne ikke bestemme format fra filnavn"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "programmeringsfeil; avbryter!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Kunne ikke starte opptak til %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Feil i lyd-/videoopptak (%s); avbryter"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Feil i lydopptak (%s); avbryter"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Feil i videoopptak (%s); avbryter"
@@ -930,12 +950,12 @@ msgstr "&Lukk"
 msgid "Printed"
 msgstr "Skrevet ut"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Feil under åpning av pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Feil under oppsett av serverkobling (%d)"
@@ -1334,7 +1354,7 @@ msgstr "&Legg til kode"
 msgid "Edit Cheat"
 msgstr "Rediger kode"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Skriv"
 
@@ -2306,8 +2326,8 @@ msgstr "Sjekksum:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2584,7 +2604,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Klikk i et felt, og trykk en tast eller beveg joystick for å legge til. Bruk backspace for å slette siste tast som ble lagt til. Forsøk å endre vindusstørrelse, eller klikk innenfor mens du beveger pekeren for å se fullstendig innhold hvis vinduet er for lite."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Opp"
 
@@ -2592,7 +2612,7 @@ msgstr "Opp"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Ned"
 
@@ -2600,7 +2620,7 @@ msgstr "Ned"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Venstre"
 
@@ -2608,7 +2628,7 @@ msgstr "Venstre"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Høyre"
 
@@ -2616,11 +2636,11 @@ msgstr "Høyre"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select-knapp"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start-knapp"
 
@@ -2744,633 +2764,657 @@ msgstr "Verbose"
 msgid "&File"
 msgstr "&Fil"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Åpne &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Åpne GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Åpne ny&lig"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Tøm nylig åpnet listen"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Frys nylig åpnet listen"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "In&formasjon om ROMen"
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-leser"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Last inn dott-kode"
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Lagre dott-kode…"
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "&Nyligste"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&Automatisk innlasting av nyligste"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Fra &fil …"
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Ikke endre &batterilagring"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Ikke endre &juksekodeliste"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Last tilstand"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&Eldste plass"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Til &fil …"
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Lagre tilstand"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&Batterifil…"
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Gameshark &kodefil…"
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Gameshark-tilstandsbilde…"
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importér"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Eksportér"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Skjermavbild&ing..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Start &lydopptak..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Stopp ly&dopptak"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Start &videoopptak…"
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Stopp vide&oopptak"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Start s&pillopptak…"
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Stop spilloppt&ak"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Ta opp"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Start avspilling av &film"
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Stopp avspilling av fil&m"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Spill av"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulering"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Pause"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Neste bilde"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Spol &tilbake"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Veksle &fullskjermsvisning"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Turbomodus"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Hopp over bilder automatisk"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&Hopp over BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Automatisk IPS/UPS/IPF-programfiks"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Pause når inaktiv"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Tilbakestill"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Valg"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Lenk til"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Start &nettverkslenke …"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Ingenting"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Kabel"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Trådløs"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&GameBoy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Lokalmodus"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Lenk ved oppstart"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Speed hack"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Sett opp …"
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Video"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Start i fullskjermsvisning"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&Behold billedforhold"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "&Bilineært filter"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Behold vindu over alt annet"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "&Statusfelt"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Slå av skjermindikatorer"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "&Gjennomsiktige skjermindikatorer"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Lyd"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "Lydinterpolering for &GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "Lydforbedring for &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "Kringlydeffekt for &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "Klikkorrigering for &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Inndata"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Autoskyt"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Sett opp …"
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&Sann-tids klokke"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Bruk BIOS-fil"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Feilrettingsutskrift"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&GB skriver"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Innhent hele siden før utskrift"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Lagre utskrifter som skjermskudd"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Bruk GB BIOS-fil"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Bruk GBC BIOS-fil"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Generelt"
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "M&apper ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "&Hurtigsnarveier …"
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Verktøy"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Juksekoder"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "&List opp &juksekoder …"
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Finn j&uksekoder …"
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Lagre/las&t inn juksekoder automatisk"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Skru på juksekoder"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "&Bryt til GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Sett opp port…"
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "&Bryt ved innlasting"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Koble fra"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Disassemble..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Loggføring"
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&IO-visning..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Kartvisning…"
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "M&innevisning…"
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&OAM-visning…"
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "&Palett-visning…"
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "&Flis-visning…"
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Vis lag"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Kanal &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Kanal &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Kanal &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Kanal &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direkte lyd &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direkte lyd &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&Lydkanaler"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Hjelp"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Rapporter &Feil"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M Brukerstøtte &Forum"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Oversettelser"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/nl.po
+++ b/po/wxvbam/nl.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Dutch (http://www.transifex.com/bgk/vba-m/language/nl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -51,120 +51,120 @@ msgstr "GameBoy Color Bestanden (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|
 msgid "Open GBC ROM file"
 msgstr "Open GBC ROM bestand"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -175,230 +175,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Geen"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Selecteer Dot Code bestand"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Selecteer batterij bestand"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Batterij bestand (*.sav)|*.sav|Flash opslag (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Het importeren van een batterij bestand wist alle opgeslagen (permanent na de volgende schrijfactie).  Wil je toch doorgaan?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Bevestig importeren"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Batterij %s geladen"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Fout bij het laden van batterij %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Selecteer code bestand"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark Code Bestand (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark Code Bestand (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Het te importeren codebestand zal alle geladen cheats vervangen. Wil je toch doorgaan?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Kan bestand %s niet openen"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Codebestand %s wordt niet ondersteund."
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Codebestand %s geladen"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Fout bij het laden van codebestand %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Selecteer snapshot bestand"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy Snapshot (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Het importeren van een snapshot bestand zal alle opgeslagen spellen wissen (permanent na de volgende schrijfbewerking). Wil je toch doorgaan?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Snapshotbestand %s geladen"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Fout bij laden van snapshotbestand %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Batterij %s geschreven"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Fout bij schrijven batterij %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Opgeslagen EEPROM spellen kunnen niet worden geëxporteerd "
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Snapshot (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Geëxporteerd uit VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Opgeslagen snapshotbestand %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Fout bij opslaan van snapshotbestand %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Selecteer outputbestand"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG-afbeeldingen|*.png|BMP-afbeeldingen|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Snapshot %s geschreven "
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "bestanden ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA-filmbestanden | * .vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Selecteer bestand"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Selecteer bestand van stand"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance opgeslagen gamebestanden|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Geluid ingeschakeld"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Geluid uitgeschakeld"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volume: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Stel in op 0 voor pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Poort om op verbinding te wachten:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB-verbinding"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Wachten op verbinding bij %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Wachten op verbinding op poort %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Wachten op GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Nintendo GameBoy (+Color+Advance) emulator."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 ForgottenCopyright (C) 2004-2006 VBA development teamCopyright (C) 2007-2017 VBA-M development team"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -414,11 +430,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "This program is free software: you can redistribute it and/or modify\nit under the terms of the GNU General Public License as published by\nthe Free Software Foundation, either version 2 of the License, or\n(at your option) any later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the\nGNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License\nalong with this program. If not, see http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "LAN-verbinding is al actief. Schakel linkmodus uit om de verbinding te verbreken."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Netwerk wordt niet ondersteund in de lokale modus."
 
@@ -622,92 +638,96 @@ msgstr "%d frames = %.2f ms"
 msgid "Default device"
 msgstr "Standaard apparaat"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Desktop modus"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Geen bruikbare rpi plugin gevonden in %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Plug-in"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Selecteer een plugin of een ander filter"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Fout bij het selecteren van plugin"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Dit zal alle door de gebruiker gedefinieerde versnellers wissen. Weet je het zeker?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Bevestig"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Hoofd icoon niet gevonden"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Hoofd beeldscherm niet gevonden"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Dubbele menu versneller: %s voor %s en %s; de eerste wordt behouden."
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Menu versneller %s voor %s overschrijft de standaard voor %s; menu wordt behouden"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Ongeldig menu item %s; wordt verwijderd"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Code"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Omschrijving"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Adres"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Oude waarde"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Nieuwe waarde"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Menu commando's"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Andere commando's"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "JoyBus host ongeldig; wordt uitgeschakeld"
 
@@ -766,99 +786,99 @@ msgstr "Kan Game Boy Advance ROM %s niet laden"
 msgid " player "
 msgstr "speler"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Geladen stand %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Fout bij laden stand %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Opgeslagen stand %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Fout bij opslaan stand %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Volledig scherm modus %dx%d-%d@%d wordt niet ondersteund; op zoek naar een andere"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Volledig scherm modus %dx%d-%d@%d wordt niet ondersteund"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Geldige modus: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Modus %dx%d-%d@%d geselecteerd"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Wijzigen van modus naar %dx%d-%d@%d is mislukt"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Geen geldige GBA cartridge"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Geen geheugen om terug te spoelen"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Fout bij het schrijven van de terugspoel stand"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "geheugentoewijzingsfout"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "fout bij initialiseren van codec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "Fout bij schrijven naar outputbestand"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "kan het outputformaat van de bestandsnaam niet raden"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "programmeerfout; afbreken!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Kan niet beginnen met opnemen naar %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Fout in geluid/video opname (%s); afbreken"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Fout in geluidsopname (%s); afbreken"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Fout in video opname (%s); afbreken"
@@ -928,12 +948,12 @@ msgstr "&Sluiten"
 msgid "Printed"
 msgstr "Geprint"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Fout bij openen van pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Fout bij het opzetten van de server socket (%d)"
@@ -1332,7 +1352,7 @@ msgstr "&Toevoegen cheat"
 msgid "Edit Cheat"
 msgstr "Bewerk Cheat"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Type"
 
@@ -2304,8 +2324,8 @@ msgstr "Checksum:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2582,7 +2602,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Klik op een veld en druk op een toets of beweeg de joystick om toe te voegen. Druk op backspace om de laatst toegevoegde toets te wissen. Pas de venstergrootte aan of beweeg de aanwijzer om de gehele inhoud te zien als het venster te klein is."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Omhoog"
 
@@ -2590,7 +2610,7 @@ msgstr "Omhoog"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Omlaag"
 
@@ -2598,7 +2618,7 @@ msgstr "Omlaag"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Links"
 
@@ -2606,7 +2626,7 @@ msgstr "Links"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Rechts"
 
@@ -2614,11 +2634,11 @@ msgstr "Rechts"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2742,633 +2762,657 @@ msgstr "Uitgebreid"
 msgid "&File"
 msgstr "&Bestand"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Open &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Open GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Open rece&nt"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Reset recente lijst"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Recente freeze lijst"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ROM-in&formatie..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Laden Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Opslaan Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Meest &recent"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&Automatisch meest recente laden"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Uit &Bestand…"
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Opgeslagen &batterij niet wijzigen"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "&Cheat lijst niet wijzigen"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Laad stand"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&Oudste slot"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Naar &Bestand"
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "Stand op&slaan"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&Batterij bestand"
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Gameshark &code bestand..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Gameshark snapshot..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importeren"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Exporteren"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Schermopname..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Start &geluidsopname..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Stop &geluidsopname..."
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Start &video opname..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Stop &video opname..."
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Start &spelopname..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Stop &spelopname..."
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Opnemen"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Start afspelen &film..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Stop afpelen f&ilm"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Afspelen"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulatie"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Pauze"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Volgende frame"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Terug&spoelen"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Omschakelen &volledig scherm"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Turbomodus"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Auto frames overslaan"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&BIOS overslaan"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Auto IPS/UPS/IPF-patch"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Pauzeer wanneer inactief"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Resetten"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Opties"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Link"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Start &Netwerk Link ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Niets"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Kabel"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Draadloos"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Locale modus"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Link bij opstarten"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Snelheidshack"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Configureren ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Video"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Start in volledig scherm"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&Behoud hoogtebreedteverhouding"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "Bilineair filter"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Houd scherm altijd boven"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "&Statusbalk"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Uitschakelen on-screen display"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "&Transparant on-screen display"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Geluid"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&GBA geluidsinterpolatie"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&GB geluidsverbetering"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&GB surround geluidseffect"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "&GB geluid declicking"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Input"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Automatisch drukken"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Configureren ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&Realtimeklok"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Gebruik BIOS-bestand"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Debug print"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&GB printer"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Haal een volledige pagina op voor het printen"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Prints opslaan als schermafbeeldingen"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Gebruik GB BIOS-bestand"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Gebruik GBC BIOS-bestand"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Algemeen ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "M&appen ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "&Sneltoetsen ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Hulpmiddelen"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Cheats"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Lijst &cheats ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Vind c&heat ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Automatisch cheats opslaan/laden"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Cheats inschakelen"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "&Onderbreek naar GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Configureer poort..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "&Onderbreek bij laden"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Verbinding verbreken"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Disassembleer…"
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Loggen…"
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&IO Weergave..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Kaart Weergave…"
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "G&eheugen Weergave..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&OAM Weergave..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "&Palet Weergave..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "&Tile Weergave..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "Bekijk &Lagen"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Kanaal &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Kanaal &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Kanaal &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Kanaal &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&Geluidskanalen"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Help"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Rapporteer &Bugs"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M Ondersteuning &Forum"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Vertalingen"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/nl_NL.po
+++ b/po/wxvbam/nl_NL.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Dutch (Netherlands) (http://www.transifex.com/bgk/vba-m/language/nl_NL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/no.po
+++ b/po/wxvbam/no.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Norwegian (http://www.transifex.com/bgk/vba-m/language/no/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/pl.po
+++ b/po/wxvbam/pl.po
@@ -11,9 +11,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-30 09:27+0000\n"
-"Last-Translator: Damian Drakon <dragon1590@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Polish (http://www.transifex.com/bgk/vba-m/language/pl/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -53,120 +53,120 @@ msgstr "Pliki konsoli GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.r
 msgid "Open GBC ROM file"
 msgstr "Otwórz plik pamięci ROM konsoli GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -177,230 +177,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Brak"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Wybierz plik Dot Code"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Wybierz plik baterii"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Plik baterii (*.sav)|*.sav|Zapis Flash (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Zaimportowanie pliku baterii usunie wszystkie zapisy gry (na stałe po ponownym zapisie). Czy chcesz kontynuować?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Potwierdź importowanie"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Wczytana bateria %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Niepowodzenie przy wczytywaniu baterii %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Wybierz plik z kodami"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Plik kodów Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Plik kodów Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Zaimportowanie pliku z kodami zastąpi wszystkie wczytane kody. Czy chcesz kontynuować?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Nie można otworzyć pliku %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Nieobsługiwany plik z kodami %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Wczytany plik z kodami %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Niepowodzenie przy wczytywaniu pliku z kodami %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Wybierz plik zrzutu"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Zrzuty GS i PAC (*.sps;*.xps)|*.sps;*.xps|Zrzuty GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Zrzut konsoli Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Zaimportowanie pliku zrzutu usunie wszystkie zapisy gry (na stałe po ponownym zapisie). Czy chcesz kontynuować?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Wczytany plik zrzutu %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Niepowodzenie przy wczytywaniu pliku zrzutu %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Zapisana bateria %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Niepowodzenie przy zapisywaniu baterii %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Zapisy EEPROM nie mogą być wyeksportowane"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Zrzut Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Wyeksportowane z VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Zapisany plik zrzutu %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Niepowodzenie przy zapisywaniu pliku zrzutu %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Zapisz jako..."
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Obrazy PNG|*.png|Obrazy BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Zapisany zrzut %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "pliki ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Pliki filmów VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Wybierz plik"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Wybierz plik zapisu stanu gry"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Pliki zapisu gry emulatora VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Dźwięk włączony"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Dźwięk wyłączony"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Głośność: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Ustaw na 0 dla pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Port oczekiwania na połączenie:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Połączenie GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Oczekiwanie na połączenie z %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Oczekiwanie na połączenie z portem %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Oczekiwanie na GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulator Nintendo GameBoy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Prawa Autorskie (C) 1999-2003 Forgotten\nPrawa Autorskie (C) 2004-2006 VBA development team\nPrawa Autorskie (C) 2007-2017 VBA-M development team"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -416,11 +432,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Ten program jest darmowym oprogramowaniem: możesz go rozpowszechniać\nlub modyfikować zgodnie z warunkami 2, albo (wedle własnego uznania)\ndowolnej późniejszej, wersji Powszechnej Licencji Publicznej GNU\nopublikowanej przez Free Software Foundation.\n\nTen program jest rozpowszechniany w nadziei, że będzie przydatny, ale BEZ\nŻADNEJ GWARANCJI; bez nawet dorozumianej gwarancji PRZYDATNOŚCI\nHANDLOWEJ lub PRZYDATNOŚCI DO OKREŚLONEGO CELU. Więcej informacji\nmożna znaleźć w Powszechnej Licencji Publicznej GNU.\n\nWraz z tym programem powinieneś otrzymać kopię Powszechnej Licencji\nPublicznej GNU. Jeśli tak się nie stanie, zobacz http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "Połączenie LAN jest już aktywne. Wyłącz tryb połączenia aby się rozłączyć."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "W trybie lokalnym sieć nie jest wspierana."
 
@@ -624,92 +640,96 @@ msgstr "%d klatki/klatek = %.2f ms"
 msgid "Default device"
 msgstr "Urządzenie domyślne"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Tryb pulpitu"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Nie znaleziono użytecznych wtyczek rpi w %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Wtyczka"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Proszę wybrać wtyczkę lub inny filtr"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Błąd wyboru wtyczki"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "To działanie spowoduje usunięcie wszystkich akceleratorów zdefiniowanych przez użytkownika. Czy chcesz kontynuować?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Potwierdź "
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Nie znaleziono głównej ikony"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Nie znaleziono głównego panelu wyświetlacza"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Zduplikowanie skrótu klawiszowego: %s dla %s i %s; pierwszy zostaje zachowany"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Skrót klawiszowy %s dla %s zastępuje domyślny dla %s ; menu zostaje zachowane"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Nieprawidłowy element menu %s; usuwanie"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kod"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Opis"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Adres"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Stara Wartość"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Nowa Wartość"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Polecenia menu"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Inne polecenia"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Nieprawidłowy host JoyBus; wyłączanie"
 
@@ -768,99 +788,99 @@ msgstr "Nie można załadować pliku pamięci ROM konsoli Game Boy Advance %s"
 msgid " player "
 msgstr "gracz"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Wczytano zapisany stan gry %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Niepowodzenie przy wczytywaniu zapisanego stanu gry %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Zapisany stan gry %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Niepowodzenie przy zapisywaniu stanu gry %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Tryb pełnoekranowy %dx%d-%d@%d nie jest wspierany; szukanie innego "
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Tryb pełnoekranowy %dx%d-%d@%d nie jest wspierany "
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Wspierany tryb: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Wybrano tryb %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Nie można zmienić trybu na %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Nieprawidłowy kartridż konsoli GBA"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Brak pamięci na przewijanie wstecz"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Niepowodzenie przy zapisywaniu stanu przewijania wstecz"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "błąd alokacji pamięci"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "niepowodzenie przy inicjowaniu kodeka"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "niepowodzenie przy zapisywaniu pliku"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "nie można rozpoznać formatu wyjściowego z nazwy pliku"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "błąd programowania; przerywanie!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Nie można rozpocząć nagrywania do %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Błąd podczas nagrywania dźwięku/obrazu (%s); przerywanie"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Błąd podczas nagrywania dźwięku (%s); przerywanie"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Błąd podczas nagrywania wideo (%s); przerywanie"
@@ -930,12 +950,12 @@ msgstr "Zamknij"
 msgid "Printed"
 msgstr "Wydrukowano"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Niepowodzenie przy otwieraniu pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Niepowodzenie przy konfigurowaniu gniazda serwera (%d)"
@@ -1334,7 +1354,7 @@ msgstr "Dodaj kod"
 msgid "Edit Cheat"
 msgstr "Edytuj Kod"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "Typ"
 
@@ -2306,8 +2326,8 @@ msgstr "Suma kontrolna:"
 msgid "&0"
 msgstr "0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "1"
 
@@ -2584,7 +2604,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "By wprowadzić zmiany, kliknij wybrane pole i naciśnij przycisk na klawiaturze lub dżojpadzie, który chcesz przypisać, albo naciśnij klawisz Backspace, by usunąć ostatni dodany przycisk. Jeśli zawartość pól nie jest w pełni widoczna, to zmień rozmiar okna lub kliknij i przytrzymaj lpm - lewy klawisz myszy - wewnątrz wybranego pola, a następnie przeciągnij wskaźnikiem myszy."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr " Góra"
 
@@ -2592,7 +2612,7 @@ msgstr " Góra"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr " Dół"
 
@@ -2600,7 +2620,7 @@ msgstr " Dół"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Lewo"
 
@@ -2608,7 +2628,7 @@ msgstr "Lewo"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Prawo"
 
@@ -2616,11 +2636,11 @@ msgstr "Prawo"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Wybierz"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2744,634 +2764,658 @@ msgstr "Pełne dla"
 msgid "&File"
 msgstr "Plik"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Otwórz (GB)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Otwórz (GBC)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Otwórz ostatnio używane"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "Zresetuj listę ostatnio używanych"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "Zablokuj listę ostatnio używanych"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "Informacje o pamięci ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "Wczytaj Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "Zapisz Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Najnowszy"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "Automatycznie wczytuj najnowszy"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "10"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Z pliku..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Nie zmieniaj zapisu baterii"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Nie zmieniaj listy kodów"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "Wczytaj zapisany stan gry"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "W najstarszym gnieździe"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Do pliku..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "Zapisz stan gry"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "Plik baterii..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Plik kodów Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Zrzut Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "Importuj"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "Eksportuj"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Zrzut ekranu..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Rozpocznij nagrywanie dźwięku..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Zatrzymaj nagrywanie dźwięku"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Rozpocznij nagrywanie obrazu..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Zatrzymaj nagrywanie obrazu"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Rozpocznij nagrywanie gry..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Zatrzymaj nagrywanie gry"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "Nagrywanie"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Rozpocznij odtwarzanie filmu..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Zatrzymaj odtwarzanie filmu"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "Odtwarzanie"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "Emulacja"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "Wstrzymaj grę"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "Następna klatka"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Przewiń wstecz"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Wł./Wył. tryb pełnoekranowy"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "Tryb turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "Synchronizacja pionowa"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "Autopomijanie klatek"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "Pomiń BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "Autozastosowanie poprawek IPS/UPS/IPF"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "Wstrzymaj grę, gdy okno jest nieaktywne"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "Zresetuj"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "Opcje"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "Połączenie"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Uruchom połączenie sieciowe"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "Brak"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "Kabel"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "Bezprzewodowy"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "Tryb lokalny"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "Połącz przy uruchamianiu"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "Złamanie prędkości"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "Konfiguruj..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "Obraz"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "Uruchom w trybie pełnoekranowym"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr "Skalowana zmiana rozmiaru"
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr "1x"
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr "2x"
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr "3x"
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr "4x"
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr "5x"
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr "6x"
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "Zachowaj proporcje"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "Filtr dwuliniowy"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "Utrzymaj okno na wierzchu"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Pasek stanu"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "Wyłącz wyświetlanie informacji na ekranie"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Wyświetlanie przejrzystych informacji na ekranie"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
-msgstr ""
+msgstr "Dźwięk"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
-msgstr ""
+msgstr "Zwiększ głośność"
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
-msgstr ""
+msgstr "Zmniejsz głośność"
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "Deasembluj..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Przeglądarka wej./wyj..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Przeglądarka map..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Przeglądarka pamięci..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "Przeglądarka OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Przeglądarka palet..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Przeglądarka kafelków..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "Tło 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "Tło 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "Tło 2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "Tło 3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Kanał 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Kanał 2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Kanał 3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Kanał 4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Kanały dźwięku"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "Pomoc"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Zgłoś błędy"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "Forum wsparcia programu VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Tłumaczenia"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
 msgstr "Przywracanie ustawień fabrycznych..."
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
+msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4
 msgid "Map Viewer"

--- a/po/wxvbam/pl_PL.po
+++ b/po/wxvbam/pl_PL.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-30 09:27+0000\n"
-"Last-Translator: Damian Drakon <dragon1590@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Polish (Poland) (http://www.transifex.com/bgk/vba-m/language/pl_PL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "Pliki konsoli GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.r
 msgid "Open GBC ROM file"
 msgstr "Otwórz plik pamięci ROM konsoli GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Nieznany"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Brak"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Wybierz plik Dot Code"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Wybierz plik baterii"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Plik baterii (*.sav)|*.sav|Zapis Flash (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Zaimportowanie pliku baterii usunie wszystkie zapisy gry (na stałe po ponownym zapisie). Czy chcesz kontynuować?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Potwierdź importowanie"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Wczytana bateria %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Niepowodzenie przy wczytywaniu baterii %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Wybierz plik z kodami"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Plik kodów Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Plik kodów Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Zaimportowanie pliku z kodami zastąpi wszystkie wczytane kody. Czy chcesz kontynuować?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Nie można otworzyć pliku %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Nieobsługiwany plik z kodami %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Wczytany plik z kodami %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Niepowodzenie przy wczytywaniu pliku z kodami %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Wybierz plik zrzutu"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Zrzuty GS i PAC (*.sps;*.xps)|*.sps;*.xps|Zrzuty GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Zrzut konsoli Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Zaimportowanie pliku zrzutu usunie wszystkie zapisy gry (na stałe po ponownym zapisie). Czy chcesz kontynuować?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Wczytany plik zrzutu %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Niepowodzenie przy wczytywaniu pliku zrzutu %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Zapisana bateria %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Niepowodzenie przy zapisywaniu baterii %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Zapisy EEPROM nie mogą być wyeksportowane"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Zrzut Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Wyeksportowane z VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Zapisany plik zrzutu %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Niepowodzenie przy zapisywaniu pliku zrzutu %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Zapisz jako..."
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Obrazy PNG|*.png|Obrazy BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Zapisany zrzut %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr " pliki ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Pliki filmów VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Wybierz plik"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Wybierz plik zapisu stanu gry"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Pliki zapisu gry emulatora VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Dźwięk włączony"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Dźwięk wyłączony"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Głośność: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Ustaw na 0 dla pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Port oczekiwania na połączenie:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Połączenie GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Oczekiwanie na połączenie z %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Oczekiwanie na połączenie z portem %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Oczekiwanie na GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulator Nintendo GameBoy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Prawa Autorskie (C) 1999-2003 Forgotten\nPrawa Autorskie (C) 2004-2006 VBA development team\nPrawa Autorskie (C) 2007-2017 VBA-M development team"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Ten program jest darmowym oprogramowaniem: możesz go rozpowszechniać\nlub modyfikować zgodnie z warunkami 2, albo (wedle własnego uznania)\ndowolnej późniejszej, wersji Powszechnej Licencji Publicznej GNU\nopublikowanej przez Free Software Foundation.\n\nTen program jest rozpowszechniany w nadziei, że będzie przydatny, ale BEZ\nŻADNEJ GWARANCJI; bez nawet dorozumianej gwarancji PRZYDATNOŚCI\nHANDLOWEJ lub PRZYDATNOŚCI DO OKREŚLONEGO CELU. Więcej informacji\nmożna znaleźć w Powszechnej Licencji Publicznej GNU.\n\nWraz z tym programem powinieneś otrzymać kopię Powszechnej Licencji\nPublicznej GNU. Jeśli tak się nie stanie, zobacz http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "Połączenie LAN jest już aktywne. Wyłącz tryb połączenia aby się rozłączyć."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "W trybie lokalnym sieć nie jest wspierana."
 
@@ -621,92 +637,96 @@ msgstr "%d klatki/klatek = %.2f ms"
 msgid "Default device"
 msgstr "Urządzenie domyślne"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Tryb pulpitu"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Nie znaleziono użytecznych wtyczek rpi w %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Wtyczka"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Proszę wybrać wtyczkę lub inny filtr"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Błąd wyboru wtyczki"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "To działanie spowoduje usunięcie wszystkich akceleratorów zdefiniowanych przez użytkownika. Czy chcesz kontynuować?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Potwierdź "
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Nie znaleziono głównej ikony"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Nie znaleziono głównego panelu wyświetlacza"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Zduplikowanie skrótu klawiszowego: %s dla %s i %s; pierwszy zostaje zachowany"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Skrót klawiszowy %s dla %s zastępuje domyślny dla %s ; menu zostaje zachowane"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Nieprawidłowy element menu %s; usuwanie"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kod"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Opis"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Adres"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Stara Wartość"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Nowa Wartość"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Polecenia menu"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Inne polecenia"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Nieprawidłowy host JoyBus; wyłączanie"
 
@@ -765,99 +785,99 @@ msgstr "Nie można załadować pliku pamięci ROM konsoli Game Boy Advance %s"
 msgid " player "
 msgstr "gracz"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Wczytano zapisany stan gry %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Niepowodzenie przy wczytywaniu zapisanego stanu gry %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Zapisany stan gry %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Niepowodzenie przy zapisywaniu stanu gry %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Tryb pełnoekranowy %dx%d-%d@%d nie jest wspierany; szukanie innego"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Tryb pełnoekranowy %dx%d-%d@%d nie jest wspierany"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Wspierany tryb: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Wybrano tryb %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Nie można zmienić trybu na %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Nieprawidłowy kartridż konsoli GBA"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Brak pamięci na przewijanie wstecz"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Niepowodzenie przy zapisywaniu stanu przewijania wstecz"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "błąd alokacji pamięci"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "niepowodzenie przy inicjowaniu kodeka"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "niepowodzenie przy zapisywaniu pliku"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "nie można rozpoznać formatu wyjściowego z nazwy pliku"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "błąd programowania; przerywanie!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Nie można rozpocząć nagrywania do %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Błąd podczas nagrywania dźwięku/obrazu (%s); przerywanie"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Błąd podczas nagrywania dźwięku (%s); przerywanie"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Błąd podczas nagrywania wideo (%s); przerywanie"
@@ -927,12 +947,12 @@ msgstr "Zamknij"
 msgid "Printed"
 msgstr "Wydrukowano"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Niepowodzenie przy otwieraniu pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Niepowodzenie przy konfigurowaniu gniazda serwera (%d)"
@@ -1331,7 +1351,7 @@ msgstr "Dodaj kod"
 msgid "Edit Cheat"
 msgstr "Edytuj Kod"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "Typ"
 
@@ -2303,8 +2323,8 @@ msgstr "Suma kontrolna:"
 msgid "&0"
 msgstr "0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "1"
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "By wprowadzić zmiany, kliknij wybrane pole i naciśnij przycisk na klawiaturze lub dżojpadzie, który chcesz przypisać, albo naciśnij klawisz Backspace, by usunąć ostatni dodany przycisk. Jeśli zawartość pól nie jest w pełni widoczna, to zmień rozmiar okna lub kliknij i przytrzymaj lpm - lewy klawisz myszy - wewnątrz wybranego pola, a następnie przeciągnij wskaźnikiem myszy."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Góra"
 
@@ -2589,7 +2609,7 @@ msgstr "Góra"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Dół"
 
@@ -2597,7 +2617,7 @@ msgstr "Dół"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Lewo"
 
@@ -2605,7 +2625,7 @@ msgstr "Lewo"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Prawo"
 
@@ -2613,11 +2633,11 @@ msgstr "Prawo"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Wybierz"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2741,634 +2761,658 @@ msgstr "Pełne dla"
 msgid "&File"
 msgstr "Plik"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Otwórz (GB)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Otwórz (GBC)..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Otwórz ostatnio używane"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "Zresetuj listę ostatnio używanych"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "Zablokuj listę ostatnio używanych"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "Informacje o pamięci ROM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "Wczytaj Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "Zapisz Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Najnowszy"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "Automatycznie wczytuj najnowszy"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "10"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Z pliku..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Nie zmieniaj zapisu baterii"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Nie zmieniaj listy kodów"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "Wczytaj zapisany stan gry"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "W najstarszym gnieździe"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Do pliku..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "Zapisz stan gry"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "Plik baterii..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Plik kodów Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Zrzut Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "Importuj"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "Eksportuj"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Zrzut ekranu..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Rozpocznij nagrywanie dźwięku..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Zatrzymaj nagrywanie dźwięku"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Rozpocznij nagrywanie obrazu..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Zatrzymaj nagrywanie obrazu"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Rozpocznij nagrywanie gry..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Zatrzymaj nagrywanie gry"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "Nagrywanie"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Rozpocznij odtwarzanie filmu..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Zatrzymaj odtwarzanie filmu"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "Odtwarzanie"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "Emulacja"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "Wstrzymaj grę"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "Następna klatka"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Przewiń wstecz"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Wł./Wył. tryb pełnoekranowy"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "Tryb turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "Synchronizacja pionowa"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "Autopomijanie klatek"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "Pomiń BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "Autozastosowanie poprawek IPS/UPS/IPF"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "Wstrzymaj grę, gdy okno jest nieaktywne"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "Zresetuj"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "Opcje"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "Połączenie"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Uruchom połączenie sieciowe"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "Brak"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "Kabel"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "Bezprzewodowy"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "Tryb lokalny"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "Połącz przy uruchamianiu"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "Złamanie prędkości"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "Konfiguruj..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "Obraz"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "Uruchom w trybie pełnoekranowym"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr "Skalowana zmiana rozmiaru"
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr "1x"
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr "2x"
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr "3x"
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr "4x"
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr "5x"
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr "6x"
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "Zachowaj proporcje"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "Filtr dwuliniowy"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "Utrzymaj okno na wierzchu"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Pasek stanu"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "Wyłącz wyświetlanie informacji na ekranie"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Wyświetlanie przejrzystych informacji na ekranie"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
-msgstr ""
+msgstr "Dźwięk"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
-msgstr ""
+msgstr "Zwiększ głośność"
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
-msgstr ""
+msgstr "Zmniejsz głośność"
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "Deasembluj..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Przeglądarka wej./wyj..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Przeglądarka map..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Przeglądarka pamięci..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "Przeglądarka OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Przeglądarka palet..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Przeglądarka kafelków..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "Tło 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "Tło 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "Tło 2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "Tło 3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Kanał 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Kanał 2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Kanał 3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Kanał 4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Kanały dźwięku"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "Pomoc"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Zgłoś błędy"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "Forum wsparcia programu VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
 msgstr "Przywracanie ustawień fabrycznych..."
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
+msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4
 msgid "Map Viewer"

--- a/po/wxvbam/pt.po
+++ b/po/wxvbam/pt.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Portuguese (http://www.transifex.com/bgk/vba-m/language/pt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/pt_BR.po
+++ b/po/wxvbam/pt_BR.po
@@ -5,6 +5,7 @@
 # Translators:
 # Charles Fernando da Silva <eu.charles@hotmail.com>, 2013,2015
 # Dotted Chaos <dottedchaos@gmail.com>, 2015
+# Edênis Freindorfer Azevedo, 2019
 # erdrsd gfdfd <654654564@64564564.com>, 2017
 # Gustavo Canedo <gknedo@gmail.com>, 2015
 # Lucas Guerra <luke.guerra@hotmail.com>, 2014
@@ -16,9 +17,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 23:46+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/bgk/vba-m/language/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -58,120 +59,120 @@ msgstr "Arquivos do GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar
 msgid "Open GBC ROM file"
 msgstr "Abrir ROM de GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -182,230 +183,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Selecione o arquivo Dot Code"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Selecione o arquivo de bateria"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Arquivo de bateria (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importar um arquivo de bateria irá apagar qualquer jogo salvo (permanentemente após a próxima gravação). Deseja continuar?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Confirmar importação"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Bateria carregada %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Erro ao carregar a bateria %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Selecione o arquivo de código"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Arquivo de Código Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Arquivo de Código Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Importar um arquivo de código irá substituir quaisquer trapaças carregadas anteriormente. Deseja continuar?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Não foi possível abrir o arquivo %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "O arquivo de código %s não é suportado"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Arquivo de código %s carregado"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Erro ao carregar o arquivo de código %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Selecione o arquivo snapshot"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy Snapshot (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importar um arquivo snapshot irá apagar qualquer jogo salvo (permanentemente após a próxima gravação). Deseja continuar?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Arquivo snapshot %s carregado"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Erro ao carregar o arquivo snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Bateria escrita %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Erro ao escrever a bateria %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Arquivos EEPROM não podem ser exportados"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Snapshot (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exportado do VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Arquivo snapshot %s salvo"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Erro ao salvar o arquivo snapshot %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Selecione o arquivo de saída"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "Imagens PNG|*.png|Imagens BMP|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Snapshot escrito %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr " arquivos ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Arquivo de Filme VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Selecione o arquivo"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Selecione o arquivo de estado"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Arquivos de jogo salvo do VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr "Slot de estado atual #%d"
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Som ativado"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Som desativado"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volume: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Defina como 0 para pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Porta para esperar por conexão:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Conexão GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Esperando a conexão de %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Esperando por conexão na porta %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Esperando por GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr "Usar filtro de pixel #%d"
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr "Usar mesclagem de quadros #%d"
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Emulador de Nintendo GameBoy (+Color+Advance)."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA development team\nCopyright (C) 2007-2017 VBA-M development team"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -421,11 +438,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Este programa é um software livre: você pode redistribuí-lo e/ou modificá-lo\nde acordo com os termos da GNU General Public License como publicado pela\nFree Sotware Foundation, bem como a versão 2 da Licença, ou (na sua opção)\nqualquer versão posterior.\n\nEste programa é distribuído na esperança que o mesmo seja útil,\nmas SEM QUALQUER GARANTIA; sem mesmo a garantia implícita de\nCOMERCIALIZAÇÃO ou ADEQUAÇÃO PARA PROPÓSITOS PESSOAIS. Consulte\na GNU General Public License para mais detalhes.\n\nVocê deve ter recebido uma cópia da GNU General Public License\njunto com este programa. Se não recebeu, veja em http://www.gnu.org/licenses."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "O link LAN já está ativo. Desative o modo link para ser desconectado."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Rede não é suportada em modo local."
 
@@ -629,92 +646,96 @@ msgstr "%d quadros = %.2f ms"
 msgid "Default device"
 msgstr "Dispositivo padrão"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Modo desktop"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Nenhum plugin rpi foi encontrado em %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Por favor, selecione um plugin ou um filtro diferente"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Erro na seleção plugin"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Isso limpará todos os aceleradores definidos pelo usuário. Você tem certeza?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Ícone principal não encontrado"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr "Procurar"
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Painel de exibição principal não encontrado"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Duplicar acelerador de menu: %s para %s e %s; mantendo primeiro"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Acelerador de menu %s para %s substitui o padrão para %s ; mantendo menu"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Item de menu inválido %s; removendo"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Código"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Descrição"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Endereço"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Valor Antigo"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Valor Novo"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Comandos do menu"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Outros comandos"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Host JoyBus inválido; desativando"
 
@@ -773,99 +794,99 @@ msgstr "Não é possível carregar Game Boy Advance ROM %s"
 msgid " player "
 msgstr "jogador"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Estado carregado %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Erro ao carregar o estado %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Estado salvo %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Erro ao salvar estado %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Modo tela-cheia %dx%d-%d@%d não é suportado; procurando por outro"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Modo tela cheia %dx%d-%d@%d não é suportado"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Modo válido: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Escolha o modo %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Falha ao mudar o modo para %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Não é um cartucho GBA válido"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Não há memória para retroceder"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Erro ao escrever estado de retrocesso"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "erro ao alocar memória"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "erro ao inicializar o codec"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "erro ao escrever o arquivo de saída"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "não é possível adivinhar o formato de saída do nome de arquivo"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "erro de programação; abortando!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Não foi possível iniciar a gravação para %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Erro em gravação de áudio/vídeo (%s); abortando"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Erro em gravação de áudio (%s); abortando"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Erro em gravação de vídeo (%s); abortando"
@@ -935,12 +956,12 @@ msgstr "&Fechar"
 msgid "Printed"
 msgstr "Impresso"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Erro ao abrir pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Erro ao configurar soquete do servidor (%d)"
@@ -1339,7 +1360,7 @@ msgstr "&Adicionar trapaça"
 msgid "Edit Cheat"
 msgstr "Editar Código"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Tipo"
 
@@ -1833,12 +1854,12 @@ msgstr "Arquivo BIOS:"
 
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:115
 msgid "Current BIOS file :"
-msgstr ""
+msgstr "Arquivo de BIOS atual:"
 
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:122
 #: ../src/wx/xrc/GameBoyConfig.xrc:138 ../src/wx/xrc/GameBoyConfig.xrc:159
 msgid "(None)"
-msgstr ""
+msgstr "(Nenhum)"
 
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:136
 #: ../src/wx/xrc/GameBoyConfig.xrc:168
@@ -1945,7 +1966,7 @@ msgstr "Sistema"
 
 #: ../src/wx/xrc/GameBoyConfig.xrc:84
 msgid "GB Boot &ROM file :"
-msgstr ""
+msgstr "Arquivo de inicialização do GB/ROM:"
 
 #: ../src/wx/xrc/GameBoyConfig.xrc:91 ../src/wx/xrc/GameBoyConfig.xrc:113
 msgid "Select A File"
@@ -1957,11 +1978,11 @@ msgstr "Arquivo ROM de boot do GBC:"
 
 #: ../src/wx/xrc/GameBoyConfig.xrc:131
 msgid "Current GB BIOS file :"
-msgstr ""
+msgstr "Arquivo de BIOS do GB:"
 
 #: ../src/wx/xrc/GameBoyConfig.xrc:152
 msgid "Current GBC BIOS file :"
-msgstr ""
+msgstr "Arquivo de BIOS do GBC:"
 
 #: ../src/wx/xrc/GameBoyConfig.xrc:186
 msgid "User 1"
@@ -2311,8 +2332,8 @@ msgstr "Checksum:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2589,7 +2610,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Clique em um campo e pressione uma tecla ou mova o joystick para adicionar. Pressione backspace para apagar a última tecla adicionada. Redimensione a janela ou clique e mova o ponteiro para ver todo o conteúdo se demasiado pequeno."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Cima"
 
@@ -2597,7 +2618,7 @@ msgstr "Cima"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Baixo"
 
@@ -2605,7 +2626,7 @@ msgstr "Baixo"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Esquerda"
 
@@ -2613,7 +2634,7 @@ msgstr "Esquerda"
 msgid "L"
 msgstr "E"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Direita"
 
@@ -2621,11 +2642,11 @@ msgstr "Direita"
 msgid "R"
 msgstr "D"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2683,7 +2704,7 @@ msgstr "Padrões"
 
 #: ../src/wx/xrc/JoyPanel.xrc:529
 msgid "Clear All"
-msgstr ""
+msgstr "Limpar todos"
 
 #: ../src/wx/xrc/LinkConfig.xrc:4
 msgid "Link configuration"
@@ -2749,634 +2770,658 @@ msgstr "Verbal"
 msgid "&File"
 msgstr "Arquivo"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr "Abrir..."
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Abrir &GB..."
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Abrir GB&C..."
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Abrir rece&nte"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Resetar lista recente"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "Congelar lista recente"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "In&formações da ROM"
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "Carregar Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Salvar Dot Code..."
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Mais &recente"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr "Carregar slot do estado atual"
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&Auto carregar mais recente"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Do arquivo..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Não alterar &bateria salva"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Não alterar lista de trapaças"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "Carregar estado"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "Sl&ot mais antigo"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr "Salvar no slot do estado atual"
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr "Incrementar o número do slot do estado atual e salvar"
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Para o arquivo..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Salvar estado"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr "Incrementar o slot do estado atual"
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr "Decrementar o slot do estado atual"
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "Arquivo de &bateria..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Arquivo de &código Gameshark"
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Snapshot &Gameshark..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importar"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Exportar"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Capt&ura de tela..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Iniciar gravação de &som..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Parar gravação de s&om"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Iniciar gravação de &vídeo..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Parar gravação de v&ídeo"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Iniciar &gravação de jogo..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Parar gr&avação de jogo"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "G&ravar"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Iniciar a reprodução de vídeo..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Parar a reprodução de vídeo"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "Re&produzir"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr "&Sair"
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emulação"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Pausa"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "Próximo quadro"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Retroceder"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Alternar para &tela cheia"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "Modo &turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "Saltar quadros &automaticamente"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "Ignorar BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Auto IPS/UPS/IPF patch"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Pausar quando inativo"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Resetar"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Opções"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Link"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Iniciar li&nk de rede..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Nada"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Cabo"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Wireless"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "Modo &local"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Linkar no boot"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "Hack de velocidade"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Configurar..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Vídeo"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Iniciar em tela cheia"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
-msgstr ""
+msgstr "&Redimensionamento proporcional"
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr "Mudar filtro de pixel"
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr "Mudar mesclagem de quadros"
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "Manter aspecto"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr "Habilitar MMX"
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "Filtro &bilinear"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Manter janela acima"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Barra de &Status"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Desabilitar exibição em tela"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Exibição em &tela transparente"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Áudio"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
-msgstr ""
+msgstr "&Aumentar volume"
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
-msgstr ""
+msgstr "&Diminuir volume"
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
-msgstr ""
+msgstr "&mutar/desmutar som"
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "Interpolação de som &GBA "
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "Aprimoramento de som &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "Efeito de som surround &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "Declicking de som &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "Entrada"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Autofire"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
-msgstr ""
+msgstr "&Auto-segurar"
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Configurar..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&Relógio em tempo real"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Usar arquivo de BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "Imprimir &debug"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "Impressão &GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "Reúna uma &página inteira antes de imprimir"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Salvar saída de impressão como captura de tela"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Usar arquivo de BIOS GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Usar arquivo de BIOS GBC"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Geral..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
-msgstr ""
+msgstr "&Acelerador / Turbo"
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "D&iretórios..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Atalhos de tecla..."
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "Ferramen&tas"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "Trapaças"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Listar trapaças"
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Pesquisar trapaça..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Salvar / carregar trapaças a&utomaticamente"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "Habilitar trapaças"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
-msgstr "&Break into GDB"
+msgstr "&Usar GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Configurar porta..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
-msgstr "&Break on load"
+msgstr "&Interromper durante carregamento"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Desconectar"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Disassemble..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
-msgstr "&Logging..."
+msgstr "&Logando..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Visualizador &IO..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Visualizador de &mapa"
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Visualizador de M&emória..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "Visualizador &OAM..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Visualizador de &paleta..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Visualizador de &tile..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr "Mostrar todas as camadas de vídeos"
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Visualizar camadas"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Canal &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Canal &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Canal &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Canal &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Canais de &som"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "Ajuda"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Reportar erros"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "&Fórum de suporte VBA-M"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Traduções"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
-msgstr ""
+msgstr "Restauração de fábrica..."
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
+msgstr "&Sobre..."
 
 #: ../src/wx/xrc/MapViewer.xrc:4
 msgid "Map Viewer"
@@ -3609,19 +3654,19 @@ msgstr "Filtro de som"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:4
 msgid "SpeedUp / Turbo Settings"
-msgstr ""
+msgstr "Configuração de Acelerador/Turbo"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:9
 msgid "Speedup Throttle"
-msgstr ""
+msgstr "Valor de aceleração"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:84
 msgid "Speedup Frame Skip"
-msgstr ""
+msgstr "Acelerar salto de quadros"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:102
 msgid "# of frames:"
-msgstr ""
+msgstr "# de quadros:"
 
 #: ../src/wx/xrc/SpeedupConfig.xrc:121
 msgid "1"

--- a/po/wxvbam/pt_PT.po
+++ b/po/wxvbam/pt_PT.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Portuguese (Portugal) (http://www.transifex.com/bgk/vba-m/language/pt_PT/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr "Abrir ficheiro ROM GBC"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr "Nenhum"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Seleccionar ficheiro Dot Code"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Selecionar ficheiro de bateria"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Ficheiro bateria  (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "A importação de um arquivo de bateria apagará qualquer jogo salvaguardado (permanentemente durante a próxima gravação).\nDeseja continuar?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Confirmar importação"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Carregar arquivo de bateria %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Selecionar arquivo de código"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Importar um arquivo de código substituirá batotas carregas. Deseja continuar?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Impossível abrir ficheiro  %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Ficheiro de código não suportado %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2589,7 +2609,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2597,7 +2617,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2605,7 +2625,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2613,11 +2633,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/ru.po
+++ b/po/wxvbam/ru.po
@@ -15,9 +15,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Russian (http://www.transifex.com/bgk/vba-m/language/ru/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,120 +57,120 @@ msgstr "Файлы GameBoy Color (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)
 msgid "Open GBC ROM file"
 msgstr "Открыть GBC ROM-файл"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark v3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -181,230 +181,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Нет"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Выбрать файл Dot-кода"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "Файлы e-Reader Dot-кодов (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Выбрать файл аппаратного сохранения"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Файлы аппаратного сохранения (*.sav)|*.sav|Файлы флеш-памяти (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Импорт файла аппаратного сохранения уничтожит все сохраненные игры (после записи изменений). Вы хотите продолжить?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Подтвердить импортирование"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Загружено аппаратное сохранение %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Ошибка загрузки аппаратного сохранения %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Выбрать файл чит-кодов"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Файл чит-кодов Gameshark (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Файл чит-кодов Gameshark (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Импорт файла чит-кодов заменит все загруженные чит-коды. Вы xотите продолжить?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Невозможно открыть файл %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Неподдерживаемый тип файла чит-кодов %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Загружен файл чит-кодов %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Ошибка загрузки файла чит-кодов %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Выбрать файл снапшота"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "Файлы снапшотов GS & PAC (*.sps;*.xps)|*.sps;*.xps|Файлы снапшотов GameShark SP (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Файлы снапшотов Gameboy (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Импорт файла снапшота уничтожит все сохраненные игры (после записи изменений). Вы хотите продолжить?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Загружен файл снапшота %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Ошибка загрузки файла снапшота %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Записано аппаратное сохранение %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Ошибка записи аппаратного сохранения %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Сохранения EEPROM не могут быт экспортированы"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Файлы снапшотов Gameshark (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Экспортировано из VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Сохранён файл снапшота %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Ошибка сохранения файла снапшота %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Выбрать файл вывода"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG-изображения|*.png|BMP-изображения|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Записан файл снапшота %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "файлы ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "Видео-файлы VBA|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Выбрать файл"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Выбрать файл сохранения"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "Сохранения VisualBoyAdvance|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Звук включен"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Звук выключен"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Громкость: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Установить 0 для псевдотерминала TTY"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Порт для ожидания подключения:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB подключение"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Ожидание подключения к %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Ожидание подключения на порту %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Ожидание ответа от GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Эмулятор Nintendo GameBoy (+Color+Advance)"
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Защищено авторскими правами (C) 1999-2003 Forgotten\nЗащищено авторскими правами (C) 2004-2006 VBA development team\nЗащищено авторскими правами (C) 2007-2017 VBA-M development team"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -420,11 +436,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Эта программа бесплатна: Вы можете её распространять\nи/или изменять под лицензией GNU General Public License,\nопубликованной Free Software Foundation, версии 2\nили (на Ваш выбор) любой последующей версии.\n\nЭта программа распространяется в надежде быть полезной,\nно БЕЗ КАКОЙ-ЛИБО ГАРАНТИИ. Для подробностей\nсмотрите лицензию GNU General Public License.\n\nВы получите копию лицензии вместе с программой\nили смотрите по ссылке http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "LAN-соединение уже активно. Отключите соединение для разрыва подключения."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Сеть не поддерживается в локальном режиме."
 
@@ -628,92 +644,96 @@ msgstr "%d кадров = %.2f мс"
 msgid "Default device"
 msgstr "Устройство по умолчанию"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Режим рабочего стола"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %d бит @ %d Гц"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Не найдено подходящих rpi-плагинов в %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Плагин"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Пожалуйста, выберите плагин или другой фильтр"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Ошибка выбора плагина"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Будут удалены все пользовательские сочетания клавиш. Вы уверены?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Подтвердить"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Главный значок не найден"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Главная панель экрана не найдена"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Повторяющееся сочетание клавиш: %s для %s и %s; оставлено первое"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Сочетание клавиш %s для %s перезаписывает %s ; оставлено для меню"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Неверный пункт меню %s удалён"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Код"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Описание"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Адрес"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Старое значение"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Новое значение"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Команды меню"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Другие команды"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "Хост JoyBus неверен; отключено"
 
@@ -772,99 +792,99 @@ msgstr "Невозможно загрузить Game Boy Advance ROM-файл %s
 msgid " player "
 msgstr "игрок"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Загружено сохранение %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Ошибка загрузки сохранения %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Сохранение игры %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Ошибка сохранения игры %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Полноэкранный режим %dx%d-%d@%d не поддерживается; поиск другого"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Полноэкранный режим %dx%d-%d@%d не поддерживается"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Верный режим: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Выбран режим %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Не удалось сменить режим на %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Неверный GBA-картридж"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Нет памяти для перемотки назад"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Ошибка записи состояния перемотки"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "ошибка выделения памяти"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "ошибка инициализации кодека"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "ошибка записи в файл вывода"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "невозможно определить формат вывода по имени файла"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "ошибка в коде программы; отмена записи!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Невозможно начать запись в %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Ошибка аудио/видеозаписи (%s); отменено"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Ошибка аудиозаписи (%s); отменено"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Ошибка видеозаписи (%s); отменено"
@@ -934,12 +954,12 @@ msgstr "&Закрыть"
 msgid "Printed"
 msgstr "Распечатано"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Ошибка открытия псевдотерминала TTY: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Ошибка настройки серверного сокета (%d)"
@@ -1338,7 +1358,7 @@ msgstr "Добавить чит-код"
 msgid "Edit Cheat"
 msgstr "Редактировать чит-код"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "Тип"
 
@@ -2310,8 +2330,8 @@ msgstr "Контрольная сумма:"
 msgid "&0"
 msgstr "0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "1"
 
@@ -2588,7 +2608,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Щелкните в поле и нажмите клавишу, чтобы добавить. Нажмите Backspace для удаления значения. Измените размер окна если мало содержимого"
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Вверх"
 
@@ -2596,7 +2616,7 @@ msgstr "Вверх"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Вниз"
 
@@ -2604,7 +2624,7 @@ msgstr "Вниз"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Влево"
 
@@ -2612,7 +2632,7 @@ msgstr "Влево"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Вправо"
 
@@ -2620,11 +2640,11 @@ msgstr "Вправо"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2748,633 +2768,657 @@ msgstr "Подробный"
 msgid "&File"
 msgstr "Файл"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Открыть GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Открыть GBC"
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Открыть недавние"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "Сброс списка последних"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "Заморозить список последних"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "Информация о Rom"
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "Загрузить Dot код"
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "Сохранить Dot код"
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "Самые последние"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "Автозагрузка последнего"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Из файла"
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Не изменяйте аппаратное сохранение"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Не изменяйте список чит-кодов"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "Загрузить состояние"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "Самая старая ячейка"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Для файла"
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "Сохранить состояние"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "Аппаратный файл"
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Файл с Gameshark кодами "
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Снимок Gameshark"
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "Импортировать"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "Экспортировать"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Скриншот"
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Начать запись звука"
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "Остановить запись звука"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Начать запись видео"
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Остановить запись видео"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Начать запись игры"
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Остановить запись игры"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "Запись"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Начать запись фильма"
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Остановить запись фильма"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "Играть"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "Эмуляция"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "Пауза"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "Следующий кадр"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Перемотка"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Вкл. &полноэкр. режим"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Ускоренный режим"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&Верт. синхронизация"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Автоперемотка кадров"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "Пропустить BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "Авто исправление IPS/UPS/IPF"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "Пауза при смене окна"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Сброс"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Настройки"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "Соеденение"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Начать сетевое соединение"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "Ничего"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "Кабель"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "Безпроводной"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "Локальный режим"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "Связь во время загрузки"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "СпидХак"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "Настройка"
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Видео"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "Запускать в полноэкранном режиме"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "Сохранить соотношение"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "&Билинейный фильтр"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "Поверх всех окон"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "Панель состояния"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "Отключить на экране дисплея"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "Прозрачный дисплей на экране"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Аудио"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&Интерполяция звука GBA"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&Улучшение звука GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&Эффект объемного звука GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "Дикликинг звука GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Ввод"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Турбо"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Настроить ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "Часы реального времени"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "Использовать BIOS файл"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "Распечатать ошибку"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "GB принтер"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "Соберите полную страницу перед печатью"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "Сохранить снимок экрана"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "Использовать GB BIOS файл"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "Использовать GBC BIOS файл"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "Общий"
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "Дериктория"
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "Сочетание клавиш"
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "Инструменты"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "Чит-коды"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Список чит-кодов"
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Найти чит"
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Автоматически сохранять/загружать читы"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "Включить читы"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "Сброс GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "Настройка порта"
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "Сброс загрузки"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "Отключить"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "Разрыв"
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "Вход"
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "Просмотр IO "
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "Просмотр карты"
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Просмотр памяти"
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "Просмотр OAM"
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "Просмотр палитры"
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Просмотр тайла"
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "Просмотреть слои"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Канал 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Канал 2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Канал 3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Канал 4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "Звуковые каналы"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "Помощь"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Сообщить об ошибке"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M  техподдержка и форум"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Переводы"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/ru_RU.po
+++ b/po/wxvbam/ru_RU.po
@@ -9,9 +9,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Russian (Russia) (http://www.transifex.com/bgk/vba-m/language/ru_RU/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -51,120 +51,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Неизвестный"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -175,230 +175,246 @@ msgstr ""
 msgid "None"
 msgstr "Никто"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Выберите Dot Code файл"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Выберите файл батареи"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Файл батареи (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Импорт файла батареи сотрет все сохраненные игры (навсегда после следующей записи). Продолжить?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Подтвердить импорт"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Батарея загружена%s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Ошибка загрузки батареи %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Выберите файл code"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark Code файл (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark Code файл (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Импорт файла кода заменит любые загруженные Читы. Вы действительно хотите продолжить?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Не удается открыть файл %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Неподдерживаемый код файл %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Файл кода загружен %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Выберите снапшот файл"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Снапшоты (*.sps;*.xps)|*.sps;*.xps|GameShark SP Снапшоты (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy Снапшот (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Импорт файла моментального снимка удалит все сохраненные игры (навсегда после следующей записи). Вы действительно хотите продолжить?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Файл снапшот загружен %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Ошибка загрузки файла снапшота %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Ошибка записи батареи %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "Сохранение EEPROM не может быть экспортировано"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Снапшот (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Экспортировано из VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Снапшот файл сохранен %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Ошибка сохранения снапшот файла %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Выберите файл"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Звук включен"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Звук отключен"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Громкость: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Порт ожидает соединения:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB Соединение"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Ждем GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -414,11 +430,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Эта программа является свободным программным обеспечением: вы можете распространять и/или изменять\nэто в соответствии с условиями GNU General Public License, опубликованной\nФонд свободного программного обеспечения, либо версии 2 Лицензии, либо\n(по вашему выбору) любая более поздняя версия.\n\nЭта программа распространяется в надежде, что она будет полезной,\nно без какой-либо гарантии; даже без подразумеваемой гарантии\nТоварность или пригодность для определенной цели. См.\nGNU General Public License для более подробной информации.\n\nВы должны были получить копию GNU General Public License\nвместе с этой программой. Если нет, см. http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -622,92 +638,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Плагин"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Ошибка выбора плагина"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Подтвердить"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Код"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Адрес"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Команды меню"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Другие команды"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -766,99 +786,99 @@ msgstr ""
 msgid " player "
 msgstr "игрок"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -928,12 +948,12 @@ msgstr "&Закрыть"
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1332,7 +1352,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2304,8 +2324,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2582,7 +2602,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2590,7 +2610,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2598,7 +2618,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2606,7 +2626,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2614,11 +2634,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2742,633 +2762,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/sk.po
+++ b/po/wxvbam/sk.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Slovak (http://www.transifex.com/bgk/vba-m/language/sk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/sk_SK.po
+++ b/po/wxvbam/sk_SK.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Slovak (Slovakia) (http://www.transifex.com/bgk/vba-m/language/sk_SK/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/sr.po
+++ b/po/wxvbam/sr.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Serbian (http://www.transifex.com/bgk/vba-m/language/sr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/su.po
+++ b/po/wxvbam/su.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Sundanese (http://www.transifex.com/bgk/vba-m/language/su/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Teu apal"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr "Teu aya"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Batre %s kacatetkeun"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Kasalahan nalika nulis batre ka %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Sora dihurungkeun"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Sora dipareuman"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "Sambungan GDB"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Ieu program teh mangrupa piranti lunak gratis. Anjeun tiasa nyebarkeun atanapi ngubah salami sasuai kana kaedah GNU General Public License nu sakumaha di publikasikeun ku Free Software Foundation, boh versi ka 2 tina lisensi, atanapi (pilihan anjeun) versi nu anyaran."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2589,7 +2609,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2597,7 +2617,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2605,7 +2625,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2613,11 +2633,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/sv.po
+++ b/po/wxvbam/sv.po
@@ -13,9 +13,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Swedish (http://www.transifex.com/bgk/vba-m/language/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -55,120 +55,120 @@ msgstr "GameBoy Color filer (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dm
 msgid "Open GBC ROM file"
 msgstr "Öppna GBC ROM fil"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Okänd"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -179,230 +179,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Inga"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Välj Dot Code fil"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Välj batterifil"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Batterifil (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importen av en batterifil kommer att radera alla sparade spel (permanent efter nästa skrivning). Vill du fortsätta?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Bekräfta import"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Laddade batteri %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Fel vid laddning av batteri %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Välj kodfil"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark Code File (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Importen av en kodfil kommer att ersätta alla laddade fusk. Vill du fortsätta?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "Kan inte öppna fil %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Kodfilen stöds inte %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "Laddade kodfil %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "Fel vid laddning av kodfil %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Välj ögonblicksfil"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC Ögonblicksfiler (*.sps;*.xps)|*.sps;*.xps|GameShark SP Ögonblicksfiler (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy Ögonblicksfil (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Importen av en ögonblicksfil kommer att radera alla sparade spel (permanent efter nästa skrivning). Vill du fortsätta?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Laddade ögonblicksfil %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Fel vid laddning av ögonblicksfil %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Skrev batteri %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Fel vid skrivning av batteri %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "EEPROM sparfiler kan inte exporteras"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Snapshot (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "Exporterat från VisualBoyAdvance-M"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Sparade ögonblicksfil %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Fel vid sparandet av ögonblicksfil%s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Välj utdatafil"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG bilder|*.png|BMP bilder|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "Skrev ögonblicksfil %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr " filer ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA filmfiler|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Välj fil"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Välj tillståndsfil"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance sparade spelfiler|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Ljud aktiverat"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Ljud inaktiverat"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Volym: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Sätt till 0 för pseudo tty"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Port att vänta på anslutning vid:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB anslutning"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Väntar på anslutning vid %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Väntar på anslutning vid port %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "Väntar på GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Nintendo GameBoy (+Color+Advance) emulator."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA-utvecklingsgrupp\nCopyright (C) 2007-2017 VBA-M-utvecklingsgrupp"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -418,11 +434,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Det här programmet är fri mjukvara: du kan omdistribuera det och/eller modifiera\ndet under villkoren av GNU General Public License som publiceras av\nthe Free Software Foundation, antingen version 2 av licensen, eller\n(om du så vill) vilken som helst senare version. \n\nDet här programmet distribueras i förhoppningen om att det kommer att fylla sin funktion,\nmen UTAN NÅGON FORM AV GARANTI; till och med utan den antydda garantin av\nSÄLJBARHET eller LÄMPLIGHET FÖR ETT VISST ÄNDAMÅL. Se\nGNU General Public License för mer detaljer.\n\nDu skall ha fått en kopia av GNU General Public License\ntillsammans med detta program. Om inte, se http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "LAN länk är redan aktiv. Inaktivera länkläge för att koppla ifrån."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Nätverk stöds inte i lokalläge."
 
@@ -626,92 +642,96 @@ msgstr "%d frames = %.2f ms"
 msgid "Default device"
 msgstr "Standardenhet"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Skrivbordsläge"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "Inga användbara rpi plugins funna i %s"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Plugin"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Var vänlig välj ett plugin eller ett annat filter"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Fel vid val av plugin"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Det här kommer att rensa alla användardefinierade acceleratorer. Är du säker?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Bekräfta"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Huvudikon ej funnen"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Huvudvisningspanel ej funnen"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Duplicera menyaccelerator: %s för %s och %s; behåller första"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Menyaccelerator %s för %s överskrider standard för %s ; behåller meny"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Ogiltigt menyföremål %s; tar bort"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kod"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Beskrivning"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Adress"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Gammalt värde"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Nytt värde"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Menykommandon"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Andra kommandon"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "JoyBus värd ogiltig; inaktiverar"
 
@@ -770,99 +790,99 @@ msgstr "Oförmögen att ladda Game Boy Advance ROM %s"
 msgid " player "
 msgstr " spelare "
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "Laddade tillstånd %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "Fel vid laddning av tillstånd %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "Sparade tillstånd %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "Fel vid sparande av tillstånd %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "Helskärmsläge %dx%d-%d@%d stöds inte; letar efter annan"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "Helskärmsläge %dx%d-%d@%d stöds inte"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Giltigt läge: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "Välj läge %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "Misslyckades att ändra läge till %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Inte en giltig GBA kassett"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Inget minne för återspolning"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Fel vid skrivande av återspolningstillstånd"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "Minnesfördelningsfel"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "Fel vid initialisering av kodek"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "Fel vid skrivande till utdatafil"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "Kan inte gissa utdataformat från filnamn"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "programmeringsfel; avbryter!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "Oförmögen att börja inspelning till %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Fel i ljud/videoinspelning (%s); avbryter"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Fel i ljudinspelning (%s); avbryter"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Fel i videoinspelning (%s); avbryter"
@@ -932,12 +952,12 @@ msgstr "&Stäng"
 msgid "Printed"
 msgstr "Tryckt"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "Fel vid öppnande av pseudo tty: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Fel vid inrättande av server sockel (%d)"
@@ -1336,7 +1356,7 @@ msgstr "&Lägg till fusk"
 msgid "Edit Cheat"
 msgstr "Redigera fusk"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Typ"
 
@@ -2308,8 +2328,8 @@ msgstr "Checksumma:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2586,7 +2606,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Klicka på ett fält och tryck på en knapp eller flytta joysticken för att lägga till. Tryck på baksteg för att ta bort senast tillagda tangent. Ändra storlek på fönstret eller klicka inuti och flytta pekaren för att se hela innehållet om fönstret är för litet."
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Upp"
 
@@ -2594,7 +2614,7 @@ msgstr "Upp"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Ner"
 
@@ -2602,7 +2622,7 @@ msgstr "Ner"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Vänster"
 
@@ -2610,7 +2630,7 @@ msgstr "Vänster"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Höger"
 
@@ -2618,11 +2638,11 @@ msgstr "Höger"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Välj"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2746,633 +2766,657 @@ msgstr "Utförligt"
 msgid "&File"
 msgstr "&Arkiv"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "Öppna &GB…"
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "Öppna GB&C…"
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Öppna se&naste"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Återställ senastelista"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Frys senastelista"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ROM-in&formation…"
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-Reader"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Läs in punktkod…"
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Spara punktkod…"
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "&Senaste"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&Läs automatiskt in senaste"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "Från &fil …"
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Ändra inte &batterisparning"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "Ändra inte &fusklista"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Läs in tillstånd"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&Äldsta luckan"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "Till &fil …"
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Spara tillstånd"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&Batterifil…"
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Gameshark &kodfil…"
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Gameshark tillstånd…"
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&Importera"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Exportera"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Infånging av &skärmbild…"
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "Påbörja &ljudinspelning…"
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "A&vsluta ljudinspelning"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "Påbörja &videoinspelning…"
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "Avs&luta videoinspelning"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "Påbörja s&pelinspelning..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "Avsluta sp&elinspelning"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Spela in"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "Påbörja f&ilminspelning..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "Avsluta fil&minspelning"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Spela"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "Emulering"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "Pausa"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Nästa bildruta"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "S&pola tillbaka"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "Växla &helskärm"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Turboläge"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&V-synk"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Hoppa automatisk över bildrutor"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "Hoppa över &BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "Patcha &automatisk IPS/UPS/IPF"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Pausa vid inaktivitet"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Återstäl"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Alternativ"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Länk"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "Starta &nätverkslänk…"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Ingenting"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Kabel"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Trådlös"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Lokalläge"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "&Länk vid uppstart"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Hastighetshack"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Konfigurera…"
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Video"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Starta i helskärm"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&Behåll bildförhållande"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "&Bilinjärt filter"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&Behåll fönster på toppen"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "&Statusrad"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&Inaktivera visning på skärm"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "&Transparent visning på skärm"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Ljud"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&GBA-ljudinterpolation"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&GB-ljudförbättring"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&GB-surroundljudseffekt"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "&Klickborttagning för GB-ljud"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Inmatning"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Autoavfyrning"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Konfigurera…"
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&Realtidsklocka"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&Använd BIOS-fil"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Debugutskrifter"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&GB-skrivare"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Samlaihop en full sida innan utskrift"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Spara utskrifter som skärmbilder"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&Använd GB-BIOS-fil"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&Använd GBC-BIOS-fil"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Allmänt…"
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "K&ataloger…"
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "&Tangentbordsgenvägar…"
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Verktyg"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Fusk"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "Lista &fusk…"
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "Hitta f&usk…"
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Spara/läs a&utomatiskt in fusk"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Aktivera fusk"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "&Bryt in i GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "&Konfigurera port…"
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "&Bryt vid inläsning"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Koppla från"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Avassemblera…"
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Logga…"
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&IO-visare…"
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Map-visare…"
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "Minn&evisare…"
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&OAM-visare…"
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "&Palettvisare…"
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "Pla&ttvisare…"
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Visa lager"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Kanal &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Kanal &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Kanal &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Kanal &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direktljud &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direktljud &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&Ljudkanaler"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&Hjälp"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Rapportera &fel"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M Support&forum"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Översättningar"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/tk.po
+++ b/po/wxvbam/tk.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Turkmen (http://www.transifex.com/bgk/vba-m/language/tk/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/tr.po
+++ b/po/wxvbam/tr.po
@@ -12,9 +12,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Turkish (http://www.transifex.com/bgk/vba-m/language/tr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -54,120 +54,120 @@ msgstr "GameBoy Color Dosyaları (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)
 msgid "Open GBC ROM file"
 msgstr "GBC ROM dosyası açın"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "Bilinmeyen"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+CEP KAMERASI"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -178,230 +178,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "Hiçbiri"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "Dot Kodu dosyasını seçin"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Kodu (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "Batarya dosyasını seçin"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "Pil dosyası (*.sav) *.sav/Flaş kaydı(*.dat)*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Pil dosyası içe aktarmak oyun savelerinizi siler(geri dönüşü yok!) . Devam etmek istiyor musunuz?"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "Almayı onayla"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "Pil dosyası yüklendi %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "Pil yükleme hatası %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "Kod dosyası seçin"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark uzantıları (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark uzantıları (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "Herhangi bir hile kodu içe aktarmak, yüklü olan kodların yerini alır. Devam edilsin mi?"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "%s dosyası açılamıyor"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "Desteklenmeyen hile uzantısı %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "%s adlı kod dosyası yüklendi"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "%s adlı kod dosyası yüklenemedi"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "Hile snapshot dosyası seçiniz"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS ve PAC snapshot uzantıları (*.sps*.xps)*.sps*.xps\\GameShark SP snapshot uzantıları (*gsv)*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy snapshot uzantısı (*.gbs)*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "Herhangibir snapshot dosyası yüklemek tüm kayıtlı oyunlarınızı silecektir (geri döndürülemez!). Devam edilsin mi?"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "Snapshot dosyası yüklendi %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "Snapshot yüklenirken hata oluştu %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "Pil yazıldı %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "Pil yazımında hata %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "EEPROM kayıtları dışa aktarılamaz"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark Snapshot uzantısı (*.sps)*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "VisualBoyAdvance-M emulatöründen çıkarılmıştır"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "Snapshot dosyası kaydedildi %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "Snapshot kaydedilirken hata oluştu %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "Çıktı dosyası seçiniz"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG resimleri *.png\\BMP resimleri *.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "snapshot kaydedildi %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "dosyalar ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA film uzantısı *.vmw"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "Dosya seçin"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "Durum dosyası seçin"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance kayıt uzantısı\\*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "Ses etkin"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "Ses kapatıldı"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "Ses Düzeyi: %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "Pseudo tty 0'a ayarlansın"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "Bağlantı için uygun port:"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB Bağlantısı"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "Bağlantı bekleniyor %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "Şu port bağlantı için beklemede %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "GDB bekleniyor..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "Nintendo GameBoy (+Color+Advance) emülatörü."
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Telif hakkı (C) 1999-2003 Forgotten\nTelif hakkı (C) 2004-2006 VBA geliştirme/yazılım takımı\nTelif Hakkı (C) 2007-2017 VBA-M geliştirme/yazılım takımı"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -417,11 +433,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "Bu ücretsiz bir programdır:Free Software Foundation'ın yayımladığı GNU General Public lisansına uygun olarak paylaşılabilir üzerinde değişiklikler yapılabilir (lisansın 2. versiyonu yada sonrasında çıkan versiyonu, sizin tercihinizdir.)\n\nBu program işe yaraması amacı ile yazılmıştır, ancak HİÇBİR GARANTİ içermez; ima edilen TİCARETE UYGUNLUK garantisi yada BELLİ BİR AMACA UYGUNLUK garantisi bile içermez. Daha fazla bilgi için GNU General Public Lisansını inceleyiniz.\n\nBu programın içinde GNU General Public lisansının bir kopyasının da bulunması gerekir. Eğer bu kopya programdan çıkmadıysa, http://www.gnu.org/licenses sitesinden Lisansa ulaşabilirsiniz."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "LAN link modu aktif. Bağlantıyı kesmek için Link modunu kapatınız."
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "Local modda ağ desteği yoktur."
 
@@ -625,92 +641,96 @@ msgstr "%dkare= %.2f ms"
 msgid "Default device"
 msgstr "Varsayılan cihaz"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "Masaüstü modu"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%dx %d-%dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "%s'da kullanılabilir rpi pluginleri mevcut değil"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "Eklenti"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "Lütfen bir plugin yada farklı bir filtre seçiniz"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "Plugin seçim hatası"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "Bu tüm kullanıcı ayarlı hızlandırıcıları silecek. Emin misiniz?"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "Onayla"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "Ana ikon bulunamadı"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "Ana ekran paneli bulunamadı"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "Menu hızlandırıcısını kopyala:%siçin%sve%s; İlk seçenek tutulur"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "Menü hızlandırıcı %siçin%svarsayılanı %siçin geçersiz kılar; Menü tutulur"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "Geçersiz menü ögesi %s; siliniyor"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "Kod"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "Açıklama"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "Adres"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "Eski Değer"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "Yeni Değer"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "Menü komutları"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "Diğer komutlar"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "JoyBus sunucusu geçersiz; kapatılıyor"
 
@@ -769,99 +789,99 @@ msgstr "Game Boy Advance ROM'u %syüklenemiyor"
 msgid " player "
 msgstr "oyuncu"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "%s Durum kaydı yüklendi"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "%s durum kaydı yüklenirken hata oluştu"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "%s Durum kaydı alındı"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "%sdurum kaydı alınamadı"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "%dx%d-%d@%dçözünürlüğünde tam ekran modu desteklenmiyor; başka çözünürlük aranıyor"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "%dx%d-%d@%d çözünürlüğünde Tam ekran modu desteklenmiyor"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "Geçerli çözünürlük: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "%dx%d-%d@%d çözünürlüğünü seç"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "çözünürlük %dx%d-%d@%d'e geçirilemedi"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "Geçerli bir GBA kartuşu değil"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "Geri sarma özelliği için yaterli hafıza yok"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "Geri sarma durumu yazılırken hata oluştu"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "Hafıza atama hatası"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "Codec başlatılırken hata"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "Çıktı dosyası yazılırken hata"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "Çıktı formatı, dosya isminden anlaşılamıyor"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "Programlama hatası; İşlem durduruluyor!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "%s(%s) buraya görüntü kaydı başlatılamıyor"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "Ses ve görüntü kaydında hata (%s); İşlem durduruluyor"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "Ses kaydı hatası (%s); İptal ediliyor"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "Video kaydı hatası (%s); İptal ediliyor"
@@ -931,12 +951,12 @@ msgstr "&Kapat"
 msgid "Printed"
 msgstr "Çıktı alındı"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "pseudo tty:%saçılırken hata oluştu"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "Sunucu soketi hazırlanırken hata oluştu (%d)"
@@ -1335,7 +1355,7 @@ msgstr "&Hile ekle"
 msgid "Edit Cheat"
 msgstr "Hile düzenle"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "&Tip"
 
@@ -2307,8 +2327,8 @@ msgstr "Checksum:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2585,7 +2605,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "Ekranda bulunan gameboy tuş alanlarından birine tıklayın, ardından o tuş ile eşleştirmek istediğiniz kol tuşunuza ya da klavye tuşunuza basın, ekleme işlemi tamamdır. Eğer eski bir tuş eşleşmesini silmek isterseniz, yine alanlardan birine tıklayınn ve ardından klavyenizin backspace tuşuna basın, silme işlemi tamamdır. Eğer tuş ayarlama ekranı küçükse pencereyi büyütün yada ekranı aşağı yukarı çekerek tüm tuş bilgilerine ulaşın. "
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "Yukarı"
 
@@ -2593,7 +2613,7 @@ msgstr "Yukarı"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "Aşağı"
 
@@ -2601,7 +2621,7 @@ msgstr "Aşağı"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "Sol"
 
@@ -2609,7 +2629,7 @@ msgstr "Sol"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "Sağ"
 
@@ -2617,11 +2637,11 @@ msgstr "Sağ"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "Select"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "Start"
 
@@ -2745,633 +2765,657 @@ msgstr "Ayrıntılı günlük"
 msgid "&File"
 msgstr "&dosya"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "&GB aç"
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "GB&C aç"
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "Yakın zamanda kullanılanları aç"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "&Yakın zamanda kullanılan listesini sıfırla"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "&Yakın zamanda kullanılan listesini dondur"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ROM bil&gisi"
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "&e-okuyucu"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "&Dot kodu yükle..."
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "&Dot kodu kaydet"
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "En yakın zamanda kullanılanlar"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "&En yakın zamanda kullanılanları otomatik olarak yükle"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "&Dosyadan..."
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "Kaset kaydını &değiştirme"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "&Hile listesini değiştirme"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "&Durum kaydı yükle"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "&En eski slot"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "&Dosyaya..."
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "&Durum kaydı"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "&Kaset dosyası..."
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Gameshark &kod dosyası..."
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "&Gameshark hile snapshot'ı..."
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "&İçe aktar"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "&Dışa aktar"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "Ekran kay&dı..."
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "&Ses kaydı başlat..."
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "S&es kaydını durdur"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "&Görüntü kaydı başlat..."
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "G&örüntü kaydını sonlandır"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "&Oyun kaydı başlat..."
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "O&yun kaydını sonlandır"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "&Kayıt"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "&Film oynatmaya başla..."
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "F&ilm oynatmayı sonlandır"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "&Oyna"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "&Emülasyon"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "&Ara var"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "&Sonraki kare"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "Geri&sar"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "&Tam ekran aç"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "&Turbo modu"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "&VSync"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "&Otomatik kare atlama"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "&BIOS'u atla"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "&Otomatik IPS/UPS/IPF yaması"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "&Pasifken ara ver"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "&Sıfırla"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "&Ayarlar"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "&Bağlantı"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "&Ağ linki başlat..."
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "&Hiç"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "&Koblo"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "&Kablosuz"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "&Yerel mod"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "Açılışta &Link kablosunu aktif et ve bağlan"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "&Hız hacki"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "&Ayarla..."
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "&Video"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "&Tam ekran başlat"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "&görüntü oranını koru"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "&Bilinear filtre"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "&VBA penceresini hep en üstte tut"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "&Durum barı"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "&OSD'yi devre dışı bırak"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "&OSD transparan olsun"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "&Ses"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "&GBA ses aradeğerlemesi"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "&GB ses iyileştirme"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "&GB surround ses efekti"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "&GB ses dekliklenmesi"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "&Girdi"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "&Oto Ateş"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "Ayarla..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "&Gerçek zamanlı saat"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "&BIOS kullan"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "&Hata ayıklama çıktısı al"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "&GB printer"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "&Çıktı almadan önce bir sayfanın dolmasını bekle"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "&Kağıda basmak yerine ekran resmi olarak kaydet"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "&GB BIOS'u kullan"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "&GBC BIOS'u kullan"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "&Genel..."
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "K&lasörler..."
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "&Tuş kısayolları"
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "&Araçlar"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "&Hileler"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "&Hileleri listele..."
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "H&ile bul..."
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "Hilelerei o&tomatik olarak yükle ve kaydet"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "&Hileleri aktif et"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "&GDB'ye gir"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "Port &ayarla..."
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "&Yüklendiğinde durdur"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "&Bağlantıyı kes"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "&GDB"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "&Parçala/kaynak kodu al..."
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "&Günlük tutuluyor..."
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "&G/Ç izleyici..."
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "&Harita izleyici..."
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "H&afıza izleyici..."
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "&OAM izleyici..."
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "&Palet izleyici..."
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "&Desen izleyici..."
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "Arka Plan &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "Arka Plan &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "Arka Plan &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "Arka Plan &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&Nesne"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&Ön Plan 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "&Katmanları gör"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Kanal &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Kanal &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Kanal &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Kanal &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&Ses kanalları"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "Yardım"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "Hata Bildirme"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M Destek Hattı"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "Çeviriler"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,120 +53,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -177,230 +177,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots (*.gsv)|"
 "*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -416,11 +432,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -624,92 +640,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -768,99 +788,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -930,12 +950,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1338,7 +1358,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2310,8 +2330,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2612,7 +2632,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2620,11 +2640,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2748,633 +2768,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/zh-Hans.po
+++ b/po/wxvbam/zh-Hans.po
@@ -15,9 +15,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Chinese Simplified (http://www.transifex.com/bgk/vba-m/language/zh-Hans/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,120 +57,120 @@ msgstr "GBC 文件\n(*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg;*.gb;*
 msgid "Open GBC ROM file"
 msgstr "打开 GBC ROM 文件"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "未知"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -181,230 +181,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "无"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "选择点代码文件"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "电子阅读器点代码 (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "选择电池文件"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "电池文件 (*.sav)|*.sav|记忆文件(*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "导入电池文件将删除之前保存的游戏进度 (直到下次写入前)。你确定要继续吗？"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "确认导入"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "读取电池 %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "读取电池错误 %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "选择代码文件"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark 代码文件 (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark 代码文件 (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "导入代码将会重置之前已经读取的所有金手指代码。你确定要继续吗？"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "无法打开文件 %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "不支持的代码文件 %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "已读取的代码文件 %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "读取代码文件错误 %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "选择快照文件"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC 快照 (*.sps;*.xps)|*.sps;*.xps|GameShark SP 快照 (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy 快照 (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "导入快照将删除之前保存的游戏进度 (直到下次保存前)。你确定要继续吗？ "
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "已读取的快照文件 %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "快照文件读取错误 %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "写入电池 %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "写入电池错误 %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "EEPROM 存档无法导出"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark 快照 (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "从 VBA-M 导出"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "保存快照文件 %s "
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "保存快照文件错误 %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "选择输出文件"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG 图片|*.png|BMP 图片|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "写入快照 %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "文件 ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA 影片文件|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "选择文件"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "选择状态文件"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance 保存游戏文件|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "开启声音"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "静音"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "音量 %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "给伪 tty 设置成 0"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "准备连接的端口"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB 连接"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "准备连接到 %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "准备连接的端口 %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "等待 GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "任天堂 GameBoy (+Color+Advance) 模拟器。"
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "版权 (C) 1999-2003 Forgotten\n版权 (C) 2004-2006 VBA 开发团队\n版权 (C) 2007-2017 VBA-M 开发团队"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -420,11 +436,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "本程序是自由软件: 你可以在自由软件基金会公布的 GNU 通用发布\n许可证条款下重新分发和/或修改此软件，依自己意愿许可证 V2 版或\n任意更新版许可证选其一即可。\n\n本程序希望是能有作用的分发出去，但【无任何担保】；甚至没有隐含\n的【可销售性】或【特定用途的适用性】保证。请查阅 GNU 通用发布\n许可证了解更多信息。\n\n你应该已经收到 GNU 通用发布许可证的副本以及本程序。\n如果没有，请查看 http://www.gnu.org/licenses 。"
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "局域网连接已激活，禁用连接模式即可断开联网。"
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "本地模式不支持网络"
 
@@ -628,92 +644,96 @@ msgstr "%d frames = %.2f ms"
 msgid "Default device"
 msgstr "默认设备"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "窗口模式"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "在 %s 中没有可用插件"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "插件"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "请选择一个插件或过滤器"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "插件选择错误"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "将清除所有自定义加速，是否继续？"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "确定"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "未找到主图标"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "未找到主显示面板"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "复写菜单加速器：%s 对应 %s 和 %s; 保持优先"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "菜单加速器 %s 为 %s 覆盖 %s 的默认值 ; 保留菜单"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "无效的菜单项目 %s; 正在移除"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "代码"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "描述"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "地址"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "原有数值"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "新数值"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "菜单命令"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "其他命令"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "JoyBus 主机无效; 正在禁用"
 
@@ -772,99 +792,99 @@ msgstr "无法载入 Game Boy Advance ROM %s"
 msgid " player "
 msgstr "玩家"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "载入状态 %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "载入状态错误 %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "保存状态 %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "保存状态错误 %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "不支持 %dx%d-%d@%d 全屏模式，选择其他模式"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "不支持 %dx%d-%d@%d 全屏模式"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "有效模式: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "选择模式 %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "切换模式失败 %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "无效 GBA 卡带"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "没有用于回退的内存"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "回写状态错误"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "内存分配错误"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "初始化代码错误"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "回写输出文件错误"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "无法从文件名猜测输出格式"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "程序错误!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "不能开始录制到 %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "录制音频/视频时错误 (%s); 正在中止"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "录制音频时错误 (%s); 正在中止"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "录制视频时错误 (%s); 正在中止"
@@ -934,12 +954,12 @@ msgstr "关闭(&C)"
 msgid "Printed"
 msgstr "印发了"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "打开伪 tty 错误: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "设置服务器接口错误 (%d)"
@@ -1338,7 +1358,7 @@ msgstr "添加金手指(&A)"
 msgid "Edit Cheat"
 msgstr "编辑金手指"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "类型(&T)"
 
@@ -2310,8 +2330,8 @@ msgstr "校验和:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2588,7 +2608,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "单击字段，然后按键或移动操纵杆以添加。 按退格键删除最后添加的键值。 如果太小则调整窗口尺寸或单击内部再移动指针以查看整个内容。"
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "上"
 
@@ -2596,7 +2616,7 @@ msgstr "上"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "下"
 
@@ -2604,7 +2624,7 @@ msgstr "下"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "左"
 
@@ -2612,7 +2632,7 @@ msgstr "左"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "右"
 
@@ -2620,11 +2640,11 @@ msgstr "右"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "选择"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "出发"
 
@@ -2748,634 +2768,658 @@ msgstr " 冗余"
 msgid "&File"
 msgstr "文件(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "打开 GB...(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "打开 GBC...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "最近打开的文件(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "重置最近列表(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "冻结最近列表(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ROM 信息(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "e-Reader(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "载入点代码...(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "保存点代码...(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "最常用"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "自动载入最常用文件(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "来自文件...(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "不更改电池存档(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "不更改金手指列表(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "载入状态(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "最近插槽(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "到文件...(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "保存状态(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "电池文件...(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Gameshark 代码文件...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Gameshark 快照...(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "导入(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "导出(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "屏幕捕获...(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "开始录制声音...(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "停止录制声音(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "开始录制视频...(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "停止录制视频(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "开始录制游戏...(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "停止录制游戏(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "录制(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "开始播放影片...(&M)"
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "停止播放影片(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "播放(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "模拟(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "暂停(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "下一帧(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "回退(&W)"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "切换全屏(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "加速模式(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "垂直同步(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "自动跳帧(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "跳过 BIOS(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "自动 IPS/UPS/IPF 补丁(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "非激活状态时暂停(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "重置(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "选项(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "连接(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "开始网络连接 ...(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "无(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "有线(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "无线(&W)"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "GameCube(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "Game Boy(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "本地模式(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "启动时连接(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "速度破解(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "配置 ...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "视频(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "启动时全屏(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr "&1x"
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr "&2x"
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr "&3x"
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr "&4x"
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr "&5x"
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr "&6x"
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "保持宽高比(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "双线性过滤(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "保持窗口在最前(&K)"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "状态栏(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "禁用屏幕显示信息(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "透明屏幕显示信息(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "音频(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr "增大音量"
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr "减小音量"
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr "声音开/关"
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "GBA 声音插值(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "GB 声音插值(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "GB 环绕音效(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "GB 声音降噪(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "输入(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "连发(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "Game Boy Advance(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "设置 ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "实时时钟(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "使用 BIOS 文件(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "调试打印(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "GB 打印机(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "在打印前聚集整个页面(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "将打印输出保存为截图(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "使用 GB BIOS 文件(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "使用 GBC BIOS 文件(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "通用(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr "加速/超频"
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "目录(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "快捷键(&K)"
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "工具(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "金手指(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "金手指列表 ...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "搜索金手指 ...(&H)"
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "自动保存/载入金手指(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "启用金手指(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "切入 GDB(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "配置端口...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "加载时切入(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "断开连接(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "GDB(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "反编译...(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "日志...(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "IO 查看器...(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "图层查看器...(&M)"
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "内存查看器...(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "OAM 查看器...(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "调色板查看器...(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "碎片查看器...(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "查看图层(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Channel &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Channel &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Channel &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Channel &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&声道"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&帮助"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "反馈"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M 支持论坛(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "翻译"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
 msgstr "恢复默认设置"
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
+msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4
 msgid "Map Viewer"

--- a/po/wxvbam/zh.po
+++ b/po/wxvbam/zh.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Chinese (http://www.transifex.com/bgk/vba-m/language/zh/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/zh_CN.GB2312.po
+++ b/po/wxvbam/zh_CN.GB2312.po
@@ -8,9 +8,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Chinese (China) (GB2312) (http://www.transifex.com/bgk/vba-m/language/zh_CN.GB2312/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -50,120 +50,120 @@ msgstr "GBC文件\n(*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg;*.gb;*.
 msgid "Open GBC ROM file"
 msgstr "打开GBC ROM文件"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "未知"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -174,230 +174,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA 影像文件|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "选择文件"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "声音开启"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "声音禁用"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "音量:%d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "等待%s的连接"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "等待%d端口连接"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "任天堂GB（GBC&GBA）模拟器。"
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA 开发团队\nCopyright (C) 2007-2017 VBA-M 开发团队"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -413,11 +429,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "本地模式下不支持网络连接。"
 
@@ -621,92 +637,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -765,99 +785,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -927,12 +947,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1331,7 +1351,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2303,8 +2323,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2581,7 +2601,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2589,7 +2609,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2597,7 +2617,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2605,7 +2625,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2613,11 +2633,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2741,633 +2761,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/zh_CN.po
+++ b/po/wxvbam/zh_CN.po
@@ -14,9 +14,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Chinese (China) (http://www.transifex.com/bgk/vba-m/language/zh_CN/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,120 +56,120 @@ msgstr "GBC 文件\n(*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg;*.gb;*
 msgid "Open GBC ROM file"
 msgstr "打开 GBC ROM 文件"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "未知"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -180,230 +180,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "无"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "选择点代码文件"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "电子阅读器点代码 (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "选择电池文件"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "电池文件 (*.sav)|*.sav|记忆文件(*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "导入电池文件将删除之前保存的游戏进度 (直到下次写入前)。你确定要继续吗？"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "确认导入"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "读取电池 %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "读取电池错误 %s"
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "选择代码文件"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark  代码文件 (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark 代码文件 (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "导入代码将会重置之前已经读取的所有金手指代码。你确定要继续吗？"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "无法打开文件 %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "不支持的代码文件 %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "已读取的代码文件 %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "读取代码文件错误 %s"
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "选择快照文件"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC 快照 (*.sps;*.xps)|*.sps;*.xps|GameShark SP 快照 (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy 快照 (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "导入快照将删除之前保存的游戏进度 (直到下次保存前)。你确定要继续吗？ "
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "已读取的快照文件 %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "快照文件读取错误 %s"
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "写入电池 %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "写入电池错误 %s"
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "EEPROM 存档无法导出"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark 快照 (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "从 VBA-M 导出"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "保存快照文件 %s "
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "保存快照文件错误 %s"
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "选择输出文件"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG 图片|*.png|BMP 图片|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "写入快照 %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "文件 ("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA 影片文件|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "选择文件"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "选择状态文件"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance 保存游戏文件|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "开启声音"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "静音"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "音量 %d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "给伪 tty 设置成 0"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "准备连接的端口"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB 连接"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "准备连接到 %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "准备连接的端口 %d"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "等待 GDB..."
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "任天堂 GameBoy (+Color+Advance) 模拟器。"
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "版权 (C) 1999-2003 Forgotten\n版权 (C) 2004-2006 VBA 开发团队\n版权 (C) 2007-2017 VBA-M 开发团队"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -419,11 +435,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "本程序是自由软件: 你可以在自由软件基金会公布的 GNU 通用发布\n许可证条款下重新分发和/或修改此软件，依自己意愿许可证 V2 版或\n任意更新版许可证选其一即可。\n\n本程序希望是能有作用的分发出去，但【无任何担保】；甚至没有隐含\n的【可销售性】或【特定用途的适用性】保证。请查阅 GNU 通用发布\n许可证了解更多信息。\n\n你应该已经收到 GNU 通用发布许可证的副本以及本程序。\n如果没有，请查看 http://www.gnu.org/licenses 。"
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "局域网连接已激活，禁用连接模式即可断开联网。"
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "本地模式不支持网络"
 
@@ -627,92 +643,96 @@ msgstr "%d frames = %.2f ms"
 msgid "Default device"
 msgstr "默认设备"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "窗口模式"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "在 %s 中没有可用插件"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "插件"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "请选择一个插件或过滤器"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "插件选择错误"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "将清除所有自定义加速，是否继续？"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "确定"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "未找到主图标"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "未找到主显示面板"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "复写菜单加速器：%s 对应 %s 和 %s; 保持优先"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "菜单加速器 %s 为 %s 覆盖 %s 的默认值 ; 保留菜单"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "无效的菜单项目 %s; 正在移除"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "代码"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "描述"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "地址"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "原有数值"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "新数值"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "菜单命令"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "其他命令"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "JoyBus 主机无效; 正在禁用"
 
@@ -771,99 +791,99 @@ msgstr "无法载入 Game Boy Advance ROM %s"
 msgid " player "
 msgstr "玩家"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "载入状态 %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "载入状态错误 %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "保存状态 %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "保存状态错误 %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "不支持 %dx%d-%d@%d 全屏模式，选择其他模式"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "不支持 %dx%d-%d@%d 全屏模式"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "有效模式: %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "选择模式 %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "切换模式失败 %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "无效 GBA 卡带"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr "没有用于回退的内存"
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr "回写状态错误"
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "内存分配错误"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "初始化代码错误"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "回写输出文件错误"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "无法从文件名猜测输出格式"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr "程序错误!"
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr "不能开始录制到 %s (%s)"
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr "录制音频/视频时错误 (%s); 正在中止"
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr "录制音频时错误 (%s); 正在中止"
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr "录制视频时错误 (%s); 正在中止"
@@ -933,12 +953,12 @@ msgstr "关闭(&C)"
 msgid "Printed"
 msgstr "印发了"
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr "打开伪 tty 错误: %s"
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr "设置服务器接口错误 (%d)"
@@ -1337,7 +1357,7 @@ msgstr "添加金手指(&A)"
 msgid "Edit Cheat"
 msgstr "编辑金手指"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "类型(&T)"
 
@@ -2309,8 +2329,8 @@ msgstr "校验和:"
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2587,7 +2607,7 @@ msgid ""
 "see entire contents if too small."
 msgstr "单击字段，然后按键或移动操纵杆以添加。 按退格键删除最后添加的键值。 如果太小则调整窗口尺寸或单击内部再移动指针以查看整个内容。"
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "上"
 
@@ -2595,7 +2615,7 @@ msgstr "上"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "下"
 
@@ -2603,7 +2623,7 @@ msgstr "下"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "左"
 
@@ -2611,7 +2631,7 @@ msgstr "左"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "右"
 
@@ -2619,11 +2639,11 @@ msgstr "右"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "选择"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "出发"
 
@@ -2747,634 +2767,658 @@ msgstr " 冗余"
 msgid "&File"
 msgstr "文件(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "打开 GB...(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "打开 GBC...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "最近打开的文件(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "重置最近列表(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "冻结最近列表(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ROM 信息(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr "e-Reader(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr "载入点代码...(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr "保存点代码...(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr "最常用"
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr "自动载入最常用文件(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr "来自文件...(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr "不更改电池存档(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr "不更改金手指列表(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "载入状态(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr "最近插槽(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr "到文件...(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "保存状态(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "电池文件...(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Gameshark 代码文件...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Gameshark 快照...(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "导入(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "导出(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "屏幕捕获...(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "开始录制声音...(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "停止录制声音(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "开始录制视频...(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "停止录制视频(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr "开始录制游戏...(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr "停止录制游戏(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "录制(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr "开始播放影片...(&M)"
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr "停止播放影片(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "播放(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "模拟(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "暂停(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "下一帧(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr "回退(&W)"
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "切换全屏(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "加速模式(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "垂直同步(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "自动跳帧(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "跳过 BIOS(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "自动 IPS/UPS/IPF 补丁(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "非激活状态时暂停(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "重置(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "选项(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "连接(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr "开始网络连接 ...(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr "无(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr "有线(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr "无线(&W)"
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "GameCube(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "Game Boy(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr "本地模式(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr "启动时连接(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr "速度破解(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "配置 ...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "视频(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "启动时全屏(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr "&1x"
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr "&2x"
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr "&3x"
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr "&4x"
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr "&5x"
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr "&6x"
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "保持宽高比(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr "双线性过滤(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "保持窗口在最前(&K)"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "状态栏(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "禁用屏幕显示信息(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "透明屏幕显示信息(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "音频(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr "增大音量"
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr "减小音量"
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr "声音开/关"
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr "GBA 声音插值(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr "GB 声音插值(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr "GB 环绕音效(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr "GB 声音降噪(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "输入(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "连发(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "Game Boy Advance(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "设置 ..."
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "实时时钟(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "使用 BIOS 文件(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr "调试打印(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr "GB 打印机(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr "在打印前聚集整个页面(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr "将打印输出保存为截图(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "使用 GB BIOS 文件(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "使用 GBC BIOS 文件(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "通用(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr "加速/超频"
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "目录(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "快捷键(&K)"
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "工具(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "金手指(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "金手指列表 ...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr "搜索金手指 ...(&H)"
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "自动保存/载入金手指(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "启用金手指(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr "切入 GDB(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr "配置端口...(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr "加载时切入(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr "断开连接(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr "GDB(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr "反编译...(&D)"
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr "日志...(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr "IO 查看器...(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr "图层查看器...(&M)"
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr "内存查看器...(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr "OAM 查看器...(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr "调色板查看器...(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr "碎片查看器...(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr "BG &0"
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr "BG &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr "BG &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr "BG &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr "&OBJ"
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr "&WIN 0"
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr "W&IN 1"
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr "O&BJ WIN"
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr "查看图层(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr "Channel &1"
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr "Channel &2"
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr "Channel &3"
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr "Channel &4"
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr "Direct Sound &A"
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr "Direct Sound &B"
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr "&声道"
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "&帮助"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "反馈"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M 支持论坛(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "翻译"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
 msgstr "恢复默认设置"
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
+msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4
 msgid "Map Viewer"

--- a/po/wxvbam/zh_HK.po
+++ b/po/wxvbam/zh_HK.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Chinese (Hong Kong) (http://www.transifex.com/bgk/vba-m/language/zh_HK/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/zh_SG.po
+++ b/po/wxvbam/zh_SG.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Chinese (Singapore) (http://www.transifex.com/bgk/vba-m/language/zh_SG/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/zh_TW.Big5.po
+++ b/po/wxvbam/zh_TW.Big5.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Chinese (Taiwan) (Big5)  (http://www.transifex.com/bgk/vba-m/language/zh_TW.Big5/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,120 +49,120 @@ msgstr ""
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -173,230 +173,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -412,11 +428,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -620,92 +636,96 @@ msgstr ""
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -764,99 +784,99 @@ msgstr ""
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -926,12 +946,12 @@ msgstr ""
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1330,7 +1350,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr ""
 
@@ -2302,8 +2322,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr ""
 
@@ -2580,7 +2600,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr ""
 
@@ -2588,7 +2608,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr ""
 
@@ -2596,7 +2616,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr ""
 
@@ -2604,7 +2624,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr ""
 
@@ -2612,11 +2632,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr ""
 
@@ -2740,633 +2760,657 @@ msgstr ""
 msgid "&File"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
-msgid "&Retain aspect ratio"
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:325
-msgid "&Bilinear filter"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:336
-msgid "&Keep window on top"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:341
-msgid "&Status bar"
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:345
-msgid "&Disable on-screen display"
+msgid "&Retain aspect ratio"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:349
-msgid "&Transparent on-screen display"
+msgid "Enable MMX"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:354
+msgid "&Bilinear filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:365
+msgid "&Keep window on top"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:370
+msgid "&Status bar"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:374
+msgid "&Disable on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:378
+msgid "&Transparent on-screen display"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/po/wxvbam/zh_TW.po
+++ b/po/wxvbam/zh_TW.po
@@ -14,9 +14,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: VBA-M\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-20 23:18+0000\n"
-"PO-Revision-Date: 2019-08-20 23:19+0000\n"
-"Last-Translator: Rafael Kitover <rkitover@gmail.com>\n"
+"POT-Creation-Date: 2019-09-06 19:39-0300\n"
+"PO-Revision-Date: 2019-09-06 22:39+0000\n"
+"Last-Translator: Edênis Freindorfer Azevedo\n"
 "Language-Team: Chinese (Taiwan) (http://www.transifex.com/bgk/vba-m/language/zh_TW/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,120 +56,120 @@ msgstr "GameBoy Color 檔案 (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.d
 msgid "Open GBC ROM file"
 msgstr "開啟 GBC ROM 檔案"
 
-#: ../src/wx/cmdevents.cpp:564 ../src/wx/cmdevents.cpp:680
-#: ../src/wx/cmdevents.cpp:719 ../src/wx/cmdevents.cpp:792
+#: ../src/wx/cmdevents.cpp:584 ../src/wx/cmdevents.cpp:700
+#: ../src/wx/cmdevents.cpp:739 ../src/wx/cmdevents.cpp:812
 msgid "Unknown"
 msgstr "未定義"
 
-#: ../src/wx/cmdevents.cpp:572
+#: ../src/wx/cmdevents.cpp:592
 msgid "ROM"
 msgstr "ROM"
 
-#: ../src/wx/cmdevents.cpp:576
+#: ../src/wx/cmdevents.cpp:596
 msgid "ROM+MBC1"
 msgstr "ROM+MBC1"
 
-#: ../src/wx/cmdevents.cpp:580
+#: ../src/wx/cmdevents.cpp:600
 msgid "ROM+MBC1+RAM"
 msgstr "ROM+MBC1+RAM"
 
-#: ../src/wx/cmdevents.cpp:584
+#: ../src/wx/cmdevents.cpp:604
 msgid "ROM+MBC1+RAM+BATT"
 msgstr "ROM+MBC1+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:588
+#: ../src/wx/cmdevents.cpp:608
 msgid "ROM+MBC2"
 msgstr "ROM+MBC2"
 
-#: ../src/wx/cmdevents.cpp:592
+#: ../src/wx/cmdevents.cpp:612
 msgid "ROM+MBC2+BATT"
 msgstr "ROM+MBC2+BATT"
 
-#: ../src/wx/cmdevents.cpp:596
+#: ../src/wx/cmdevents.cpp:616
 msgid "ROM+MMM01"
 msgstr "ROM+MMM01"
 
-#: ../src/wx/cmdevents.cpp:600
+#: ../src/wx/cmdevents.cpp:620
 msgid "ROM+MMM01+RAM"
 msgstr "ROM+MMM01+RAM"
 
-#: ../src/wx/cmdevents.cpp:604
+#: ../src/wx/cmdevents.cpp:624
 msgid "ROM+MMM01+RAM+BATT"
 msgstr "ROM+MMM01+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:608
+#: ../src/wx/cmdevents.cpp:628
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr "ROM+MBC3+TIMER+BATT"
 
-#: ../src/wx/cmdevents.cpp:612
+#: ../src/wx/cmdevents.cpp:632
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr "ROM+MBC3+TIMER+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:616
+#: ../src/wx/cmdevents.cpp:636
 msgid "ROM+MBC3"
 msgstr "ROM+MBC3"
 
-#: ../src/wx/cmdevents.cpp:620
+#: ../src/wx/cmdevents.cpp:640
 msgid "ROM+MBC3+RAM"
 msgstr "ROM+MBC3+RAM"
 
-#: ../src/wx/cmdevents.cpp:624
+#: ../src/wx/cmdevents.cpp:644
 msgid "ROM+MBC3+RAM+BATT"
 msgstr "ROM+MBC3+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:628
+#: ../src/wx/cmdevents.cpp:648
 msgid "ROM+MBC5"
 msgstr "ROM+MBC5"
 
-#: ../src/wx/cmdevents.cpp:632
+#: ../src/wx/cmdevents.cpp:652
 msgid "ROM+MBC5+RAM"
 msgstr "ROM+MBC5+RAM"
 
-#: ../src/wx/cmdevents.cpp:636
+#: ../src/wx/cmdevents.cpp:656
 msgid "ROM+MBC5+RAM+BATT"
 msgstr "ROM+MBC5+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:640
+#: ../src/wx/cmdevents.cpp:660
 msgid "ROM+MBC5+RUMBLE"
 msgstr "ROM+MBC5+RUMBLE"
 
-#: ../src/wx/cmdevents.cpp:644
+#: ../src/wx/cmdevents.cpp:664
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr "ROM+MBC5+RUMBLE+RAM"
 
-#: ../src/wx/cmdevents.cpp:648
+#: ../src/wx/cmdevents.cpp:668
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr "ROM+MBC5+RUMBLE+RAM+BATT"
 
-#: ../src/wx/cmdevents.cpp:652
+#: ../src/wx/cmdevents.cpp:672
 msgid "ROM+MBC7+BATT"
 msgstr "ROM+MBC7+BATT"
 
-#: ../src/wx/cmdevents.cpp:656 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
 msgid "GameGenie"
 msgstr "GameGenie"
 
-#: ../src/wx/cmdevents.cpp:660
+#: ../src/wx/cmdevents.cpp:680
 msgid "GameShark V3.0"
 msgstr "GameShark V3.0"
 
-#: ../src/wx/cmdevents.cpp:664
+#: ../src/wx/cmdevents.cpp:684
 msgid "ROM+POCKET CAMERA"
 msgstr "ROM+POCKET CAMERA"
 
-#: ../src/wx/cmdevents.cpp:668
+#: ../src/wx/cmdevents.cpp:688
 msgid "ROM+BANDAI TAMA5"
 msgstr "ROM+BANDAI TAMA5"
 
-#: ../src/wx/cmdevents.cpp:672
+#: ../src/wx/cmdevents.cpp:692
 msgid "ROM+HuC-3"
 msgstr "ROM+HuC-3"
 
-#: ../src/wx/cmdevents.cpp:676
+#: ../src/wx/cmdevents.cpp:696
 msgid "ROM+HuC-1"
 msgstr "ROM+HuC-1"
 
-#: ../src/wx/cmdevents.cpp:726 ../src/wx/guiinit.cpp:1826
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1829
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -180,230 +180,246 @@ msgstr "ROM+HuC-1"
 msgid "None"
 msgstr "無"
 
-#: ../src/wx/cmdevents.cpp:825 ../src/wx/cmdevents.cpp:841
+#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
 msgid "Select Dot Code file"
 msgstr "選擇Dot Code檔案"
 
-#: ../src/wx/cmdevents.cpp:827 ../src/wx/cmdevents.cpp:843
+#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 
-#: ../src/wx/cmdevents.cpp:862 ../src/wx/cmdevents.cpp:1057
+#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
 msgid "Select battery file"
 msgstr "選擇電池記憶檔"
 
-#: ../src/wx/cmdevents.cpp:863 ../src/wx/cmdevents.cpp:1058
+#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr "電池記憶檔 (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 
-#: ../src/wx/cmdevents.cpp:871
+#: ../src/wx/cmdevents.cpp:891
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "匯入電池記憶檔將會抹除現有的存檔（下次存檔後就永遠無法復原）。你要繼續嗎？"
 
-#: ../src/wx/cmdevents.cpp:872 ../src/wx/cmdevents.cpp:900
-#: ../src/wx/cmdevents.cpp:1020
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
+#: ../src/wx/cmdevents.cpp:1040
 msgid "Confirm import"
 msgstr "匯入確認"
 
-#: ../src/wx/cmdevents.cpp:878 ../src/wx/panel.cpp:344
+#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:344
 #, c-format
 msgid "Loaded battery %s"
 msgstr "已讀取電池記憶檔 %s"
 
-#: ../src/wx/cmdevents.cpp:880
+#: ../src/wx/cmdevents.cpp:900
 #, c-format
 msgid "Error loading battery %s"
 msgstr "讀取電池記憶檔%s時發生錯誤 "
 
-#: ../src/wx/cmdevents.cpp:889
+#: ../src/wx/cmdevents.cpp:909
 msgid "Select code file"
 msgstr "選擇代碼檔"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr "Gameshark 代碼檔 (*.spc;*.xpc)|*.spc;*.xpc"
 
-#: ../src/wx/cmdevents.cpp:890
+#: ../src/wx/cmdevents.cpp:910
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr "Gameshark 代碼檔 (*.gcf)|*.gcf"
 
-#: ../src/wx/cmdevents.cpp:899
+#: ../src/wx/cmdevents.cpp:919
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr "匯入的代碼檔將會取代已經載入的代碼。  你要繼續嗎？"
 
-#: ../src/wx/cmdevents.cpp:916
+#: ../src/wx/cmdevents.cpp:936
 #, c-format
 msgid "Cannot open file %s"
 msgstr "無法開啟檔案 %s"
 
-#: ../src/wx/cmdevents.cpp:926
+#: ../src/wx/cmdevents.cpp:946
 #, c-format
 msgid "Unsupported code file %s"
 msgstr "不支援的代碼檔 %s"
 
-#: ../src/wx/cmdevents.cpp:996
+#: ../src/wx/cmdevents.cpp:1016
 #, c-format
 msgid "Loaded code file %s"
 msgstr "已讀取代碼檔 %s"
 
-#: ../src/wx/cmdevents.cpp:998
+#: ../src/wx/cmdevents.cpp:1018
 #, c-format
 msgid "Error loading code file %s"
 msgstr "讀取代碼檔%s時發生錯誤 "
 
-#: ../src/wx/cmdevents.cpp:1009 ../src/wx/cmdevents.cpp:1085
+#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
 msgid "Select snapshot file"
 msgstr "選擇快照檔"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr "GS & PAC 快照檔 (*.sps;*.xps)|*.sps;*.xps|GameShark SP 快照檔 (*.gsv)|*.gsv"
 
-#: ../src/wx/cmdevents.cpp:1010
+#: ../src/wx/cmdevents.cpp:1030
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr "Gameboy 快照檔 (*.gbs)|*.gbs"
 
-#: ../src/wx/cmdevents.cpp:1019
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr "匯入快照檔將會抹除現有存檔（下次存檔後就永遠無法復原）。你要繼續嗎？"
 
-#: ../src/wx/cmdevents.cpp:1044
+#: ../src/wx/cmdevents.cpp:1064
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr "已讀取快照檔 %s"
 
-#: ../src/wx/cmdevents.cpp:1046
+#: ../src/wx/cmdevents.cpp:1066
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr "讀取快照檔%s時發生錯誤 "
 
-#: ../src/wx/cmdevents.cpp:1069
+#: ../src/wx/cmdevents.cpp:1089
 #, c-format
 msgid "Wrote battery %s"
 msgstr "寫入電池記憶檔 %s"
 
-#: ../src/wx/cmdevents.cpp:1071 ../src/wx/panel.cpp:648
+#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:651
 #, c-format
 msgid "Error writing battery %s"
 msgstr "寫入電池記憶檔%s時發生錯誤 "
 
-#: ../src/wx/cmdevents.cpp:1079
+#: ../src/wx/cmdevents.cpp:1099
 msgid "EEPROM saves cannot be exported"
 msgstr "EEPROM 記錄不能匯出"
 
-#: ../src/wx/cmdevents.cpp:1086
+#: ../src/wx/cmdevents.cpp:1106
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr "Gameshark 快照檔 (*.sps)|*.sps"
 
-#: ../src/wx/cmdevents.cpp:1100
+#: ../src/wx/cmdevents.cpp:1120
 msgid "Exported from VisualBoyAdvance-M"
 msgstr "從 VisualBoyAdvance-M 匯出"
 
-#: ../src/wx/cmdevents.cpp:1112
+#: ../src/wx/cmdevents.cpp:1132
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr "已儲存快照檔 %s"
 
-#: ../src/wx/cmdevents.cpp:1114
+#: ../src/wx/cmdevents.cpp:1134
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr "儲存快照檔%s時發生錯誤 "
 
-#: ../src/wx/cmdevents.cpp:1129 ../src/wx/cmdevents.cpp:1207
-#: ../src/wx/cmdevents.cpp:1277 ../src/wx/cmdevents.cpp:1304
+#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
+#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr "選擇輸出檔案"
 
-#: ../src/wx/cmdevents.cpp:1130 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr "PNG 圖片|*.png|BMP 圖片|*.bmp"
 
-#: ../src/wx/cmdevents.cpp:1154 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr "寫入快照檔 %s"
 
-#: ../src/wx/cmdevents.cpp:1175 ../src/wx/cmdevents.cpp:1245
+#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
 msgid " files ("
 msgstr "檔案("
 
-#: ../src/wx/cmdevents.cpp:1305 ../src/wx/cmdevents.cpp:1326
+#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
 msgid "VBA Movie files|*.vmv"
 msgstr "VBA 影像檔|*.vmv"
 
-#: ../src/wx/cmdevents.cpp:1325
+#: ../src/wx/cmdevents.cpp:1345
 msgid "Select file"
 msgstr "選擇檔案"
 
-#: ../src/wx/cmdevents.cpp:1610 ../src/wx/cmdevents.cpp:1703
+#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
 msgid "Select state file"
 msgstr "選擇即時紀錄檔"
 
-#: ../src/wx/cmdevents.cpp:1611 ../src/wx/cmdevents.cpp:1704
+#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr "VisualBoyAdvance saved game files|*.sgm"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
+#: ../src/wx/cmdevents.cpp:1775
+#, c-format
+msgid "Current state slot #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound enabled"
 msgstr "音效已啟動"
 
-#: ../src/wx/cmdevents.cpp:1943
+#: ../src/wx/cmdevents.cpp:2044
 msgid "Sound disabled"
 msgstr "音效已關閉"
 
-#: ../src/wx/cmdevents.cpp:1956 ../src/wx/cmdevents.cpp:1970
+#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
 #, c-format
 msgid "Volume: %d%%"
 msgstr "音量：%d%%"
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2146
 msgid "Set to 0 for pseudo tty"
 msgstr "虛擬終端設置為0"
 
-#: ../src/wx/cmdevents.cpp:2046
+#: ../src/wx/cmdevents.cpp:2148
 msgid "Port to wait for connection:"
 msgstr "等待連接的連接埠"
 
-#: ../src/wx/cmdevents.cpp:2047
+#: ../src/wx/cmdevents.cpp:2149
 msgid "GDB Connection"
 msgstr "GDB 連接"
 
-#: ../src/wx/cmdevents.cpp:2094
+#: ../src/wx/cmdevents.cpp:2202
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr "等待連接 %s"
 
-#: ../src/wx/cmdevents.cpp:2101
+#: ../src/wx/cmdevents.cpp:2209
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr "在連接埠 %d 等候連接"
 
-#: ../src/wx/cmdevents.cpp:2104
+#: ../src/wx/cmdevents.cpp:2212
 msgid "Waiting for GDB..."
 msgstr "正在等候 GDB ……"
 
-#: ../src/wx/cmdevents.cpp:2626
+#: ../src/wx/cmdevents.cpp:2609
+#, c-format
+msgid "Using pixel filter #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2624
+#, c-format
+msgid "Using interframe blending #%d"
+msgstr ""
+
+#: ../src/wx/cmdevents.cpp:2747
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr "任天堂 GameBoy (+Color+Advance) 模擬器"
 
-#: ../src/wx/cmdevents.cpp:2627
+#: ../src/wx/cmdevents.cpp:2748
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr "Copyright (C) 1999-2003 Forgotten\nCopyright (C) 2004-2006 VBA development team\nCopyright (C) 2007-2017 VBA-M development team"
 
-#: ../src/wx/cmdevents.cpp:2628
+#: ../src/wx/cmdevents.cpp:2749
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -419,11 +435,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr "This program is free software: you can redistribute it and/or modify\nit under the terms of the GNU General Public License as published by\nthe Free Software Foundation, either version 2 of the License, or\n(at your option) any later version.\n\nThis program is distributed in the hope that it will be useful,\nbut WITHOUT ANY WARRANTY; without even the implied warranty of\nMERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\nGNU General Public License for more details.\n\nYou should have received a copy of the GNU General Public License\nalong with this program.  If not, see http://www.gnu.org/licenses ."
 
-#: ../src/wx/cmdevents.cpp:2888
+#: ../src/wx/cmdevents.cpp:3011
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr "區網連接已開啟。禁用連接模式。"
 
-#: ../src/wx/cmdevents.cpp:2894
+#: ../src/wx/cmdevents.cpp:3017
 msgid "Network is not supported in local mode."
 msgstr "網路不支持本地模式"
 
@@ -627,92 +643,96 @@ msgstr "%d frames = %.2f ms"
 msgid "Default device"
 msgstr "預設裝置"
 
-#: ../src/wx/guiinit.cpp:1706
+#: ../src/wx/guiinit.cpp:1709
 msgid "Desktop mode"
 msgstr "桌面模式"
 
-#: ../src/wx/guiinit.cpp:1713
+#: ../src/wx/guiinit.cpp:1716
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr "%d x %d - %dbpp @ %dHz"
 
-#: ../src/wx/guiinit.cpp:1867
+#: ../src/wx/guiinit.cpp:1870
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr "在%s找不到可用的 rpi 外掛元件"
 
-#: ../src/wx/guiinit.cpp:1887 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1890 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr "插件"
 
-#: ../src/wx/guiinit.cpp:1915
+#: ../src/wx/guiinit.cpp:1918
 msgid "Please select a plugin or a different filter"
 msgstr "請選取一個插件或一個不同的過濾器"
 
-#: ../src/wx/guiinit.cpp:1916
+#: ../src/wx/guiinit.cpp:1919
 msgid "Plugin selection error"
 msgstr "插件選取錯誤"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr "這將清除所有使用者的加速器設定"
 
-#: ../src/wx/guiinit.cpp:2115
+#: ../src/wx/guiinit.cpp:2118
 msgid "Confirm"
 msgstr "確認"
 
-#: ../src/wx/guiinit.cpp:2709
+#: ../src/wx/guiinit.cpp:2712
 msgid "Main icon not found"
 msgstr "主圖示未找到"
 
-#: ../src/wx/guiinit.cpp:2727
+#: ../src/wx/guiinit.cpp:2722
+msgid "Browse"
+msgstr ""
+
+#: ../src/wx/guiinit.cpp:2736
 msgid "Main display panel not found"
 msgstr "主顯示螢幕未找到"
 
-#: ../src/wx/guiinit.cpp:2841
+#: ../src/wx/guiinit.cpp:2875
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr "複製選單加速器:%s於%s和%s；保持第一"
 
-#: ../src/wx/guiinit.cpp:2855
+#: ../src/wx/guiinit.cpp:2889
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr "選單加速器%s%s的預設覆蓋%s的；保存選單"
 
-#: ../src/wx/guiinit.cpp:2971
+#: ../src/wx/guiinit.cpp:3013
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr "無效的選單項%s；去除"
 
-#: ../src/wx/guiinit.cpp:3166
+#: ../src/wx/guiinit.cpp:3208
 msgid "Code"
 msgstr "代碼"
 
-#: ../src/wx/guiinit.cpp:3175
+#: ../src/wx/guiinit.cpp:3217
 msgid "Description"
 msgstr "描述"
 
-#: ../src/wx/guiinit.cpp:3249 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3291 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr "位址"
 
-#: ../src/wx/guiinit.cpp:3250
+#: ../src/wx/guiinit.cpp:3292
 msgid "Old Value"
 msgstr "舊數值"
 
-#: ../src/wx/guiinit.cpp:3251
+#: ../src/wx/guiinit.cpp:3293
 msgid "New Value"
 msgstr "新數值"
 
-#: ../src/wx/guiinit.cpp:3787
+#: ../src/wx/guiinit.cpp:3836
 msgid "Menu commands"
 msgstr "選單指令"
 
-#: ../src/wx/guiinit.cpp:3810
+#: ../src/wx/guiinit.cpp:3859
 msgid "Other commands"
 msgstr "其他指令"
 
-#: ../src/wx/guiinit.cpp:3921
+#: ../src/wx/guiinit.cpp:3970
 msgid "JoyBus host invalid; disabling"
 msgstr "遊戲總線主機無效;禁用"
 
@@ -771,99 +791,99 @@ msgstr "無法讀取 Game Boy Advance ROM %s"
 msgid " player "
 msgstr "播放器"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Loaded state %s"
 msgstr "已讀取即時紀錄檔 %s"
 
-#: ../src/wx/panel.cpp:596
+#: ../src/wx/panel.cpp:599
 #, c-format
 msgid "Error loading state %s"
 msgstr "讀取即時紀錄檔時發生錯誤 %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Saved state %s"
 msgstr "已完成即時紀錄 %s"
 
-#: ../src/wx/panel.cpp:620
+#: ../src/wx/panel.cpp:623
 #, c-format
 msgid "Error saving state %s"
 msgstr "即時記錄時發生錯誤 %s"
 
-#: ../src/wx/panel.cpp:824
+#: ../src/wx/panel.cpp:827
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr "不支援全螢幕模式 %dx%d-%d@%d， 尋找其他模式。"
 
-#: ../src/wx/panel.cpp:862
+#: ../src/wx/panel.cpp:865
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr "不支援全螢幕模式 %dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:867
+#: ../src/wx/panel.cpp:870
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr "有效模式：%dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:878
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr "選擇模式：%dx%d-%d@%d"
 
-#: ../src/wx/panel.cpp:879
+#: ../src/wx/panel.cpp:882
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr "無法切換到 %dx%d-%d@%d 模式"
 
-#: ../src/wx/panel.cpp:962
+#: ../src/wx/panel.cpp:966
 msgid "Not a valid GBA cartridge"
 msgstr "不是有效的 GBA 卡匣"
 
-#: ../src/wx/panel.cpp:1100
+#: ../src/wx/panel.cpp:1107
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1110
+#: ../src/wx/panel.cpp:1117
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2321
+#: ../src/wx/panel.cpp:2329
 msgid "memory allocation error"
 msgstr "記憶體配置錯誤"
 
-#: ../src/wx/panel.cpp:2324
+#: ../src/wx/panel.cpp:2332
 msgid "error initializing codec"
 msgstr "解碼器初始化錯誤"
 
-#: ../src/wx/panel.cpp:2327
+#: ../src/wx/panel.cpp:2335
 msgid "error writing to output file"
 msgstr "輸出檔寫入錯誤"
 
-#: ../src/wx/panel.cpp:2330
+#: ../src/wx/panel.cpp:2338
 msgid "can't guess output format from file name"
 msgstr "從檔名猜測輸出格式失敗"
 
-#: ../src/wx/panel.cpp:2335
+#: ../src/wx/panel.cpp:2343
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2352 ../src/wx/panel.cpp:2383
+#: ../src/wx/panel.cpp:2360 ../src/wx/panel.cpp:2391
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2411
+#: ../src/wx/panel.cpp:2419
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2417
+#: ../src/wx/panel.cpp:2425
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2427
+#: ../src/wx/panel.cpp:2435
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -933,12 +953,12 @@ msgstr "關閉(&C)"
 msgid "Printed"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1185
+#: ../src/wx/sys.cpp:1187
 #, c-format
 msgid "Error opening pseudo tty: %s"
 msgstr ""
 
-#: ../src/wx/sys.cpp:1284
+#: ../src/wx/sys.cpp:1286
 #, c-format
 msgid "Error setting up server socket (%d)"
 msgstr ""
@@ -1337,7 +1357,7 @@ msgstr "新增代碼(&A)"
 msgid "Edit Cheat"
 msgstr "編輯金手指代碼"
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:250
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
 msgid "&Type"
 msgstr "類型(&T)"
 
@@ -2309,8 +2329,8 @@ msgstr ""
 msgid "&0"
 msgstr "&0"
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:47
-#: ../src/wx/xrc/MainMenu.xrc:97
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
+#: ../src/wx/xrc/MainMenu.xrc:108
 msgid "&1"
 msgstr "&1"
 
@@ -2587,7 +2607,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
 msgid "Up"
 msgstr "上"
 
@@ -2595,7 +2615,7 @@ msgstr "上"
 msgid "A"
 msgstr "A"
 
-#: ../src/wx/xrc/JoyPanel.xrc:60
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
 msgid "Down"
 msgstr "下"
 
@@ -2603,7 +2623,7 @@ msgstr "下"
 msgid "B"
 msgstr "B"
 
-#: ../src/wx/xrc/JoyPanel.xrc:106
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
 msgid "Left"
 msgstr "左"
 
@@ -2611,7 +2631,7 @@ msgstr "左"
 msgid "L"
 msgstr "L"
 
-#: ../src/wx/xrc/JoyPanel.xrc:152
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
 msgid "Right"
 msgstr "右"
 
@@ -2619,11 +2639,11 @@ msgstr "右"
 msgid "R"
 msgstr "R"
 
-#: ../src/wx/xrc/JoyPanel.xrc:199
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
 msgid "Select"
 msgstr "選擇"
 
-#: ../src/wx/xrc/JoyPanel.xrc:222
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
 msgid "Start"
 msgstr "開始"
 
@@ -2747,633 +2767,657 @@ msgstr ""
 msgid "&File"
 msgstr "檔案(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:8
+#: ../src/wx/xrc/MainMenu.xrc:7
+msgid "Open..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:10
 msgid "Open &GB..."
 msgstr "開啟 GB"
 
-#: ../src/wx/xrc/MainMenu.xrc:11
+#: ../src/wx/xrc/MainMenu.xrc:13
 msgid "Open GB&C..."
 msgstr "開啟 GBC"
 
-#: ../src/wx/xrc/MainMenu.xrc:14
+#: ../src/wx/xrc/MainMenu.xrc:16
 msgid "Open rece&nt"
 msgstr "歷史清單(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:16
+#: ../src/wx/xrc/MainMenu.xrc:18
 msgid "&Reset recent list"
 msgstr "清空歷史清單(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:19
+#: ../src/wx/xrc/MainMenu.xrc:21
 msgid "&Freeze recent list"
 msgstr "凍結歷史清單(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:24
+#: ../src/wx/xrc/MainMenu.xrc:26
 msgid "ROM in&formation..."
 msgstr "ROM 資訊(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:28
+#: ../src/wx/xrc/MainMenu.xrc:30
 msgid "&e-Reader"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:30
+#: ../src/wx/xrc/MainMenu.xrc:32
 msgid "&Load Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:33
+#: ../src/wx/xrc/MainMenu.xrc:35
 msgid "&Save Dot Code..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:39
+#: ../src/wx/xrc/MainMenu.xrc:41
 msgid "Most &recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:42
+#: ../src/wx/xrc/MainMenu.xrc:44
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:47
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:50 ../src/wx/xrc/MainMenu.xrc:100
+#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
 msgid "&2"
 msgstr "&2"
 
-#: ../src/wx/xrc/MainMenu.xrc:53 ../src/wx/xrc/MainMenu.xrc:103
+#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
 msgid "&3"
 msgstr "&3"
 
-#: ../src/wx/xrc/MainMenu.xrc:56 ../src/wx/xrc/MainMenu.xrc:106
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&4"
 msgstr "&4"
 
-#: ../src/wx/xrc/MainMenu.xrc:59 ../src/wx/xrc/MainMenu.xrc:109
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&5"
 msgstr "&5"
 
-#: ../src/wx/xrc/MainMenu.xrc:62 ../src/wx/xrc/MainMenu.xrc:112
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&6"
 msgstr "&6"
 
-#: ../src/wx/xrc/MainMenu.xrc:65 ../src/wx/xrc/MainMenu.xrc:115
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&7"
 msgstr "&7"
 
-#: ../src/wx/xrc/MainMenu.xrc:68 ../src/wx/xrc/MainMenu.xrc:118
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&8"
 msgstr "&8"
 
-#: ../src/wx/xrc/MainMenu.xrc:71 ../src/wx/xrc/MainMenu.xrc:121
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&9"
 msgstr "&9"
 
-#: ../src/wx/xrc/MainMenu.xrc:74 ../src/wx/xrc/MainMenu.xrc:124
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "1&0"
 msgstr "1&0"
 
-#: ../src/wx/xrc/MainMenu.xrc:78
+#: ../src/wx/xrc/MainMenu.xrc:83
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:82
+#: ../src/wx/xrc/MainMenu.xrc:87
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:86
+#: ../src/wx/xrc/MainMenu.xrc:91
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:89
+#: ../src/wx/xrc/MainMenu.xrc:94
 msgid "&Load state"
 msgstr "讀取即時記錄(&L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:93
+#: ../src/wx/xrc/MainMenu.xrc:98
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:128
+#: ../src/wx/xrc/MainMenu.xrc:101
+msgid "Save current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:104
+msgid "Increase state slot number and save"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:139
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:130
+#: ../src/wx/xrc/MainMenu.xrc:141
 msgid "&Save state"
 msgstr "即時記錄(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:135 ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:144
+msgid "Increase state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:147
+msgid "Decrease state slot number"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
 msgid "&Battery file..."
 msgstr "電池記憶檔(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:138
+#: ../src/wx/xrc/MainMenu.xrc:155
 msgid "Gameshark &code file..."
 msgstr "Gameshark 代碼檔(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:141 ../src/wx/xrc/MainMenu.xrc:150
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
 msgid "&Gameshark snapshot..."
 msgstr "Gameshark 快照(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:143
+#: ../src/wx/xrc/MainMenu.xrc:160
 msgid "&Import"
 msgstr "匯入(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:152
+#: ../src/wx/xrc/MainMenu.xrc:169
 msgid "&Export"
 msgstr "匯出(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:156
+#: ../src/wx/xrc/MainMenu.xrc:173
 msgid "Screen capt&ure..."
 msgstr "擷取畫面(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:177
 msgid "Start &sound recording..."
 msgstr "開始錄音(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:163
+#: ../src/wx/xrc/MainMenu.xrc:180
 msgid "Stop s&ound recording"
 msgstr "停止錄音(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:166
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &video recording..."
 msgstr "開始錄影(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop v&ideo recording"
 msgstr "停止錄影(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:172
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:175
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:194
 msgid "&Record"
 msgstr "錄影(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:181
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:184
+#: ../src/wx/xrc/MainMenu.xrc:201
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:203
 msgid "&Play"
 msgstr "播放(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:193
+#: ../src/wx/xrc/MainMenu.xrc:208
+msgid "&Quit"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:212
 msgid "&Emulation"
 msgstr "模擬(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:195
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Pause"
 msgstr "暫停(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:199
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Next frame"
 msgstr "下一個畫格(&N)"
 
-#: ../src/wx/xrc/MainMenu.xrc:202
+#: ../src/wx/xrc/MainMenu.xrc:221
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:206
+#: ../src/wx/xrc/MainMenu.xrc:225
 msgid "Toggle &full screen"
 msgstr "全螢幕"
 
-#: ../src/wx/xrc/MainMenu.xrc:213
+#: ../src/wx/xrc/MainMenu.xrc:232
 msgid "&Turbo mode"
 msgstr "渦輪加速模式(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:217
+#: ../src/wx/xrc/MainMenu.xrc:236
 msgid "&VSync"
 msgstr "垂直同步(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:240
 msgid "&Auto skip frames"
 msgstr "自動省略畫格(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:226
+#: ../src/wx/xrc/MainMenu.xrc:245
 msgid "&Skip BIOS"
 msgstr "跳過 BIOS"
 
-#: ../src/wx/xrc/MainMenu.xrc:230
+#: ../src/wx/xrc/MainMenu.xrc:249
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr "自動套用 IPS/UPS/IPF 補丁(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:234
+#: ../src/wx/xrc/MainMenu.xrc:253
 msgid "&Pause when inactive"
 msgstr "非作用時暫停(&P)"
 
-#: ../src/wx/xrc/MainMenu.xrc:239
+#: ../src/wx/xrc/MainMenu.xrc:258
 msgid "&Reset"
 msgstr "重置(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:243
+#: ../src/wx/xrc/MainMenu.xrc:262
 msgid "&Options"
 msgstr "選項(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Link"
 msgstr "連線(L)"
 
-#: ../src/wx/xrc/MainMenu.xrc:247
+#: ../src/wx/xrc/MainMenu.xrc:266
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:252
+#: ../src/wx/xrc/MainMenu.xrc:271
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:256
+#: ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:260
+#: ../src/wx/xrc/MainMenu.xrc:279
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:283
 msgid "&GameCube"
 msgstr "&GameCube"
 
-#: ../src/wx/xrc/MainMenu.xrc:268 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
 msgid "&Game Boy"
 msgstr "&Game Boy"
 
-#: ../src/wx/xrc/MainMenu.xrc:273
+#: ../src/wx/xrc/MainMenu.xrc:292
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:277
+#: ../src/wx/xrc/MainMenu.xrc:296
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:281
+#: ../src/wx/xrc/MainMenu.xrc:300
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:285 ../src/wx/xrc/MainMenu.xrc:291
-#: ../src/wx/xrc/MainMenu.xrc:356 ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
 msgid "&Configure ..."
 msgstr "設定(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:289
+#: ../src/wx/xrc/MainMenu.xrc:308
 msgid "&Video"
 msgstr "視訊(&V)"
 
-#: ../src/wx/xrc/MainMenu.xrc:295
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Start in full screen"
 msgstr "以全螢幕模式開始(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:299
+#: ../src/wx/xrc/MainMenu.xrc:318
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:301
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304
+#: ../src/wx/xrc/MainMenu.xrc:323
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:307
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:310
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:313
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:339
+msgid "Change pixel filter"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:342
+msgid "Change interframe blending"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "&Retain aspect ratio"
 msgstr "保持長寬比(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:325
+#: ../src/wx/xrc/MainMenu.xrc:349
+msgid "Enable MMX"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:354
 msgid "&Bilinear filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:336
+#: ../src/wx/xrc/MainMenu.xrc:365
 msgid "&Keep window on top"
 msgstr "保持視窗在最上層"
 
-#: ../src/wx/xrc/MainMenu.xrc:341
+#: ../src/wx/xrc/MainMenu.xrc:370
 msgid "&Status bar"
 msgstr "狀態列(&S)"
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:374
 msgid "&Disable on-screen display"
 msgstr "關閉 OS&D"
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:378
 msgid "&Transparent on-screen display"
 msgstr "OSD 透明度(&T)"
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:383
 msgid "&Audio"
 msgstr "音訊(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:359
+#: ../src/wx/xrc/MainMenu.xrc:388
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:363
+#: ../src/wx/xrc/MainMenu.xrc:392
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:367
+#: ../src/wx/xrc/MainMenu.xrc:396
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:372
+#: ../src/wx/xrc/MainMenu.xrc:401
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:377
+#: ../src/wx/xrc/MainMenu.xrc:406
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:381
+#: ../src/wx/xrc/MainMenu.xrc:410
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:385
+#: ../src/wx/xrc/MainMenu.xrc:414
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:390
+#: ../src/wx/xrc/MainMenu.xrc:419
 msgid "&Input"
 msgstr "控制(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Autofire"
 msgstr "自動連擊(&A)"
 
-#: ../src/wx/xrc/MainMenu.xrc:398 ../src/wx/xrc/MainMenu.xrc:433
+#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
 msgid "&A"
 msgstr "&A"
 
-#: ../src/wx/xrc/MainMenu.xrc:402 ../src/wx/xrc/MainMenu.xrc:437
+#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
 msgid "&B"
 msgstr "&B"
 
-#: ../src/wx/xrc/MainMenu.xrc:406 ../src/wx/xrc/MainMenu.xrc:441
+#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
 msgid "&L"
 msgstr "&L"
 
-#: ../src/wx/xrc/MainMenu.xrc:410 ../src/wx/xrc/MainMenu.xrc:445
+#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
 msgid "&R"
 msgstr "&R"
 
-#: ../src/wx/xrc/MainMenu.xrc:415
+#: ../src/wx/xrc/MainMenu.xrc:444
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:417
-msgid "&Up"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:421
-msgid "&Down"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:425
-msgid "&Left"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:429
-msgid "&Right"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:449
-msgid "&Select"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:453
-msgid "&Start"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:459
+#: ../src/wx/xrc/MainMenu.xrc:488
 msgid "&Game Boy Advance"
 msgstr "&Game Boy Advance"
 
-#: ../src/wx/xrc/MainMenu.xrc:461 ../src/wx/xrc/MainMenu.xrc:480
+#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
 msgid "Configure ..."
 msgstr "設定"
 
-#: ../src/wx/xrc/MainMenu.xrc:465
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Real-time clock"
 msgstr "真實時鐘(&R)"
 
-#: ../src/wx/xrc/MainMenu.xrc:469
+#: ../src/wx/xrc/MainMenu.xrc:498
 msgid "&Use BIOS file"
 msgstr "使用 BIOS 檔案(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:473
+#: ../src/wx/xrc/MainMenu.xrc:502
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:484
+#: ../src/wx/xrc/MainMenu.xrc:513
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:517
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:492
+#: ../src/wx/xrc/MainMenu.xrc:521
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:497
+#: ../src/wx/xrc/MainMenu.xrc:526
 msgid "&Use GB BIOS file"
 msgstr "使用 GB BIOS 檔案(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:501
+#: ../src/wx/xrc/MainMenu.xrc:530
 msgid "&Use GBC BIOS file"
 msgstr "使用 GBC BIOS 檔案(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:506
+#: ../src/wx/xrc/MainMenu.xrc:535
 msgid "&General ..."
 msgstr "一般設定(&G)"
 
-#: ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:538
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:512
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "D&irectories ..."
 msgstr "資料夾(&I)"
 
-#: ../src/wx/xrc/MainMenu.xrc:515
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Key Shortcuts ..."
 msgstr "快捷鍵(&K)"
 
-#: ../src/wx/xrc/MainMenu.xrc:519
+#: ../src/wx/xrc/MainMenu.xrc:548
 msgid "&Tools"
 msgstr "工具(&O)"
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Cheats"
 msgstr "金手指(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:523
+#: ../src/wx/xrc/MainMenu.xrc:552
 msgid "List &cheats ..."
 msgstr "列出金手指代碼(&C)"
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:555
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:559
 msgid "A&utomatically save/load cheats"
 msgstr "自動儲存/讀取金手指代碼(&U)"
 
-#: ../src/wx/xrc/MainMenu.xrc:534
+#: ../src/wx/xrc/MainMenu.xrc:563
 msgid "&Enable cheats"
 msgstr "啟動金手指(&E)"
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:570
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:545
+#: ../src/wx/xrc/MainMenu.xrc:574
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:577
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:553
+#: ../src/wx/xrc/MainMenu.xrc:582
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:584
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:558
+#: ../src/wx/xrc/MainMenu.xrc:587
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:561
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:564
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:567
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:573
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:576
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:579
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:613
+msgid "Show all video layers"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:617
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:589
+#: ../src/wx/xrc/MainMenu.xrc:622
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:594
+#: ../src/wx/xrc/MainMenu.xrc:627
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:632
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:604
+#: ../src/wx/xrc/MainMenu.xrc:637
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:609
+#: ../src/wx/xrc/MainMenu.xrc:642
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:614
+#: ../src/wx/xrc/MainMenu.xrc:647
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:619
+#: ../src/wx/xrc/MainMenu.xrc:652
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:623
+#: ../src/wx/xrc/MainMenu.xrc:656
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:660
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:665
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:670
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:675
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:680
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:685
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:689
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:693
 msgid "&Help"
 msgstr "說明(&H)"
 
-#: ../src/wx/xrc/MainMenu.xrc:662
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "Report &Bugs"
 msgstr "回報程式瑕疵(&B)"
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:698
 msgid "VBA-M Support &Forum"
 msgstr "VBA-M 線上支援及論壇(&F)"
 
-#: ../src/wx/xrc/MainMenu.xrc:668
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Translations"
 msgstr "協助翻譯"
 
-#: ../src/wx/xrc/MainMenu.xrc:679
+#: ../src/wx/xrc/MainMenu.xrc:712
 msgid "&Factory Reset..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:716
+msgid "&About..."
 msgstr ""
 
 #: ../src/wx/xrc/MapViewer.xrc:4

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2803,8 +2803,10 @@ EVT_HANDLER(ApplyPatches, "Apply IPS/UPS/IPF patches if found")
 
 EVT_HANDLER(MMX, "Enable MMX")
 {
+#ifdef MMX
     GetMenuOptionInt("MMX", disableMMX, 1);
     update_opts();
+#endif
 }
 
 EVT_HANDLER(KeepOnTop, "Keep window on top")

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -1749,12 +1749,20 @@ EVT_HANDLER_MASK(SaveGameSlot, "Save current state slot", CMDEN_GB | CMDEN_GBA)
 EVT_HANDLER_MASK(IncrGameSlot, "Increase state slot number", CMDEN_GB | CMDEN_GBA)
 {
     state_slot = (state_slot + 1) % 10;
+
+    wxString msg;
+    msg.Printf(_("Current state slot #%d"), state_slot);
+    systemScreenMessage(msg);
 }
 
 // new
 EVT_HANDLER_MASK(DecrGameSlot, "Decrease state slot number", CMDEN_GB | CMDEN_GBA)
 {
     state_slot = (state_slot + 9) % 10;
+
+    wxString msg;
+    msg.Printf(_("Current state slot #%d"), state_slot);
+    systemScreenMessage(msg);
 }
 
 // new
@@ -1762,6 +1770,10 @@ EVT_HANDLER_MASK(IncrGameSlotSave, "Increase state slot number and save", CMDEN_
 {
     state_slot = (state_slot + 1) % 10;
     panel->SaveState(state_slot + 1);
+
+    wxString msg;
+    msg.Printf(_("Current state slot #%d"), state_slot);
+    systemScreenMessage(msg);
 }
 
 EVT_HANDLER_MASK(Rewind, "Rewind", CMDEN_REWIND)
@@ -2523,6 +2535,10 @@ EVT_HANDLER_MASK(ChangeFilter, "Change Pixel Filter", CMDEN_NREC_ANY)
         panel->panel->Destroy();
         panel->panel = NULL;
     }
+
+    wxString msg;
+    msg.Printf(_("Using pixel filter #%d"), gopts.filter);
+    systemScreenMessage(msg);
 }
 
 EVT_HANDLER_MASK(ChangeIFB, "Change Interframe Blending", CMDEN_NREC_ANY)
@@ -2534,6 +2550,10 @@ EVT_HANDLER_MASK(ChangeIFB, "Change Interframe Blending", CMDEN_NREC_ANY)
         panel->panel->Destroy();
         panel->panel = NULL;
     }
+
+    wxString msg;
+    msg.Printf(_("Using interframe blending #%d"), gopts.ifb);
+    systemScreenMessage(msg);
 }
 
 EVT_HANDLER_MASK(SoundConfigure, "Sound options...", CMDEN_NREC_ANY)

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -1839,61 +1839,100 @@ EVT_HANDLER(CheatsEnable, "Enable cheats (toggle)")
 // Debug menu
 EVT_HANDLER_MASK(VideoLayersBG0, "Video layer BG0 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("VideoLayersBG0", layerSettings, (1 << 8));
+    bool menuPress;
+    char keyName[] = "VideoLayersBG0";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &layerSettings, (1 << 8));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, layerSettings, (1 << 8));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersBG1, "Video layer BG1 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("VideoLayersBG1", layerSettings, (1 << 9));
+    bool menuPress;
+    char keyName[] = "VideoLayersBG1";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &layerSettings, (1 << 9));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, layerSettings, (1 << 9));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersBG2, "Video layer BG2 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("VideoLayersBG2", layerSettings, (1 << 10));
+    bool menuPress;
+    char keyName[] = "VideoLayersBG2";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &layerSettings, (1 << 10));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, layerSettings, (1 << 10));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersBG3, "Video layer BG3 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("VideoLayersBG3", layerSettings, (1 << 11));
+    bool menuPress;
+    char keyName[] = "VideoLayersBG3";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &layerSettings, (1 << 11));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, layerSettings, (1 << 11));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersOBJ, "Video layer OBJ (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("VideoLayersOBJ", layerSettings, (1 << 12));
+    bool menuPress;
+    char keyName[] = "VideoLayersOBJ";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &layerSettings, (1 << 12));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, layerSettings, (1 << 12));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersWIN0, "Video layer WIN0 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("VideoLayersWIN0", layerSettings, (1 << 13));
+    bool menuPress;
+    char keyName[] = "VideoLayersWIN0";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &layerSettings, (1 << 13));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, layerSettings, (1 << 13));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersWIN1, "Video layer WIN1 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("VideoLayersWIN1", layerSettings, (1 << 14));
+    bool menuPress;
+    char keyName[] = "VideoLayersWIN1";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &layerSettings, (1 << 14));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, layerSettings, (1 << 14));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersOBJWIN, "Video layer OBJWIN (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("VideoLayersOBJWIN", layerSettings, (1 << 15));
+    bool menuPress;
+    char keyName[] = "VideoLayersOBJWIN";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &layerSettings, (1 << 15));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, layerSettings, (1 << 15));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
-// not in menu
 EVT_HANDLER_MASK(VideoLayersReset, "Show all video layers", CMDEN_GB | CMDEN_GBA)
 {
 #define set_vl(s)                                     \
@@ -1920,42 +1959,72 @@ EVT_HANDLER_MASK(VideoLayersReset, "Show all video layers", CMDEN_GB | CMDEN_GBA
 
 EVT_HANDLER_MASK(SoundChannel1, "Sound Channel 1 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("SoundChannel1", gopts.sound_en, (1 << 0));
+    bool menuPress;
+    char keyName[] = "SoundChannel1";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &gopts.sound_en, (1 << 0));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 0));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
 
 EVT_HANDLER_MASK(SoundChannel2, "Sound Channel 2 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("SoundChannel2", gopts.sound_en, (1 << 1));
+    bool menuPress;
+    char keyName[] = "SoundChannel2";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &gopts.sound_en, (1 << 1));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 1));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
 
 EVT_HANDLER_MASK(SoundChannel3, "Sound Channel 3 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("SoundChannel3", gopts.sound_en, (1 << 2));
+    bool menuPress;
+    char keyName[] = "SoundChannel3";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &gopts.sound_en, (1 << 2));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 2));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
 
 EVT_HANDLER_MASK(SoundChannel4, "Sound Channel 4 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    GetMenuOptionInt("SoundChannel4", gopts.sound_en, (1 << 3));
+    bool menuPress;
+    char keyName[] = "SoundChannel4";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &gopts.sound_en, (1 << 3));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 3));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
 
 EVT_HANDLER_MASK(DirectSoundA, "Direct Sound A (toggle)", CMDEN_GBA)
 {
-    GetMenuOptionInt("DirectSoundA", gopts.sound_en, (1 << 8));
+    bool menuPress;
+    char keyName[] = "DirectSoundA";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &gopts.sound_en, (1 << 8));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 8));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
 
 EVT_HANDLER_MASK(DirectSoundB, "Direct Sound B (toggle)", CMDEN_GBA)
 {
-    GetMenuOptionInt("DirectSoundB", gopts.sound_en, (1 << 9));
+    bool menuPress;
+    char keyName[] = "DirectSoundB";
+    GetMenuOptionBool(keyName, menuPress);
+    toggleBitVar(&menuPress, &gopts.sound_en, (1 << 9));
+    SetMenuOption(keyName, menuPress ? 1 : 0);
+    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 9));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -1672,6 +1672,9 @@ public:
                 if (defkeys_joystick[i].joy)
                     a.push_back(defkeys_joystick[i]);
 
+                if (extrakeys_joystick[i].joy)
+                    a.push_back(extrakeys_joystick[i]);
+
                 tc->SetValue(wxJoyKeyTextCtrl::ToString(a));
             }
         }

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2716,6 +2716,12 @@ void MainFrame::BindAppIcon() {
     SetIcon(icon);
 }
 
+static void setCustomLabelForFilePicker(wxDirPickerCtrl* dp)
+{
+    wxButton *pButt = static_cast<wxButton*>(dp->GetPickerCtrl());
+    if (pButt) pButt->SetLabel(_("Browse"));
+}
+
 // If there is a menubar, store all special menuitems
 #define XRCITEM_I(id) menubar->FindItem(id, NULL)
 #define XRCITEM_D(s) XRCITEM_I(XRCID_D(s))
@@ -3731,12 +3737,19 @@ bool MainFrame::BindControls()
         d = LoadXRCDialog("DirectoriesConfig");
         {
             getdp("GBARoms", gopts.gba_rom_dir);
+            setCustomLabelForFilePicker(dp);
             getdp("GBRoms", gopts.gb_rom_dir);
+            setCustomLabelForFilePicker(dp);
             getdp("GBCRoms", gopts.gbc_rom_dir);
+            setCustomLabelForFilePicker(dp);
             getdp("BatSaves", gopts.battery_dir);
+            setCustomLabelForFilePicker(dp);
             getdp("StateSaves", gopts.state_dir);
+            setCustomLabelForFilePicker(dp);
             getdp("Screenshots", gopts.scrshot_dir);
+            setCustomLabelForFilePicker(dp);
             getdp("Recordings", gopts.recording_dir);
+            setCustomLabelForFilePicker(dp);
             d->Fit();
         }
         wxDialog* joyDialog = LoadXRCropertySheetDialog("JoypadConfig");

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2833,6 +2833,17 @@ bool MainFrame::BindControls()
                 continue;
 	    }
 #endif
+#ifndef MMX
+
+	    if (cmdtab[i].cmd_id == XRCID("MMX"))
+	    {
+		if (mi)
+		    mi->GetMenu()->Remove(mi);
+                cmdtab[i].cmd_id = XRCID("NOOP");
+                cmdtab[i].mi = NULL;
+                continue;
+	    }
+#endif
 
             if (mi) {
                 // wxgtk provides no way to retrieve stock label/accel
@@ -2911,6 +2922,7 @@ bool MainFrame::BindControls()
         // remove this item from the menu completely
         wxMenuItem* gdbmi = XRCITEM("GDBMenu");
         gdbmi->GetMenu()->Remove(gdbmi);
+        gdbmi = NULL;
 #endif
 
         // if a recent menu is present, save its location
@@ -2981,6 +2993,7 @@ bool MainFrame::BindControls()
         MenuOptionIntMask("JoypadAutoholdR", autohold, KEYM_R);
         MenuOptionIntMask("JoypadAutoholdSelect", autohold, KEYM_SELECT);
         MenuOptionIntMask("JoypadAutoholdStart", autohold, KEYM_START);
+        MenuOptionIntMask("MMX", disableMMX, 1);
         MenuOptionBool("EmulatorSpeedupToggle", turbo);
         MenuOptionIntRadioValue("LinkType0Nothing", gopts.gba_link_type, 0);
         MenuOptionIntRadioValue("LinkType1Cable", gopts.gba_link_type, 1);

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -3,8 +3,9 @@
 
 #define NUM_KEYS 21
 extern const wxString joynames[NUM_KEYS];
-extern wxJoyKeyBinding defkeys_keyboard[NUM_KEYS]; // keyboard defaults
-extern wxJoyKeyBinding defkeys_joystick[NUM_KEYS]; // joystick defaults
+extern wxJoyKeyBinding defkeys_keyboard[NUM_KEYS];  // keyboard defaults
+extern wxJoyKeyBinding defkeys_joystick[NUM_KEYS];  // joystick defaults
+extern wxJoyKeyBinding extrakeys_joystick[NUM_KEYS];// extra joystick defaults
 
 extern struct opts_t {
     opts_t();

--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -40,6 +40,9 @@
         <object class="wxMenuItem" name="LoadGameRecent">
           <label>Most _recent</label>
         </object>
+        <object class="wxMenuItem" name="LoadGameSlot">
+          <label>Load current state slot</label>
+        </object>
         <object class="wxMenuItem" name="LoadGameAutoLoad">
           <label>_Auto load most recent</label>
           <checkable>1</checkable>
@@ -94,6 +97,12 @@
         <object class="wxMenuItem" name="SaveGameOldest">
           <label>_Oldest slot</label>
         </object>
+        <object class="wxMenuItem" name="SaveGameSlot">
+          <label>Save current state slot</label>
+        </object>
+        <object class="wxMenuItem" name="IncrGameSlotSave">
+          <label>Increase state slot number and save</label>
+        </object>
         <object class="separator"/>
         <object class="wxMenuItem" name="SaveGame01">
           <label>_1</label>
@@ -130,6 +139,12 @@
           <label>To _File ...</label>
         </object>
         <label>_Save state</label>
+      </object>
+      <object class="wxMenuItem" name="IncrGameSlot">
+        <label>Increase state slot number</label>
+      </object>
+      <object class="wxMenuItem" name="DecrGameSlot">
+        <label>Decrease state slot number</label>
       </object>
       <object class="separator"/>
       <object class="wxMenu">
@@ -320,8 +335,18 @@
             <label>_6x</label>
           </object>
         </object>
+        <object class="wxMenuItem" name="ChangeFilter">
+          <label>Change pixel filter</label>
+        </object>
+        <object class="wxMenuItem" name="ChangeIFB">
+          <label>Change interframe blending</label>
+        </object>
         <object class="wxMenuItem" name="RetainAspect">
           <label>_Retain aspect ratio</label>
+          <checkable>1</checkable>
+        </object>
+        <object class="wxMenuItem" name="MMX">
+          <label>Enable MMX</label>
           <checkable>1</checkable>
         </object>
         <object class="separator"/>
@@ -418,19 +443,19 @@
         <object class="wxMenu">
           <label>_Autohold</label>
           <object class="wxMenuItem" name="JoypadAutoholdUp">
-            <label>_Up</label>
+            <label>Up</label>
             <checkable>1</checkable>
           </object>
           <object class="wxMenuItem" name="JoypadAutoholdDown">
-            <label>_Down</label>
+            <label>Down</label>
             <checkable>1</checkable>
           </object>
           <object class="wxMenuItem" name="JoypadAutoholdLeft">
-            <label>_Left</label>
+            <label>Left</label>
             <checkable>1</checkable>
           </object>
           <object class="wxMenuItem" name="JoypadAutoholdRight">
-            <label>_Right</label>
+            <label>Right</label>
             <checkable>1</checkable>
           </object>
           <object class="wxMenuItem" name="JoypadAutoholdA">
@@ -450,11 +475,11 @@
             <checkable>1</checkable>
           </object>
           <object class="wxMenuItem" name="JoypadAutoholdSelect">
-            <label>_Select</label>
+            <label>Select</label>
             <checkable>1</checkable>
           </object>
           <object class="wxMenuItem" name="JoypadAutoholdStart">
-            <label>_Start</label>
+            <label>Start</label>
             <checkable>1</checkable>
           </object>
         </object>
@@ -584,6 +609,10 @@
       </object>
       <object class="separator"/>
       <object class="wxMenu">
+        <object class="wxMenuItem" name="VideoLayersReset">
+          <label>Show all video layers</label>
+        </object>
+        <object class="separator"/>
         <object class="wxMenuItem" name="VideoLayersBG0">
           <label>BG _0</label>
           <checkable>1</checkable>
@@ -683,7 +712,9 @@
         <label>_Factory Reset...</label>
       </object>
       <object class="separator"/>
-      <object class="wxMenuItem" name="wxID_ABOUT"/>
+      <object class="wxMenuItem" name="wxID_ABOUT">
+        <label>_About...</label>
+      </object>
     </object>
   </object>
 </resource>

--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -3,7 +3,9 @@
   <object class="wxMenuBar" name="MainMenu">
     <object class="wxMenu">
       <label>_File</label>
-      <object class="wxMenuItem" name="wxID_OPEN"/>
+      <object class="wxMenuItem" name="wxID_OPEN">
+        <label>Open...</label>
+      </object>
       <object class="wxMenuItem" name="OpenGB">
         <label>Open _GB...</label>
       </object>
@@ -187,7 +189,9 @@
       </object>
       <object class="separator"/>
       <object class="wxMenuItem" name="wxID_CLOSE"/>
-      <object class="wxMenuItem" name="wxID_EXIT"/>
+      <object class="wxMenuItem" name="wxID_EXIT">
+        <label>_Quit</label>
+      </object>
     </object>
     <object class="wxMenu">
       <label>_Emulation</label>


### PR DESCRIPTION
@rkitover This is a bunch of stuff regarding the translation issues:

9784766 : these were never being translated or appeared on the po files because they were not on any XRC and strings from `cmdevents` are processed by cmake syntax.  So we could not use `_()` for gettext.

0b6bcdc : wxWidgets has some issues when translating internal strings (such as the buttons you would expect to be translated automatically). This is due how there is a difference between user and system locale (easy example on commit message about `pt_BR` and `en_US` on 837a48c).

The two above should fix #483 (I did the `pt_BR` translation entirely, and the user of hungarian localization can use transifex to solve the ones he complains there).

3c2acf9 : new operations regarding save states.

A bit unrelated but discovered while working on this:

a572a6a and 5de33cd : just some work that was missing when using key shortcuts for these options (they would not work before, much like the pause issue we had some time ago).