### PR TITLE
travis: Test clang builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,11 @@ matrix:
           dist: xenial
           # xvfb fails on xenial too
         - env: BUILD_ENV=ubuntu-trusty XVFB_RUN=1
+        - env: BUILD_ENV=ubuntu-trusty XVFB_RUN=1 CC=clang CXX=clang++
         - env: BUILD_ENV=mingw-w64
         - env: BUILD_ENV=mingw-w32
         - env: BUILD_ENV=libretro
+        - env: BUILD_ENV=libretro CC=clang CXX=clang++
         - env: BUILD_ENV=mac
           os: osx
           osx_image: xcode10.2


### PR DESCRIPTION
This tests clang builds on trusty for both standalone and libretro.

The caveat is that that this shows many warnings with standalone which could be something wrong with travis's cmake or clang?
```
[  0%] Building C object src/wx/CMakeFiles/bin2c.dir/bin2c.c.o
clang-5.0: warning: argument unused during compilation: '-I /home/travis/build/visualboyadvance-m/visualboyadvance-m/build' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /home/travis/build/visualboyadvance-m/visualboyadvance-m/fex' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/SDL2' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/AL' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-isystem /usr/lib/x86_64-linux-gnu/wx/include/gtk2-unicode-3.0' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-isystem /usr/include/wx-3.0' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/gtk-2.0' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/lib/x86_64-linux-gnu/gtk-2.0/include' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/atk-1.0' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/cairo' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/gdk-pixbuf-2.0' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/pango-1.0' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/gio-unix-2.0' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/freetype2' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/glib-2.0' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/lib/x86_64-linux-gnu/glib-2.0/include' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/pixman-1' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/libpng12' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /usr/include/harfbuzz' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /home/travis/build/visualboyadvance-m/visualboyadvance-m/src/wx/widgets' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /home/travis/build/visualboyadvance-m/visualboyadvance-m/build/src/wx' [-Wunused-command-line-argument]
clang-5.0: warning: argument unused during compilation: '-I /home/travis/build/visualboyadvance-m/visualboyadvance-m/src/wx' [-Wunused-command-line-argument]
```