### PR TITLE
Some leftovers.

### DIFF
--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -1197,7 +1197,7 @@ EVT_HANDLER_MASK(RecordSoundStartRecording, "Start sound recording...", CMDEN_NS
             ext.Replace(wxT(","), wxT(";*."));
             ext.insert(0, wxT("*."));
 
-            if (sound_extno < 0 && ext.find(wxT("*.mp3")) != wxString::npos)
+            if (sound_extno < 0 && ext.find(wxT("*.wav")) != wxString::npos)
                 sound_extno = extno;
 
             sound_exts.append(ext);


### PR DESCRIPTION
@rkitover I changed the default audio recording to `.wav`. Is there a reason why when you select the file type on the wxWidgets window, it does not change the filename to its current extension?

If I select `mp3`, I want to not only show the `*.mp3` files on the current dir, but also toggle the `game.wav` to `game.mp3` on the filename.

I want to include a possible fix for this here, so if there is none, I will merge this myself.