### PR TITLE
cmake: Silence cmake policy warning CMP0058.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ endif()
 
 set(ALL_TARGETS fex visualboyadvance-m vbamcore vbam)
 
+add_custom_target(generate)
+
 #Output all binaries at top level
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR})
 

--- a/cmake/HostCompile.cmake
+++ b/cmake/HostCompile.cmake
@@ -21,9 +21,9 @@ function(host_compile src dst_cmd)
 	set(compile_command ${CMAKE_C_COMPILER} ${src} /link "/out:${dst}")
     endif()
 
-    execute_process(COMMAND ${compile_command} OUTPUT_VARIABLE compile_out ERROR_VARIABLE compile_err RESULT_VARIABLE compile_result)
-
-    if(NOT compile_result EQUAL 0)
-        message(FATAL_ERROR "Failed compiling ${src} for the host: ${compile_err}")
-    endif()
+    add_custom_command(
+        OUTPUT "${dst}"
+        COMMAND ${compile_command}
+        DEPENDS "${src}"
+    )
 endfunction()

--- a/cmake/PathRun.cmake
+++ b/cmake/PathRun.cmake
@@ -1,71 +1,16 @@
 function(make_path_run_wrapper cmd target)
+    get_filename_component(name "${target}" NAME)
     get_filename_component(cmd_resolved "${cmd}" REALPATH)
     get_filename_component(base_name "${cmd_resolved}" NAME)
     get_filename_component(dir_name  "${cmd_resolved}" DIRECTORY)
 
     set(source "${target}.c")
 
-    file(WRITE "${source}"
-"
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
-
-#define BUF_SZ 4096
-
-#ifdef _WIN32
-    #include <process.h>
-    #define PATH_SEP ';'
-    #define setenv(var, val, dummy) _putenv_s(var, val)
-    #define execvp my_execvp
-#else
-    #include <unistd.h>
-    #define PATH_SEP ':'
-#endif
-
-char* dir_name  = \"${dir_name}\";
-char* base_name = \"${base_name}\";
-
-int main(int argc, char** argv) {
-    size_t dir_len  = strlen(dir_name);
-    char* path      = getenv(\"PATH\");
-    size_t path_len = strlen(path);
-    char* new_path  = malloc(dir_len + path_len + 2);
-    char** new_argv = malloc(sizeof(char*) * argc);
-    char** p;
-    char buf[BUF_SZ];
-
-    strcpy(new_path, dir_name);
-    new_path[dir_len] = PATH_SEP;
-    strcpy(new_path + dir_len + 1, path);
-
-    setenv(\"PATH\", new_path, 1);
-
-    free(new_path);
-
-    p = new_argv;
-    *(p++) = base_name;
-    while (*(++argv)) *(p++) = *argv;
-    *p = NULL;
-
-    execvp(base_name, new_argv);
-
-    // this is only reached if exec failed
-    snprintf(buf, BUF_SZ, \"%s: exec failed\", argv[0]);
-    perror(buf);
-
-    return EXIT_FAILURE;
-}
-
-#ifdef _WIN32
-int my_execvp(char* cmd, char** argv) {
-    int ret = _spawnvp(_P_WAIT, cmd, argv);
-    if (ret == -1) return ret;
-    exit(ret);
-}
-#endif
-")
+    configure_file(src/gcc-wrap.c.in "${source}")
 
     include(HostCompile)
     host_compile("${source}" "${target}")
+
+    add_custom_target(generate_${name} DEPENDS "${CMAKE_BINARY_DIR}/${name}")
+    add_dependencies(generate generate_${name})
 endfunction()

--- a/fex/CMakeLists.txt
+++ b/fex/CMakeLists.txt
@@ -42,3 +42,5 @@ ADD_LIBRARY(
     STATIC
     ${SRC_FEX}
 )
+
+add_dependencies(fex generate)

--- a/src/gcc-wrap.c.in
+++ b/src/gcc-wrap.c.in
@@ -1,0 +1,57 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#define BUF_SZ 4096
+
+#ifdef _WIN32
+    #include <process.h>
+    #define PATH_SEP ';'
+    #define setenv(var, val, dummy) _putenv_s(var, val)
+    #define execvp my_execvp
+#else
+    #include <unistd.h>
+    #define PATH_SEP ':'
+#endif
+
+char* dir_name  = "${dir_name}";
+char* base_name = "${base_name}";
+
+int main(int argc, char** argv) {
+    size_t dir_len  = strlen(dir_name);
+    char* path      = getenv("PATH");
+    size_t path_len = strlen(path);
+    char* new_path  = malloc(dir_len + path_len + 2);
+    char** new_argv = malloc(sizeof(char*) * argc);
+    char** p;
+    char buf[BUF_SZ];
+
+    strcpy(new_path, dir_name);
+    new_path[dir_len] = PATH_SEP;
+    strcpy(new_path + dir_len + 1, path);
+
+    setenv("PATH", new_path, 1);
+
+    free(new_path);
+
+    p = new_argv;
+    *(p++) = base_name;
+    while (*(++argv)) *(p++) = *argv;
+    *p = NULL;
+
+    execvp(base_name, new_argv);
+
+    // this is only reached if exec failed
+    snprintf(buf, BUF_SZ, "%s: exec failed", argv[0]);
+    perror(buf);
+
+    return EXIT_FAILURE;
+}
+
+#ifdef _WIN32
+int my_execvp(char* cmd, char** argv) {
+    int ret = _spawnvp(_P_WAIT, cmd, argv);
+    if (ret == -1) return ret;
+    exit(ret);
+}
+#endif


### PR DESCRIPTION
For more details please see `cmake --help-policy CMP0058`. I tested this with both `cmake -GNinja ..` using `samu` and with `gmake`.
```
CMake Warning (dev):
  Policy CMP0058 is not set: Ninja requires custom command byproducts to be
  explicit.  Run "cmake --help-policy CMP0058" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  This project specifies custom command DEPENDS on files in the build tree
  that are not specified as the OUTPUT or BYPRODUCTS of any
  add_custom_command or add_custom_target:

   bin2c

  For compatibility with versions of CMake that did not have the BYPRODUCTS
  option, CMake is generating phony rules for such files to convince 'ninja'
  to build.

  Project authors should add the missing BYPRODUCTS or OUTPUT options to the
  custom commands that produce these files.
This warning is for project developers.  Use -Wno-dev to suppress it.
```