### PR TITLE
cmake: Use add_executable when not cross-compiling.

### DIFF
--- a/cmake/HostCompile.cmake
+++ b/cmake/HostCompile.cmake
@@ -1,29 +1,25 @@
 function(host_compile src dst_cmd)
-    unset(link_flags)
+    if(CMAKE_CROSSCOMPILING)
+        unset(link_flags)
 
-    if(CMAKE_HOST_WIN32)
-        if(NOT dst MATCHES "\\.[Ee][Xx][Ee]\$")
+        if(CMAKE_HOST_WIN32)
             set(dst "${dst_cmd}.exe")
+
+            if(CMAKE_COMPILER_IS_GNUCXX)
+                set(link_flags -Wl,--subsystem,console)
+            endif()
+        else()
+            set(dst "${dst_cmd}")
         endif()
 
-        if(CMAKE_COMPILER_IS_GNUCXX)
-            set(link_flags -Wl,--subsystem,console)
-        endif()
-    else()
-        set(dst "${dst_cmd}")
-    endif()
-
-    if(NOT MSVC)
         # assume cc foo.c -o foo # will work on most hosts
-        set(compile_command cc ${src} -o ${dst} ${link_flags})
+        add_custom_command(
+            OUTPUT "${dst}"
+            COMMAND cc ${src} -o ${dst} ${link_flags}
+            DEPENDS "${src}"
+        )
     else()
-        # special case for Visual Studio
-	set(compile_command ${CMAKE_C_COMPILER} ${src} /link "/out:${dst}")
+        get_filename_component(dst "${dst_cmd}" NAME)
+        add_executable("${dst}" "${src}")
     endif()
-
-    add_custom_command(
-        OUTPUT "${dst}"
-        COMMAND ${compile_command}
-        DEPENDS "${src}"
-    )
 endfunction()

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -524,19 +524,14 @@ set(XRC_SOURCES
 # wxrc does not support xrs files in -c output (> 10x compression)
 # we do it using the bin2c.c utility
 
-set(BIN2C ${CMAKE_BINARY_DIR}/bin2c)
-
-if(NOT MSVC)
-	include(HostCompile)
-	host_compile(${CMAKE_CURRENT_SOURCE_DIR}/bin2c.c ${BIN2C})
-	set(BIN2C_DEP ${BIN2C})
+if(CMAKE_CROSSCOMPILING)
+    set(BIN2C ${CMAKE_BINARY_DIR}/bin2c)
 else()
-	# on the appveyor visual studio environment, cl.exe cannot be run from
-	# cmake
-	add_executable(bin2c ${CMAKE_CURRENT_SOURCE_DIR}/bin2c.c)
-	set(BIN2C     bin2c)
-	set(BIN2C_DEP bin2c)
+    set(BIN2C bin2c)
 endif()
+
+include(HostCompile)
+host_compile(${CMAKE_CURRENT_SOURCE_DIR}/bin2c.c ${BIN2C})
 
 if(WXRC)
     separate_arguments(WXRC UNIX_COMMAND ${WXRC})
@@ -613,14 +608,14 @@ add_custom_command(
 add_custom_command(
     OUTPUT builtin-xrc.h
     COMMAND ${BIN2C} wxvbam.xrs builtin-xrc.h builtin_xrs
-    DEPENDS wxvbam.xrs ${BIN2C_DEP}
+    DEPENDS wxvbam.xrs ${BIN2C}
 )
 
 # use a built-in vba-over.ini if no config file present
 add_custom_command(
     OUTPUT builtin-over.h
     COMMAND ${BIN2C} ${CMAKE_CURRENT_SOURCE_DIR}/../vba-over.ini builtin-over.h builtin_over
-    DEPENDS ../vba-over.ini ${BIN2C_DEP}
+    DEPENDS ../vba-over.ini ${BIN2C}
 )
 
 # I don't like duplicating/triplicating code, so I only declare


### PR DESCRIPTION
This is potential clean up, lets see what CI says. It works here on linux at least.