### PR TITLE
travis: Test make install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ script:
     - cd -- "$DIR"
     - if [ "$BUILD_ENV" != libretro ]; then $CMAKE $CMAKE_ARGS ..; fi
     - make
+    - if [ "$BUILD_ENV" != libretro ]; then make install DESTDIR=/tmp/VBAM; fi
     - |
         if [ -n "$XVFB_RUN" ]; then
             xvfb-run ./visualboyadvance-m --help

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -983,7 +983,6 @@ endif()
 
 if(ENABLE_WX)
     add_subdirectory(src/wx)
-    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/visualboyadvance-m${CMAKE_EXECUTABLE_SUFFIX} DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
 endif()
 
 if(ENABLE_WX)

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -838,3 +838,9 @@ if(APPLE)
 endif()
 
 set(WX_EXE_NAME visualboyadvance-m-wx${CMAKE_EXECUTABLE_SUFFIX})
+
+install(
+    TARGETS visualboyadvance-m
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    BUNDLE  DESTINATION ${CMAKE_INSTALL_BINDIR}
+)


### PR DESCRIPTION
This tests `make install` with travis everywhere except libretro to better catch issues.

The second commit uses a modern install target for `visualboyadvance-m` to fix `make install` on osx. I am not sure useful this is on osx, but it seems like an easy fix regardless. Considering what to do with `make install` better on osx can be done later.