### PR TITLE
wx: Silence -Woverloaded-virtual warnings with debug builds.

### DIFF
--- a/src/wx/viewers.cpp
+++ b/src/wx/viewers.cpp
@@ -679,7 +679,7 @@ public:
     }
     void Goto(uint32_t addr)
     {
-        mv->Show(addr, true);
+        mv->ShowAddr(addr, true);
     }
     void RefreshCmd(wxCommandEvent& ev)
     {

--- a/src/wx/viewsupt.cpp
+++ b/src/wx/viewsupt.cpp
@@ -725,7 +725,7 @@ void MemView::Resize(wxSizeEvent& ev)
         Refill();
 }
 
-void MemView::Show(uint32_t addr, bool force_update)
+void MemView::ShowAddr(uint32_t addr, bool force_update)
 {
     if (addr < topaddr || addr >= topaddr + (nlines - 1) * 16) {
         // align to nearest 16-byte block

--- a/src/wx/viewsupt.h
+++ b/src/wx/viewsupt.h
@@ -194,7 +194,7 @@ private:
 
 public:
     // make addr visible
-    void Show(uint32_t addr, bool force_update = false);
+    void ShowAddr(uint32_t addr, bool force_update = false);
 
     // current selection, or topaddr if none
     uint32_t GetAddr();
@@ -407,7 +407,7 @@ protected:
 // a display-only checkbox which does not look like it's disabled
 class DispCheckBox : public wxCheckBox {
 public:
-    bool AcceptsFocus()
+    bool AcceptsFocus() const
     {
         return false;
     }

--- a/src/wx/widgets/wx/sdljoy.h
+++ b/src/wx/widgets/wx/sdljoy.h
@@ -111,8 +111,6 @@ public:
     {
         return prev_val;
     }
-    // required for PostEvent, apparently
-    wxEvent* Clone();
 
 protected:
     unsigned short joy;

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -283,7 +283,7 @@ public:
     void set_global_accels();
 
     // 2.8 has no HasFocus(), and FindFocus() doesn't work right
-    bool HasFocus()
+    bool HasFocus() const
     {
         return focused;
     }


### PR DESCRIPTION
The `AcceptsFocus`, `Clone` and `HasFocus` functions seem unused and can be removed. While `Show` is renamed to `ShowAddr` to not conflict with unrelated functions.

@rkitover Please take a look at this closer to make sure I am not doing anything stupid. I'm not that great with C++.
```
[187/196] Building CXX object src/wx/CMakeFiles/visualboyadvance-m.dir/viewsupt.cpp.o
In file included from ../src/wx/viewsupt.cpp:1:
../src/wx/viewsupt.h:197:10: warning: 'Viewers::MemView::Show' hides overloaded virtual function [-Woverloaded-virtual]
    void Show(uint32_t addr, bool force_update = false);
         ^
/usr/include/wx-3.0/wx/gtk/window.h:64:18: note: hidden overloaded virtual function 'wxWindow::Show' declared here: different number of parameters (1 vs 2)
    virtual bool Show( bool show = true );
                 ^
In file included from ../src/wx/viewsupt.cpp:1:
../src/wx/viewsupt.h:410:10: warning: 'Viewers::DispCheckBox::AcceptsFocus' hides overloaded virtual function [-Woverloaded-virtual]
    bool AcceptsFocus()
         ^
/usr/include/wx-3.0/wx/window.h:724:18: note: hidden overloaded virtual function 'wxWindowBase::AcceptsFocus' declared here: different qualifiers ('const' vs unqualified)
    virtual bool AcceptsFocus() const { return true; }
                 ^
In file included from ../src/wx/viewsupt.cpp:3:
In file included from ../src/wx/wxvbam.h:14:
In file included from ../src/wx/widgets/wx/joyedit.h:9:
../src/wx/widgets/wx/sdljoy.h:115:14: warning: 'wxSDLJoyEvent::Clone' hides overloaded virtual function [-Woverloaded-virtual]
    wxEvent* Clone();
             ^
/usr/include/wx-3.0/wx/event.h:1569:22: note: hidden overloaded virtual function 'wxCommandEvent::Clone' declared here: different qualifiers ('const' vs unqualified)
    virtual wxEvent *Clone() const { return new wxCommandEvent(*this); }
                     ^
In file included from ../src/wx/viewsupt.cpp:3:
../src/wx/wxvbam.h:286:10: warning: 'MainFrame::HasFocus' hides overloaded virtual function [-Woverloaded-virtual]
    bool HasFocus()
         ^
/usr/include/wx-3.0/wx/window.h:715:18: note: hidden overloaded virtual function 'wxWindowBase::HasFocus' declared here: different qualifiers ('const' vs unqualified)
    virtual bool HasFocus() const;
                 ^
4 warnings generated.
```