### PR TITLE
Leftovers.

### DIFF
--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2930,6 +2930,12 @@ bool MainFrame::BindControls()
         gdbmi->GetMenu()->Remove(gdbmi);
         gdbmi = NULL;
 #endif
+#ifdef NO_LINK
+        // remove this item from the menu completely
+        wxMenuItem* linkmi = XRCITEM("LinkMenu");
+        linkmi->GetMenu()->Remove(linkmi);
+        linkmi = NULL;
+#endif
 
         // if a recent menu is present, save its location
         wxMenuItem* recentmi = XRCITEM("RecentMenu");

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -3398,7 +3398,7 @@ bool MainFrame::BindControls()
             // Online Auto Update check frequency
             getrbi("UpdateNever", gopts.onlineupdates, 0);
             getrbi("UpdateDaily", gopts.onlineupdates, 1);
-            getrbi("UpdateWeekly", gopts.onlineupdates, 7);
+            getrbi("UpdateWeekly", gopts.onlineupdates, 2);
 #else
             wxWindowList &children = d->GetChildren();
             std::vector<wxWindow*> forDeletion;

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -803,6 +803,11 @@ void update_opts()
             if (cmdtab[cmd].cmd_id == cmd_id)
                 break;
 
+        // NOOP overwrittes commands removed by the user
+        wxString command = cmdtab[cmd].cmd;
+        if (cmdtab[cmd].cmd_id == XRCID("NOOP"))
+            command = wxT("NOOP");
+
         wxAcceleratorEntry_v::iterator j;
 
         for (j = i + 1; j < gopts.accels.end(); ++j)
@@ -812,8 +817,8 @@ void update_opts()
         wxAcceleratorEntry_v nv(i, j);
         wxString nvs = wxKeyTextCtrl::ToString(nv);
 
-        if (nvs != cfg->Read(cmdtab[cmd].cmd))
-            cfg->Write(cmdtab[cmd].cmd, nvs);
+        if (nvs != cfg->Read(command))
+            cfg->Write(command, nvs);
     }
 
     cfg->SetPath(wxT("/"));

--- a/src/wx/sys.cpp
+++ b/src/wx/sys.cpp
@@ -69,7 +69,7 @@ void systemMessage(int id, const char* fmt, ...)
             exit(1);
     }
 
-    wxLogError(wxT("%s"), wxString(buf, wxConvLibc).c_str());
+    wxLogError(wxT("%s"), wxString(buf, wxConvUTF8).c_str());
 }
 
 static int frames = 0;
@@ -1044,7 +1044,7 @@ void systemScreenMessage(const wxString& msg)
 
 void systemScreenMessage(const char* msg)
 {
-    systemScreenMessage(wxString(msg, wxConvLibc));
+    systemScreenMessage(wxString(msg, wxConvUTF8));
 }
 
 bool systemCanChangeSoundQuality()
@@ -1185,7 +1185,7 @@ bool debugOpenPty()
 
     if ((pty_master = posix_openpt(O_RDWR | O_NOCTTY)) < 0 || grantpt(pty_master) < 0 || unlockpt(pty_master) < 0 || !(slave_name = ptsname(pty_master))) {
         wxLogError(_("Error opening pseudo tty: %s"), wxString(strerror(errno),
-                                                          wxConvLibc)
+                                                          wxConvUTF8)
                                                           .c_str());
 
         if (pty_master >= 0) {
@@ -1196,7 +1196,7 @@ bool debugOpenPty()
         return false;
     }
 
-    pty_slave = wxString(slave_name, wxConvLibc);
+    pty_slave = wxString(slave_name, wxConvUTF8);
     remoteSendFnc = debugWritePty;
     remoteRecvFnc = debugReadPty;
     remoteCleanUpFnc = debugClosePty;
@@ -1308,7 +1308,7 @@ void log(const char* defaultMsg, ...)
     char buf[2048];
     va_start(valist, defaultMsg);
     vsnprintf(buf, 2048, defaultMsg, valist);
-    wxString msg = wxString(buf, wxConvLibc);
+    wxString msg = wxString(buf, wxConvUTF8);
     va_end(valist);
     wxGetApp().log.append(msg);
 

--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -260,7 +260,7 @@
     </object>
     <object class="wxMenu">
       <label>_Options</label>
-      <object class="wxMenu">
+      <object class="wxMenu" name="LinkMenu">
         <label>_Link</label>
         <object class="wxMenuItem" name="LanLink">
           <label>Start _Network Link ...</label>


### PR DESCRIPTION
@rkitover These are some leftovers from a couple of issues.

ebe1be7: Some UTF-8 messages were being displayed wrong.

387a1c8: the `xBRZ` optimization for some platforms. The only one missing from what I wanted is the `Windows x64` because it does not accept inline ASM. It is too much work to make it worth for visual studio.

a6f5848: I am studying `WinSparkle` for a definitive solution. So, although it fixes the crash, I will let the issue open for now.

4998a5d: From
![menulink-old](https://user-images.githubusercontent.com/11354751/64981262-17f0e980-d892-11e9-9190-5f46ebccaf4d.png)

to

![menulink-new](https://user-images.githubusercontent.com/11354751/64981273-1d4e3400-d892-11e9-93c4-59c590dbbe56.png)
