### PR TITLE
Fix integer overflow in cheatsImportGSACodeFile.

### DIFF
--- a/src/gba/Cheats.cpp
+++ b/src/gba/Cheats.cpp
@@ -2047,7 +2047,7 @@ bool cheatsImportGSACodeFile(const char* name, int game, bool v3)
         return false;
     }
 
-    int len = 0;
+    uint32_t len = 0;
     bool found = false;
     int g = 0;
     while (games > 0) {


### PR DESCRIPTION
## Description
Although a length check is being performed on the imported GSA Codes file [here](https://github.com/visualboyadvance-m/visualboyadvance-m/blob/master/src/gba/Cheats.cpp#L2082), `len` is both a signed `int` and attacker controlled.

With a specially crafted GSA Codes file, an attacker could specify a value for `len` that overflows the `int` type, rolling over into a negative number. By doing so, the attacker can bypass the conditional mentioned above.

![highlighted bytes used for len](https://user-images.githubusercontent.com/7784322/72638654-e0727680-3931-11ea-8d37-6b91867559cb.png)
(highlighted bytes used for len)

![conditional](https://user-images.githubusercontent.com/7784322/72640838-b8394680-3936-11ea-8e73-24be930653bf.png)
(the JLE signed conditional instruction is being used, our len of 0xFFFFFFFF will be interpreted as -1)

The `fread` [length parameter](http://www.cplusplus.com/reference/cstdio/fread/) is of type `size_t` which is an `unsigned int`, this will result in `len` being interpreted as a large `unsigned int`, allowing for a stack based buffed overflow in the [desc](https://github.com/visualboyadvance-m/visualboyadvance-m/blob/master/src/gba/Cheats.cpp#L2084) char array.

Making `len` an unsigned integer will prevent the overflow, ensuring that the bounds check works as intended.

## Reproduction Steps
1- Apply the following diff and make a fresh build.
```
diff --git a/src/wx/wxvbam.cpp b/src/wx/wxvbam.cpp
index 0677ad44..9cf2a57a 100644
--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -29,6 +29,8 @@
 #include "../common/ConfigManager.h"
 #include "builtin-over.h"
 
+#include "../gba/Cheats.h"
+
 IMPLEMENT_APP(wxvbamApp)
 IMPLEMENT_DYNAMIC_CLASS(MainFrame, wxFrame)
 
@@ -218,6 +220,15 @@ static void init_check_for_updates()
 #include <windows.h>
 #endif
 
+void harness(wxString file)
+{
+    cheatsImportGSACodeFile(file.mb_str(), 0, true);
+    //cheatsImportGSACodeFile(file.mb_str(), 0, false);
+    //cheatsImportGSACodeFile(file.mb_str(), 1, true);
+    //cheatsImportGSACodeFile(file.mb_str(), 1, false);
+    exit(0);
+}
+
 bool wxvbamApp::OnInit()
 {
     // set up logging
@@ -523,6 +534,9 @@ void wxvbamApp::OnInitCmdLine(wxCmdLineParser& cl)
     // to the idea that command-line syntax should not change based on
     // locale
     static wxCmdLineEntryDesc opttab[] = {
+        { wxCMD_LINE_OPTION, NULL, t("test-case"), 
+            N_("Give fuzzing harness a handle to test case"),
+        wxCMD_LINE_VAL_STRING, 0 },
         { wxCMD_LINE_OPTION, NULL, t("save-xrc"),
             N_("Save built-in XRC file and exit"),
            wxCMD_LINE_VAL_STRING, 0 },
@@ -571,6 +585,10 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
         return false;
 
     wxString s;
+    
+    if (cl.Found(wxT("test-case"), &s)) {
+        harness(s);
+    }
 
     if (cl.Found(wxT("save-xrc"), &s)) {
         // This was most likely done on a command line, so use

```

2- Pass the attached crafted XPC file to the build like so:
```
./visualboyadvance-m --test-case payload.xpc
```

[payload.zip](https://github.com/visualboyadvance-m/visualboyadvance-m/files/4078509/payload.zip)