### PR TITLE
cmake: Add generate as a vbamcore dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -941,6 +941,7 @@ add_library(
     ${SRC_DEBUGGER}
     ${HDR_DEBUGGER}
 )
+add_dependencies(vbamcore generate)
 set_property(TARGET vbamcore PROPERTY CXX_STANDARD 11)
 set_property(TARGET vbamcore PROPERTY CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
Fixes https://github.com/visualboyadvance-m/visualboyadvance-m/issues/542.