### PR TITLE
wx: Fix conditional jump on uninitialized value with valgrind.

### DIFF
--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -120,7 +120,7 @@ public:
     // the main configuration
     wxFileConfig* cfg;
     // vba-over.ini
-    wxFileConfig* overrides;
+    wxFileConfig* overrides = nullptr;
 
     wxFileName rom_database;
     wxFileName rom_database_scene;


### PR DESCRIPTION
This tries to fix an unconditional jump or move on an uninitialized value as show by valgrind when running `--help`.

My understanding is that `overrides` is only set when `console_mode` is false and should only be deleted when `console_mode` is false where it was being deleted regardless before. At least this makes valgrind happy and it seems to work correctly here.

Please review this to make sure I understood this correctly and have the right solution.
```
$ valgrind ./visualboyadvance-m --help
==15788== Memcheck, a memory error detector
==15788== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==15788== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==15788== Command: ./visualboyadvance-m --help
==15788== 
VisualBoyAdvance-M

Usage: visualboyadvance-m [-h] [--verbose] [--save-xrc <str>] [--save-over <str>] [--print-cfg-path] [-f] [-s] [-o] [ROM file] [<config>=<value>...]
  -h, --help               	show this help message
  --verbose                	generate verbose log messages
  --save-xrc=<str>         	Save built-in XRC file and exit
  --save-over=<str>        	Save built-in vba-over.ini and exit
  --print-cfg-path         	Print configuration path and exit
  -f, --fullscreen         	Start in full-screen mode
  -s, --delete-shared-state	Delete shared link state first, if it exists
  -o, --list-options       	List all settable options and exit
==15788== Conditional jump or move depends on uninitialised value(s)
==15788==    at 0x5143A2: wxvbamApp::~wxvbamApp() (wxvbam.cpp:682)
==15788==    by 0x5144BB: wxvbamApp::~wxvbamApp() (wxvbam.cpp:676)
==15788==    by 0x739CD22: wxEntryCleanup() (in /usr/lib64/libwx_baseu-3.0.so.0.4.0)
==15788==    by 0x739D02B: wxUninitialize() (in /usr/lib64/libwx_baseu-3.0.so.0.4.0)
==15788==    by 0x739CE39: wxEntry(int&, wchar_t**) (in /usr/lib64/libwx_baseu-3.0.so.0.4.0)
==15788==    by 0x50BD42: main (wxvbam.cpp:32)
==15788== 
==15788== 
==15788== HEAP SUMMARY:
==15788==     in use at exit: 330,639 bytes in 2,287 blocks
==15788==   total heap usage: 113,772 allocs, 111,485 frees, 11,993,126 bytes allocated
==15788== 
==15788== LEAK SUMMARY:
==15788==    definitely lost: 0 bytes in 0 blocks
==15788==    indirectly lost: 0 bytes in 0 blocks
==15788==      possibly lost: 1,632 bytes in 24 blocks
==15788==    still reachable: 316,583 bytes in 2,142 blocks
==15788==                       of which reachable via heuristic:
==15788==                         length64           : 208 bytes in 4 blocks
==15788==                         newarray           : 1,584 bytes in 19 blocks
==15788==         suppressed: 0 bytes in 0 blocks
==15788== Rerun with --leak-check=full to see details of leaked memory
==15788== 
==15788== Use --track-origins=yes to see where uninitialised values come from
==15788== For lists of detected and suppressed errors, rerun with: -s
==15788== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```