### PR TITLE
travis: Make xenial the main distribution.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 cache: ccache
-dist: trusty
+dist: xenial
 language: cpp
 services: xvfb
 sudo: required
@@ -10,10 +10,10 @@ matrix:
     include:
         - env: BUILD_ENV=ubuntu-bionic XVFB_RUN=1
           dist: bionic
-        - env: BUILD_ENV=ubuntu-xenial XVFB_RUN=1
-          dist: xenial
         - env: BUILD_ENV=ubuntu-trusty XVFB_RUN=1
-        - env: BUILD_ENV=ubuntu-trusty XVFB_RUN=1 CC=clang CXX=clang++
+          dist: trusty
+        - env: BUILD_ENV=ubuntu-xenial XVFB_RUN=1
+        - env: BUILD_ENV=ubuntu-xenial XVFB_RUN=1 CC=clang CXX=clang++
         - env: BUILD_ENV=mingw-w64
         - env: BUILD_ENV=mingw-w32
         - env: BUILD_ENV=libretro


### PR DESCRIPTION
The end of standard support for trusty ended in April 2019 and the end of life is April 2022. For xenial the end of standard support is April 2021 and the end of life is April 2024.

Most users should have xenial or newer at this point.

Source: https://wiki.ubuntu.com/Releases

It seems the crashes with `--help` were fixed in commit https://github.com/visualboyadvance-m/visualboyadvance-m/commit/65c908141c46156cfd573a4e57cf9ac70c55c2d3 and I forced the rebuilds in travis for all of the ubuntu builds 5 times each. We should let travis pass one more time to be sure.

For trusty I would suggest leaving one build until one of the following happens.

* It becomes too hard to maintain.
* The EOL is reached in April 2022.
* Travis removes their support.