### PR TITLE
cmake: Don't install visualboyadvance-m twice on WIN32.

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -751,7 +751,6 @@ add_executable(
     ${CM_STUFF}
 )
 
-
 target_link_libraries(
     visualboyadvance-m
     ${VBAMCORE_LIBS}
@@ -805,10 +804,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif()
 endif()
 
-if(WIN32)
-    install(PROGRAMS ${PROJECT_BINARY_DIR}/visualboyadvance-m${CMAKE_EXECUTABLE_SUFFIX} DESTINATION ${CMAKE_BINARY_DIR})
-endif()
-
 if(NOT WIN32 AND NOT APPLE)
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/wxvbam.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)
 endif()
@@ -836,8 +831,6 @@ if(APPLE)
         )
     endif()
 endif()
-
-set(WX_EXE_NAME visualboyadvance-m-wx${CMAKE_EXECUTABLE_SUFFIX})
 
 install(
     TARGETS visualboyadvance-m


### PR DESCRIPTION
On the `mingw` travis builds it will install `visualboyadvance-m` twice.
```
-- Installing: /tmp/VBAM/home/travis/build/visualboyadvance-m/visualboyadvance-m/build/visualboyadvance-m.exe
-- Installing: /tmp/VBAM/usr/lib/mxe/usr/x86_64-w64-mingw32.static/bin/visualboyadvance-m.exe
```
This will make it so that only the second instance is installed.
```
-- Installing: /tmp/VBAM/usr/lib/mxe/usr/x86_64-w64-mingw32.static/bin/visualboyadvance-m.exe
```
I am not sure there is a good reason why its being installed twice or not and am opening this PR for review.

I also removed the unused `WX_EXE_NAME` variable.