### PR TITLE
cmake: Silence _FORTIFY_SOURCE warnings with debug builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -505,7 +505,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
     endif()
 
     # common flags
-    set(MY_C_FLAGS -pipe -Wformat -Wformat-security -D_FORTIFY_SOURCE=2 -feliminate-unused-debug-types)
+    set(MY_C_FLAGS -pipe -Wformat -Wformat-security -feliminate-unused-debug-types)
+
+    if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
+        list(APPEND MY_C_FLAGS -D_FORTIFY_SOURCE=2)
+    endif()
 
     if(NOT (WIN32 OR X86_32)) # inline asm is not allowed with -fPIC
         set(MY_C_FLAGS ${MY_C_FLAGS} -fPIC)


### PR DESCRIPTION
Silences many noisy warnings with debug builds.
```
[79/196] Building CXX object fex/CMakeFiles/fex.dir/fex/Zlib_Inflater.cpp.o
In file included from ../fex/fex/Zlib_Inflater.cpp:3:
In file included from ../fex/fex/Zlib_Inflater.h:7:
In file included from ../fex/fex/Data_Reader.h:7:
In file included from ../fex/fex/blargg_common.h:8:
In file included from /usr/include/assert.h:35:
/usr/include/features.h:382:4: warning: _FORTIFY_SOURCE requires compiling with optimization (-O) [-W#warnings]
   ^
1 warning generated.
```