### PR TITLE
Fix key accel overriding menus and dialogs.

### DIFF
--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -821,7 +821,7 @@ void MainFrame::OnSize(wxSizeEvent& event)
 
 int MainFrame::FilterEvent(wxEvent& event)
 {
-    if (event.GetEventType() == wxEVT_KEY_DOWN)
+    if (event.GetEventType() == wxEVT_KEY_DOWN && !menus_opened && !dialog_opened)
     {
         wxKeyEvent& ke = (wxKeyEvent&)event;
         int keyCode = ke.GetKeyCode();


### PR DESCRIPTION
```
All keys were being captured before being processed by any window of the
app to check for accelerators. This meant being impossible to use any
keys for input if they were saved for an accel.

- Fix #516.
```

Sorry about this. This slip through because my custom desktop settings.