### PR TITLE
SDL misc.

### DIFF
--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -898,6 +898,7 @@ int ReadOpts(int argc, char ** argv)
 			preferences = NULL;
 			OpenPreferences(optarg);
 			fclose(f);
+			LoadConfig();
 		}
 		break;
 		case 'd':

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -1538,8 +1538,8 @@ int main(int argc, char** argv)
     gb_effects_config.surround = false;
     gb_effects_config.enabled = false;
 
-    ReadOpts(argc, argv);
     LoadConfig(); // Parse command line arguments (overrides ini)
+    ReadOpts(argc, argv);
 
     inputSetKeymap(PAD_1, KEY_LEFT, ReadPrefHex("Joy0_Left"));
     inputSetKeymap(PAD_1, KEY_RIGHT, ReadPrefHex("Joy0_Right"));


### PR DESCRIPTION
This is meant to remove one of the branches (`arthur/sdl2`).

Also, there was a weird behaviour when using the command line of the sdl port. There was an overriding between `LoadConfig()` and `ReadOpts()`. We get the `--config` on `ReadOpts`, but only load the default options or `vbam.ini`. The command line options were also getting ignored. Now we should have order priority:

`$ ./vbam -O 2 -f 10 -I 2 -c vbam.ini ~/Downloads/loz/loz.zip` uses the `vbam.ini` options over the others, meanwhile
`$ ./vbam -c vbam.ini -O 2 -f 10 -I 2  ~/Downloads/loz/loz.zip` uses the command line over `vbam.ini`

This was somewhat annoying to dealt with it.