### PR TITLE
Remove top border black line when using filters.

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1567,7 +1567,7 @@ public:
                 return 0;
             }
 
-            //src += instride;
+            src += instride;
 
             // interframe blending filter
             // definitely not thread safe by default


### PR DESCRIPTION
```
We don't want to display the top border when using filters, since it
is a single line with black pixels.

- Fix #561.
```

This was tested with the game `Marie, Elie & Anis no Atelier - Soyokaze kara no Dengon`.