### PR TITLE
travis: Test --help on osx.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,11 +59,10 @@ script:
     - make
     - if [ "$BUILD_ENV" != libretro ]; then make install DESTDIR=/tmp/VBAM; fi
     - |
-        if [ -n "$XVFB_RUN" ]; then
+        if [ "$BUILD_ENV" = mac ]; then
+            ./$PRGNAM.app/Contents/MacOS/$PRGNAM --help
+        elif [ -n "$XVFB_RUN" ]; then
             xvfb-run -a ./$PRGNAM --help
-        # TODO: --help crashes on OSX sometimes.
-        #elif [ "$BUILD_ENV" = mac ]; then
-        #    ./$PRGNAM.app/Contents/MacOS/$PRGNAM --help
         fi
 
 env:


### PR DESCRIPTION
It seems the crashes with `--help` were fixed in commit https://github.com/visualboyadvance-m/visualboyadvance-m/commit/65c908141c46156cfd573a4e57cf9ac70c55c2d3 and I forced the rebuilds in travis for the mac build 5 times. We should let it pass travis pass one more time to be sure.