### PR TITLE
Fix: a issue with loading e-Reader dot code

### DIFF
--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-11-22 23:25+0000\n"
+"POT-Creation-Date: 2020-02-14 18:00+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -142,7 +142,7 @@ msgstr ""
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:734
+#: ../src/wx/cmdevents.cpp:676 ../src/wx/guiinit.cpp:736
 msgid "GameGenie"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1839
+#: ../src/wx/cmdevents.cpp:746 ../src/wx/guiinit.cpp:1841
 #: ../src/wx/xrc/DisplayConfig.xrc:85 ../src/wx/xrc/DisplayConfig.xrc:135
 #: ../src/wx/xrc/DisplayConfig.xrc:221
 #: ../src/wx/xrc/GameBoyAdvanceConfig.xrc:32
@@ -177,246 +177,246 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:845 ../src/wx/cmdevents.cpp:861
+#: ../src/wx/cmdevents.cpp:848 ../src/wx/cmdevents.cpp:870
 msgid "Select Dot Code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:847 ../src/wx/cmdevents.cpp:863
+#: ../src/wx/cmdevents.cpp:850 ../src/wx/cmdevents.cpp:872
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:882 ../src/wx/cmdevents.cpp:1077
+#: ../src/wx/cmdevents.cpp:891 ../src/wx/cmdevents.cpp:1086
 msgid "Select battery file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:883 ../src/wx/cmdevents.cpp:1078
+#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:1087
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:891
+#: ../src/wx/cmdevents.cpp:900
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:892 ../src/wx/cmdevents.cpp:920
-#: ../src/wx/cmdevents.cpp:1040
+#: ../src/wx/cmdevents.cpp:901 ../src/wx/cmdevents.cpp:929
+#: ../src/wx/cmdevents.cpp:1049
 msgid "Confirm import"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:898 ../src/wx/panel.cpp:350
+#: ../src/wx/cmdevents.cpp:907 ../src/wx/panel.cpp:356
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:900
+#: ../src/wx/cmdevents.cpp:909
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:909
+#: ../src/wx/cmdevents.cpp:918
 msgid "Select code file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:910
+#: ../src/wx/cmdevents.cpp:919
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:910
+#: ../src/wx/cmdevents.cpp:919
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:919
+#: ../src/wx/cmdevents.cpp:928
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:936
+#: ../src/wx/cmdevents.cpp:945
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:946
+#: ../src/wx/cmdevents.cpp:955
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1016
+#: ../src/wx/cmdevents.cpp:1025
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1018
+#: ../src/wx/cmdevents.cpp:1027
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1029 ../src/wx/cmdevents.cpp:1105
+#: ../src/wx/cmdevents.cpp:1038 ../src/wx/cmdevents.cpp:1114
 msgid "Select snapshot file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1030
+#: ../src/wx/cmdevents.cpp:1039
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots (*.gsv)|"
 "*.gsv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1030
+#: ../src/wx/cmdevents.cpp:1039
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1039
+#: ../src/wx/cmdevents.cpp:1048
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1064
+#: ../src/wx/cmdevents.cpp:1073
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1066
+#: ../src/wx/cmdevents.cpp:1075
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1089
+#: ../src/wx/cmdevents.cpp:1098
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1091 ../src/wx/panel.cpp:656
+#: ../src/wx/cmdevents.cpp:1100 ../src/wx/panel.cpp:662
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1099
+#: ../src/wx/cmdevents.cpp:1108
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1106
+#: ../src/wx/cmdevents.cpp:1115
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1120
+#: ../src/wx/cmdevents.cpp:1129
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1132
+#: ../src/wx/cmdevents.cpp:1141
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1134
+#: ../src/wx/cmdevents.cpp:1143
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1149 ../src/wx/cmdevents.cpp:1227
-#: ../src/wx/cmdevents.cpp:1297 ../src/wx/cmdevents.cpp:1324
+#: ../src/wx/cmdevents.cpp:1158 ../src/wx/cmdevents.cpp:1236
+#: ../src/wx/cmdevents.cpp:1306 ../src/wx/cmdevents.cpp:1333
 #: ../src/wx/viewers.cpp:562 ../src/wx/viewers.cpp:772
 #: ../src/wx/viewsupt.cpp:1168
 msgid "Select output file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1150 ../src/wx/viewsupt.cpp:1169
+#: ../src/wx/cmdevents.cpp:1159 ../src/wx/viewsupt.cpp:1169
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1174 ../src/wx/sys.cpp:442
+#: ../src/wx/cmdevents.cpp:1183 ../src/wx/sys.cpp:442
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1195 ../src/wx/cmdevents.cpp:1265
+#: ../src/wx/cmdevents.cpp:1204 ../src/wx/cmdevents.cpp:1274
 msgid " files ("
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1325 ../src/wx/cmdevents.cpp:1346
+#: ../src/wx/cmdevents.cpp:1334 ../src/wx/cmdevents.cpp:1355
 msgid "VBA Movie files|*.vmv"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1345
+#: ../src/wx/cmdevents.cpp:1354
 msgid "Select file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1630 ../src/wx/cmdevents.cpp:1723
+#: ../src/wx/cmdevents.cpp:1639 ../src/wx/cmdevents.cpp:1732
 msgid "Select state file"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1631 ../src/wx/cmdevents.cpp:1724
+#: ../src/wx/cmdevents.cpp:1640 ../src/wx/cmdevents.cpp:1733
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:1754 ../src/wx/cmdevents.cpp:1764
-#: ../src/wx/cmdevents.cpp:1775
+#: ../src/wx/cmdevents.cpp:1763 ../src/wx/cmdevents.cpp:1773
+#: ../src/wx/cmdevents.cpp:1784
 #, c-format
 msgid "Current state slot #%d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2053
 msgid "Sound enabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2044
+#: ../src/wx/cmdevents.cpp:2053
 msgid "Sound disabled"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2057 ../src/wx/cmdevents.cpp:2071
+#: ../src/wx/cmdevents.cpp:2066 ../src/wx/cmdevents.cpp:2080
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2146
+#: ../src/wx/cmdevents.cpp:2155
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2148
+#: ../src/wx/cmdevents.cpp:2157
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2149
+#: ../src/wx/cmdevents.cpp:2158
 msgid "GDB Connection"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2202
+#: ../src/wx/cmdevents.cpp:2211
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2209
+#: ../src/wx/cmdevents.cpp:2218
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2212
+#: ../src/wx/cmdevents.cpp:2221
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2609
+#: ../src/wx/cmdevents.cpp:2618
 #, c-format
 msgid "Using pixel filter #%d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2624
+#: ../src/wx/cmdevents.cpp:2633
 #, c-format
 msgid "Using interframe blending #%d"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2752
+#: ../src/wx/cmdevents.cpp:2761
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2753
+#: ../src/wx/cmdevents.cpp:2762
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:2754
+#: ../src/wx/cmdevents.cpp:2763
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -432,11 +432,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:3018
+#: ../src/wx/cmdevents.cpp:3027
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: ../src/wx/cmdevents.cpp:3024
+#: ../src/wx/cmdevents.cpp:3033
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -510,252 +510,252 @@ msgstr ""
 msgid "Start!"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:82 ../src/wx/xrc/NetLink.xrc:86
+#: ../src/wx/guiinit.cpp:82 ../src/wx/xrc/NetLink.xrc:99
 msgid "Connect"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:96
+#: ../src/wx/guiinit.cpp:98
 msgid "You must enter a valid host name"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:97
+#: ../src/wx/guiinit.cpp:99
 msgid "Host name invalid"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:115
+#: ../src/wx/guiinit.cpp:117
 msgid "Waiting for clients..."
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:116
+#: ../src/wx/guiinit.cpp:118
 #, c-format
 msgid "Server IP address is: %s\n"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:118
+#: ../src/wx/guiinit.cpp:120
 msgid "Waiting for connection..."
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:119
+#: ../src/wx/guiinit.cpp:121
 #, c-format
 msgid "Connecting to %s\n"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:152
+#: ../src/wx/guiinit.cpp:154
 msgid ""
 "Error occurred.\n"
 "Please try again."
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:219 ../src/wx/guiinit.cpp:272
+#: ../src/wx/guiinit.cpp:221 ../src/wx/guiinit.cpp:274
 msgid "Select cheat file"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:220
+#: ../src/wx/guiinit.cpp:222
 msgid "VBA cheat lists (*.clt)|*.clt|CHT cheat lists (*.cht)|*.cht"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:239 ../src/wx/panel.cpp:407
+#: ../src/wx/guiinit.cpp:241 ../src/wx/panel.cpp:413
 msgid "Loaded cheats"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:273
+#: ../src/wx/guiinit.cpp:275
 msgid "VBA cheat lists (*.clt)|*.clt"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:291
+#: ../src/wx/guiinit.cpp:293
 msgid "Saved cheats"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:322 ../src/wx/guiinit.cpp:341
+#: ../src/wx/guiinit.cpp:324 ../src/wx/guiinit.cpp:343
 msgid "Restore old values?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:323 ../src/wx/guiinit.cpp:342
+#: ../src/wx/guiinit.cpp:325 ../src/wx/guiinit.cpp:344
 msgid "Removing cheats"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:733 ../src/wx/xrc/JoyPanel.xrc:364
+#: ../src/wx/guiinit.cpp:735 ../src/wx/xrc/JoyPanel.xrc:364
 msgid "GameShark"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:736
+#: ../src/wx/guiinit.cpp:738
 msgid "Generic Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:737
+#: ../src/wx/guiinit.cpp:739
 msgid "GameShark Advance"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:738
+#: ../src/wx/guiinit.cpp:740
 msgid "CodeBreaker Advance"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:739
+#: ../src/wx/guiinit.cpp:741
 msgid "Flashcart CHT"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:807 ../src/wx/guiinit.cpp:1062
+#: ../src/wx/guiinit.cpp:809 ../src/wx/guiinit.cpp:1064
 msgid "Number cannot be empty"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:845
+#: ../src/wx/guiinit.cpp:847
 #, c-format
 msgid "Search produced %d results.  Please refine better"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:857
+#: ../src/wx/guiinit.cpp:859
 msgid "Search produced no results"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1020
+#: ../src/wx/guiinit.cpp:1022
 msgid "8-bit "
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1024
+#: ../src/wx/guiinit.cpp:1026
 msgid "16-bit "
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1028
+#: ../src/wx/guiinit.cpp:1030
 msgid "32-bit "
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1034
+#: ../src/wx/guiinit.cpp:1036
 msgid "signed decimal"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1038
+#: ../src/wx/guiinit.cpp:1040
 msgid "unsigned decimal"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1042
+#: ../src/wx/guiinit.cpp:1044
 msgid "unsigned hexadecimal"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1520
+#: ../src/wx/guiinit.cpp:1522
 #, c-format
 msgid "%d frames = %.2f ms"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1532
+#: ../src/wx/guiinit.cpp:1534
 msgid "Default device"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1719
+#: ../src/wx/guiinit.cpp:1721
 msgid "Desktop mode"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1726
+#: ../src/wx/guiinit.cpp:1728
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1880
+#: ../src/wx/guiinit.cpp:1882
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1900 ../src/wx/xrc/DisplayConfig.xrc:107
+#: ../src/wx/guiinit.cpp:1902 ../src/wx/xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1928
+#: ../src/wx/guiinit.cpp:1930
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:1929
+#: ../src/wx/guiinit.cpp:1931
 msgid "Plugin selection error"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2128
+#: ../src/wx/guiinit.cpp:2130
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2128
+#: ../src/wx/guiinit.cpp:2130
 msgid "Confirm"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2722
+#: ../src/wx/guiinit.cpp:2724
 msgid "Main icon not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2732
+#: ../src/wx/guiinit.cpp:2734
 msgid "Browse"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2746
+#: ../src/wx/guiinit.cpp:2748
 msgid "Main display panel not found"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2895
+#: ../src/wx/guiinit.cpp:2897
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:2909
+#: ../src/wx/guiinit.cpp:2911
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3039
+#: ../src/wx/guiinit.cpp:3041
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3234
+#: ../src/wx/guiinit.cpp:3242
 msgid "Code"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3243
+#: ../src/wx/guiinit.cpp:3251
 msgid "Description"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3317 ../src/wx/xrc/CheatAdd.xrc:31
+#: ../src/wx/guiinit.cpp:3325 ../src/wx/xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3318
+#: ../src/wx/guiinit.cpp:3326
 msgid "Old Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3319
+#: ../src/wx/guiinit.cpp:3327
 msgid "New Value"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3839
+#: ../src/wx/guiinit.cpp:3847
 msgid "Menu commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3862
+#: ../src/wx/guiinit.cpp:3870
 msgid "Other commands"
 msgstr ""
 
-#: ../src/wx/guiinit.cpp:3973
+#: ../src/wx/guiinit.cpp:3981
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
-#: ../src/wx/opts.cpp:548 ../src/wx/opts.cpp:849
+#: ../src/wx/opts.cpp:550 ../src/wx/opts.cpp:855
 #, c-format
 msgid "Invalid value %s for option %s; valid values are %s%s%s"
 msgstr ""
 
-#: ../src/wx/opts.cpp:565 ../src/wx/opts.cpp:861
+#: ../src/wx/opts.cpp:567 ../src/wx/opts.cpp:867
 #, c-format
 msgid "Invalid value %d for option %s; valid values are %d - %d"
 msgstr ""
 
-#: ../src/wx/opts.cpp:572 ../src/wx/opts.cpp:581 ../src/wx/opts.cpp:869
-#: ../src/wx/opts.cpp:877
+#: ../src/wx/opts.cpp:574 ../src/wx/opts.cpp:583 ../src/wx/opts.cpp:875
+#: ../src/wx/opts.cpp:883
 #, c-format
 msgid "Invalid value %f for option %s; valid values are %f - %f"
 msgstr ""
 
-#: ../src/wx/opts.cpp:641 ../src/wx/opts.cpp:662 ../src/wx/opts.cpp:946
-#: ../src/wx/opts.cpp:972
+#: ../src/wx/opts.cpp:643 ../src/wx/opts.cpp:664 ../src/wx/opts.cpp:952
+#: ../src/wx/opts.cpp:978
 #, c-format
 msgid "Invalid key binding %s for %s"
 msgstr ""
 
-#: ../src/wx/opts.cpp:832
+#: ../src/wx/opts.cpp:838
 #, c-format
 msgid "Invalid flag option %s - %s ignored"
 msgstr ""
@@ -765,122 +765,122 @@ msgstr ""
 msgid "%s is not a valid ROM file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:91 ../src/wx/panel.cpp:148 ../src/wx/panel.cpp:209
+#: ../src/wx/panel.cpp:91 ../src/wx/panel.cpp:152 ../src/wx/panel.cpp:213
 msgid "Problem loading file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:147
+#: ../src/wx/panel.cpp:151
 #, c-format
 msgid "Unable to load Game Boy ROM %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:185 ../src/wx/panel.cpp:281
+#: ../src/wx/panel.cpp:189 ../src/wx/panel.cpp:287
 #, c-format
 msgid "Could not load BIOS %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:208
+#: ../src/wx/panel.cpp:212
 #, c-format
 msgid "Unable to load Game Boy Advance ROM %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:439
+#: ../src/wx/panel.cpp:445
 msgid " player "
 msgstr ""
 
-#: ../src/wx/panel.cpp:604
+#: ../src/wx/panel.cpp:610
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:604
+#: ../src/wx/panel.cpp:610
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:628
+#: ../src/wx/panel.cpp:634
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:628
+#: ../src/wx/panel.cpp:634
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: ../src/wx/panel.cpp:832
+#: ../src/wx/panel.cpp:838
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: ../src/wx/panel.cpp:870
+#: ../src/wx/panel.cpp:876
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: ../src/wx/panel.cpp:875
+#: ../src/wx/panel.cpp:881
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:883
+#: ../src/wx/panel.cpp:889
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:887
+#: ../src/wx/panel.cpp:893
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: ../src/wx/panel.cpp:971
+#: ../src/wx/panel.cpp:977
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1113
+#: ../src/wx/panel.cpp:1120
 msgid "No memory for rewinding"
 msgstr ""
 
-#: ../src/wx/panel.cpp:1123
+#: ../src/wx/panel.cpp:1130
 msgid "Error writing rewind state"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2334
+#: ../src/wx/panel.cpp:2341
 msgid "memory allocation error"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2337
+#: ../src/wx/panel.cpp:2344
 msgid "error initializing codec"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2340
+#: ../src/wx/panel.cpp:2347
 msgid "error writing to output file"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2343
+#: ../src/wx/panel.cpp:2350
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2348
+#: ../src/wx/panel.cpp:2355
 msgid "programming error; aborting!"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2365 ../src/wx/panel.cpp:2396
+#: ../src/wx/panel.cpp:2372 ../src/wx/panel.cpp:2403
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2424
+#: ../src/wx/panel.cpp:2431
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2430
+#: ../src/wx/panel.cpp:2437
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: ../src/wx/panel.cpp:2440
+#: ../src/wx/panel.cpp:2447
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -1048,51 +1048,51 @@ msgstr ""
 msgid "B:"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:222
+#: ../src/wx/wxvbam.cpp:240
 msgid "visualboyadvance-m"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:436
+#: ../src/wx/wxvbam.cpp:454
 msgid "Could not create main window"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:507
+#: ../src/wx/wxvbam.cpp:526
 msgid "Save built-in XRC file and exit"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:510
+#: ../src/wx/wxvbam.cpp:529
 msgid "Save built-in vba-over.ini and exit"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:513
+#: ../src/wx/wxvbam.cpp:532
 msgid "Print configuration path and exit"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:516
+#: ../src/wx/wxvbam.cpp:535
 msgid "Start in full-screen mode"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:520
+#: ../src/wx/wxvbam.cpp:539
 msgid "Delete shared link state first, if it exists"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:527
+#: ../src/wx/wxvbam.cpp:546
 msgid "List all settable options and exit"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:530
+#: ../src/wx/wxvbam.cpp:549
 msgid "ROM file"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:532
+#: ../src/wx/wxvbam.cpp:551
 msgid "<config>=<value>"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:563
+#: ../src/wx/wxvbam.cpp:582
 msgid "Configuration/build error: can't find built-in xrc"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:571
+#: ../src/wx/wxvbam.cpp:590
 #, c-format
 msgid ""
 "Wrote built-in configuration to %s.\n"
@@ -1101,11 +1101,11 @@ msgid ""
 "built-in:"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:586
+#: ../src/wx/wxvbam.cpp:605
 msgid "Configuration is read from, in order:"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:600
+#: ../src/wx/wxvbam.cpp:619
 #, c-format
 msgid ""
 "Wrote built-in override file to %s\n"
@@ -1113,13 +1113,13 @@ msgid ""
 "from search path:"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:606
+#: ../src/wx/wxvbam.cpp:625
 msgid ""
 "\n"
 "\tbuilt-in"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:617
+#: ../src/wx/wxvbam.cpp:636
 msgid ""
 "Options set from the command line are saved if any configuration changes are "
 "made in the user interface.\n"
@@ -1128,13 +1128,13 @@ msgid ""
 "\n"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:638
+#: ../src/wx/wxvbam.cpp:657
 msgid ""
 "The commands available for the Keyboard/* option are:\n"
 "\n"
 msgstr ""
 
-#: ../src/wx/wxvbam.cpp:672
+#: ../src/wx/wxvbam.cpp:691
 msgid "Bad configuration option or multiple ROM files given:\n"
 msgstr ""
 
@@ -1203,12 +1203,12 @@ msgstr ""
 msgid "CONTROL"
 msgstr ""
 
-#: ../src/wx/widgets/sdljoy.cpp:105
+#: ../src/wx/widgets/sdljoy.cpp:115
 #, c-format
 msgid "Connected game controller %d"
 msgstr ""
 
-#: ../src/wx/widgets/sdljoy.cpp:115
+#: ../src/wx/widgets/sdljoy.cpp:129
 #, c-format
 msgid "Disconnected game controller %d"
 msgstr ""
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Edit Cheat"
 msgstr ""
 
-#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:269
+#: ../src/wx/xrc/CheatEdit.xrc:31 ../src/wx/xrc/MainMenu.xrc:275
 msgid "&Type"
 msgstr ""
 
@@ -2340,8 +2340,8 @@ msgstr ""
 msgid "&0"
 msgstr ""
 
-#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:52
-#: ../src/wx/xrc/MainMenu.xrc:108
+#: ../src/wx/xrc/GBTileViewer.xrc:20 ../src/wx/xrc/MainMenu.xrc:58
+#: ../src/wx/xrc/MainMenu.xrc:114
 msgid "&1"
 msgstr ""
 
@@ -2602,7 +2602,7 @@ msgid ""
 "see entire contents if too small."
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:446
+#: ../src/wx/xrc/JoyPanel.xrc:14 ../src/wx/xrc/MainMenu.xrc:452
 msgid "Up"
 msgstr ""
 
@@ -2610,7 +2610,7 @@ msgstr ""
 msgid "A"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:450
+#: ../src/wx/xrc/JoyPanel.xrc:60 ../src/wx/xrc/MainMenu.xrc:456
 msgid "Down"
 msgstr ""
 
@@ -2618,7 +2618,7 @@ msgstr ""
 msgid "B"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:454
+#: ../src/wx/xrc/JoyPanel.xrc:106 ../src/wx/xrc/MainMenu.xrc:460
 msgid "Left"
 msgstr ""
 
@@ -2626,7 +2626,7 @@ msgstr ""
 msgid "L"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:458
+#: ../src/wx/xrc/JoyPanel.xrc:152 ../src/wx/xrc/MainMenu.xrc:464
 msgid "Right"
 msgstr ""
 
@@ -2634,11 +2634,11 @@ msgstr ""
 msgid "R"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:478
+#: ../src/wx/xrc/JoyPanel.xrc:199 ../src/wx/xrc/MainMenu.xrc:484
 msgid "Select"
 msgstr ""
 
-#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:482
+#: ../src/wx/xrc/JoyPanel.xrc:222 ../src/wx/xrc/MainMenu.xrc:488
 msgid "Start"
 msgstr ""
 
@@ -2795,627 +2795,635 @@ msgid "&e-Reader"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:32
-msgid "&Load Dot Code..."
+msgid "&Reset Loading Dot Code"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:35
-msgid "&Save Dot Code..."
+msgid "&Load Dot Code..."
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:38
+msgid "&Reset Saving Dot Code"
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:41
-msgid "Most &recent"
-msgstr ""
-
-#: ../src/wx/xrc/MainMenu.xrc:44
-msgid "Load current state slot"
+msgid "&Save Dot Code..."
 msgstr ""
 
 #: ../src/wx/xrc/MainMenu.xrc:47
+msgid "Most &recent"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:50
+msgid "Load current state slot"
+msgstr ""
+
+#: ../src/wx/xrc/MainMenu.xrc:53
 msgid "&Auto load most recent"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:55 ../src/wx/xrc/MainMenu.xrc:111
+#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
 msgid "&2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:58 ../src/wx/xrc/MainMenu.xrc:114
+#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
 msgid "&3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:61 ../src/wx/xrc/MainMenu.xrc:117
+#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
 msgid "&4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:64 ../src/wx/xrc/MainMenu.xrc:120
+#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
 msgid "&5"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:67 ../src/wx/xrc/MainMenu.xrc:123
+#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
 msgid "&6"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:70 ../src/wx/xrc/MainMenu.xrc:126
+#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
 msgid "&7"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:73 ../src/wx/xrc/MainMenu.xrc:129
+#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
 msgid "&8"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:76 ../src/wx/xrc/MainMenu.xrc:132
+#: ../src/wx/xrc/MainMenu.xrc:82 ../src/wx/xrc/MainMenu.xrc:138
 msgid "&9"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:79 ../src/wx/xrc/MainMenu.xrc:135
+#: ../src/wx/xrc/MainMenu.xrc:85 ../src/wx/xrc/MainMenu.xrc:141
 msgid "1&0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:83
+#: ../src/wx/xrc/MainMenu.xrc:89
 msgid "From &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:87
+#: ../src/wx/xrc/MainMenu.xrc:93
 msgid "Do not change &battery save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:91
+#: ../src/wx/xrc/MainMenu.xrc:97
 msgid "Do not change &cheat list"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:94
+#: ../src/wx/xrc/MainMenu.xrc:100
 msgid "&Load state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:98
+#: ../src/wx/xrc/MainMenu.xrc:104
 msgid "&Oldest slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:101
+#: ../src/wx/xrc/MainMenu.xrc:107
 msgid "Save current state slot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:104
+#: ../src/wx/xrc/MainMenu.xrc:110
 msgid "Increase state slot number and save"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:139
+#: ../src/wx/xrc/MainMenu.xrc:145
 msgid "To &File ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:141
+#: ../src/wx/xrc/MainMenu.xrc:147
 msgid "&Save state"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:144
+#: ../src/wx/xrc/MainMenu.xrc:150
 msgid "Increase state slot number"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:147
+#: ../src/wx/xrc/MainMenu.xrc:153
 msgid "Decrease state slot number"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:152 ../src/wx/xrc/MainMenu.xrc:164
+#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:170
 msgid "&Battery file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:155
+#: ../src/wx/xrc/MainMenu.xrc:161
 msgid "Gameshark &code file..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:158 ../src/wx/xrc/MainMenu.xrc:167
+#: ../src/wx/xrc/MainMenu.xrc:164 ../src/wx/xrc/MainMenu.xrc:173
 msgid "&Gameshark snapshot..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:160
+#: ../src/wx/xrc/MainMenu.xrc:166
 msgid "&Import"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:169
+#: ../src/wx/xrc/MainMenu.xrc:175
 msgid "&Export"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:173
+#: ../src/wx/xrc/MainMenu.xrc:179
 msgid "Screen capt&ure..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:177
+#: ../src/wx/xrc/MainMenu.xrc:183
 msgid "Start &sound recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:180
+#: ../src/wx/xrc/MainMenu.xrc:186
 msgid "Stop s&ound recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:183
+#: ../src/wx/xrc/MainMenu.xrc:189
 msgid "Start &video recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:186
+#: ../src/wx/xrc/MainMenu.xrc:192
 msgid "Stop v&ideo recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:189
+#: ../src/wx/xrc/MainMenu.xrc:195
 msgid "Start &game recording..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:192
+#: ../src/wx/xrc/MainMenu.xrc:198
 msgid "Stop g&ame recording"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:194
+#: ../src/wx/xrc/MainMenu.xrc:200
 msgid "&Record"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:198
+#: ../src/wx/xrc/MainMenu.xrc:204
 msgid "Start playing &movie..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:201
+#: ../src/wx/xrc/MainMenu.xrc:207
 msgid "Stop playing m&ovie"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:203
+#: ../src/wx/xrc/MainMenu.xrc:209
 msgid "&Play"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:208
+#: ../src/wx/xrc/MainMenu.xrc:214
 msgid "&Quit"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:212
+#: ../src/wx/xrc/MainMenu.xrc:218
 msgid "&Emulation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:214
+#: ../src/wx/xrc/MainMenu.xrc:220
 msgid "&Pause"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:218
+#: ../src/wx/xrc/MainMenu.xrc:224
 msgid "&Next frame"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:221
+#: ../src/wx/xrc/MainMenu.xrc:227
 msgid "Re&wind"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:225
+#: ../src/wx/xrc/MainMenu.xrc:231
 msgid "Toggle &full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:232
+#: ../src/wx/xrc/MainMenu.xrc:238
 msgid "&Turbo mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:236
+#: ../src/wx/xrc/MainMenu.xrc:242
 msgid "&VSync"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:240
+#: ../src/wx/xrc/MainMenu.xrc:246
 msgid "&Auto skip frames"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:245
+#: ../src/wx/xrc/MainMenu.xrc:251
 msgid "&Skip BIOS"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:249
+#: ../src/wx/xrc/MainMenu.xrc:255
 msgid "&Auto IPS/UPS/IPF patch"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:253
+#: ../src/wx/xrc/MainMenu.xrc:259
 msgid "&Pause when inactive"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:258
+#: ../src/wx/xrc/MainMenu.xrc:264
 msgid "&Reset"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:262
+#: ../src/wx/xrc/MainMenu.xrc:268
 msgid "&Options"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:264
+#: ../src/wx/xrc/MainMenu.xrc:270
 msgid "&Link"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:266
+#: ../src/wx/xrc/MainMenu.xrc:272
 msgid "Start &Network Link ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:271
+#: ../src/wx/xrc/MainMenu.xrc:277
 msgid "&Nothing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:275
+#: ../src/wx/xrc/MainMenu.xrc:281
 msgid "&Cable"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:279
+#: ../src/wx/xrc/MainMenu.xrc:285
 msgid "&Wireless"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:283
+#: ../src/wx/xrc/MainMenu.xrc:289
 msgid "&GameCube"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:287 ../src/wx/xrc/MainMenu.xrc:507
+#: ../src/wx/xrc/MainMenu.xrc:293 ../src/wx/xrc/MainMenu.xrc:513
 msgid "&Game Boy"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:292
+#: ../src/wx/xrc/MainMenu.xrc:298
 msgid "&Local mode"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:296
+#: ../src/wx/xrc/MainMenu.xrc:302
 msgid "&Link at boot"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:300
+#: ../src/wx/xrc/MainMenu.xrc:306
 msgid "&Speed hack"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:304 ../src/wx/xrc/MainMenu.xrc:310
-#: ../src/wx/xrc/MainMenu.xrc:385 ../src/wx/xrc/MainMenu.xrc:421
+#: ../src/wx/xrc/MainMenu.xrc:310 ../src/wx/xrc/MainMenu.xrc:316
+#: ../src/wx/xrc/MainMenu.xrc:391 ../src/wx/xrc/MainMenu.xrc:427
 msgid "&Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:308
+#: ../src/wx/xrc/MainMenu.xrc:314
 msgid "&Video"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:314
+#: ../src/wx/xrc/MainMenu.xrc:320
 msgid "&Start in full screen"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:318
+#: ../src/wx/xrc/MainMenu.xrc:324
 msgid "&Scaled resize"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:320
+#: ../src/wx/xrc/MainMenu.xrc:326
 msgid "&1x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:323
+#: ../src/wx/xrc/MainMenu.xrc:329
 msgid "&2x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:326
+#: ../src/wx/xrc/MainMenu.xrc:332
 msgid "&3x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:329
+#: ../src/wx/xrc/MainMenu.xrc:335
 msgid "&4x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:332
+#: ../src/wx/xrc/MainMenu.xrc:338
 msgid "&5x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:335
+#: ../src/wx/xrc/MainMenu.xrc:341
 msgid "&6x"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:339
+#: ../src/wx/xrc/MainMenu.xrc:345
 msgid "Change pixel filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:342
+#: ../src/wx/xrc/MainMenu.xrc:348
 msgid "Change interframe blending"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:345
+#: ../src/wx/xrc/MainMenu.xrc:351
 msgid "&Retain aspect ratio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:349
+#: ../src/wx/xrc/MainMenu.xrc:355
 msgid "Enable MMX"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:354
+#: ../src/wx/xrc/MainMenu.xrc:360
 msgid "&Bilinear filter"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:365
+#: ../src/wx/xrc/MainMenu.xrc:371
 msgid "&Keep window on top"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:370
+#: ../src/wx/xrc/MainMenu.xrc:376
 msgid "&Status bar"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:374
+#: ../src/wx/xrc/MainMenu.xrc:380
 msgid "&Disable on-screen display"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:378
+#: ../src/wx/xrc/MainMenu.xrc:384
 msgid "&Transparent on-screen display"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:383
+#: ../src/wx/xrc/MainMenu.xrc:389
 msgid "&Audio"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:388
+#: ../src/wx/xrc/MainMenu.xrc:394
 msgid "&Increase volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:392
+#: ../src/wx/xrc/MainMenu.xrc:398
 msgid "&Decrease volume"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:396
+#: ../src/wx/xrc/MainMenu.xrc:402
 msgid "&Toggle sound"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:401
+#: ../src/wx/xrc/MainMenu.xrc:407
 msgid "&GBA sound interpolation"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:406
+#: ../src/wx/xrc/MainMenu.xrc:412
 msgid "&GB sound enhancement"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:410
+#: ../src/wx/xrc/MainMenu.xrc:416
 msgid "&GB surround sound effect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:414
+#: ../src/wx/xrc/MainMenu.xrc:420
 msgid "&GB sound declicking"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:419
+#: ../src/wx/xrc/MainMenu.xrc:425
 msgid "&Input"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:425
+#: ../src/wx/xrc/MainMenu.xrc:431
 msgid "&Autofire"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:427 ../src/wx/xrc/MainMenu.xrc:462
+#: ../src/wx/xrc/MainMenu.xrc:433 ../src/wx/xrc/MainMenu.xrc:468
 msgid "&A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:431 ../src/wx/xrc/MainMenu.xrc:466
+#: ../src/wx/xrc/MainMenu.xrc:437 ../src/wx/xrc/MainMenu.xrc:472
 msgid "&B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:435 ../src/wx/xrc/MainMenu.xrc:470
+#: ../src/wx/xrc/MainMenu.xrc:441 ../src/wx/xrc/MainMenu.xrc:476
 msgid "&L"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:439 ../src/wx/xrc/MainMenu.xrc:474
+#: ../src/wx/xrc/MainMenu.xrc:445 ../src/wx/xrc/MainMenu.xrc:480
 msgid "&R"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:444
+#: ../src/wx/xrc/MainMenu.xrc:450
 msgid "&Autohold"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:488
+#: ../src/wx/xrc/MainMenu.xrc:494
 msgid "&Game Boy Advance"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:490 ../src/wx/xrc/MainMenu.xrc:509
+#: ../src/wx/xrc/MainMenu.xrc:496 ../src/wx/xrc/MainMenu.xrc:515
 msgid "Configure ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:494
+#: ../src/wx/xrc/MainMenu.xrc:500
 msgid "&Real-time clock"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:498
+#: ../src/wx/xrc/MainMenu.xrc:504
 msgid "&Use BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:502
+#: ../src/wx/xrc/MainMenu.xrc:508
 msgid "&Debug print"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:513
+#: ../src/wx/xrc/MainMenu.xrc:519
 msgid "&GB printer"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:517
+#: ../src/wx/xrc/MainMenu.xrc:523
 msgid "&Gather a full page before printing"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:521
+#: ../src/wx/xrc/MainMenu.xrc:527
 msgid "&Save printouts as screen captures"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:526
+#: ../src/wx/xrc/MainMenu.xrc:532
 msgid "&Use GB BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:530
+#: ../src/wx/xrc/MainMenu.xrc:536
 msgid "&Use GBC BIOS file"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:535
+#: ../src/wx/xrc/MainMenu.xrc:541
 msgid "&General ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:538
+#: ../src/wx/xrc/MainMenu.xrc:544
 msgid "&Speedup / Turbo ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:541
+#: ../src/wx/xrc/MainMenu.xrc:547
 msgid "D&irectories ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:544
+#: ../src/wx/xrc/MainMenu.xrc:550
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:548
+#: ../src/wx/xrc/MainMenu.xrc:554
 msgid "&Tools"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:550
+#: ../src/wx/xrc/MainMenu.xrc:556
 msgid "&Cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:552
+#: ../src/wx/xrc/MainMenu.xrc:558
 msgid "List &cheats ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:555
+#: ../src/wx/xrc/MainMenu.xrc:561
 msgid "Find c&heat ..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:559
+#: ../src/wx/xrc/MainMenu.xrc:565
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:563
+#: ../src/wx/xrc/MainMenu.xrc:569
 msgid "&Enable cheats"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:570
+#: ../src/wx/xrc/MainMenu.xrc:576
 msgid "&Break into GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:574
+#: ../src/wx/xrc/MainMenu.xrc:580
 msgid "&Configure port..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:577
+#: ../src/wx/xrc/MainMenu.xrc:583
 msgid "&Break on load"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:582
+#: ../src/wx/xrc/MainMenu.xrc:588
 msgid "&Disconnect"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:584
+#: ../src/wx/xrc/MainMenu.xrc:590
 msgid "&GDB"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:587
+#: ../src/wx/xrc/MainMenu.xrc:593
 msgid "&Disassemble..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:590
+#: ../src/wx/xrc/MainMenu.xrc:596
 msgid "&Logging..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:593
+#: ../src/wx/xrc/MainMenu.xrc:599
 msgid "&IO Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:596
+#: ../src/wx/xrc/MainMenu.xrc:602
 msgid "&Map Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:599
+#: ../src/wx/xrc/MainMenu.xrc:605
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:602
+#: ../src/wx/xrc/MainMenu.xrc:608
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:605
+#: ../src/wx/xrc/MainMenu.xrc:611
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:608
+#: ../src/wx/xrc/MainMenu.xrc:614
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:613
+#: ../src/wx/xrc/MainMenu.xrc:619
 msgid "Show all video layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:617
+#: ../src/wx/xrc/MainMenu.xrc:623
 msgid "BG &0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:622
+#: ../src/wx/xrc/MainMenu.xrc:628
 msgid "BG &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:627
+#: ../src/wx/xrc/MainMenu.xrc:633
 msgid "BG &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:632
+#: ../src/wx/xrc/MainMenu.xrc:638
 msgid "BG &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:637
+#: ../src/wx/xrc/MainMenu.xrc:643
 msgid "&OBJ"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:642
+#: ../src/wx/xrc/MainMenu.xrc:648
 msgid "&WIN 0"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:647
+#: ../src/wx/xrc/MainMenu.xrc:653
 msgid "W&IN 1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:652
+#: ../src/wx/xrc/MainMenu.xrc:658
 msgid "O&BJ WIN"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:656
+#: ../src/wx/xrc/MainMenu.xrc:662
 msgid "&View Layers"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:660
+#: ../src/wx/xrc/MainMenu.xrc:666
 msgid "Channel &1"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:665
+#: ../src/wx/xrc/MainMenu.xrc:671
 msgid "Channel &2"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:670
+#: ../src/wx/xrc/MainMenu.xrc:676
 msgid "Channel &3"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:675
+#: ../src/wx/xrc/MainMenu.xrc:681
 msgid "Channel &4"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:680
+#: ../src/wx/xrc/MainMenu.xrc:686
 msgid "Direct Sound &A"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:685
+#: ../src/wx/xrc/MainMenu.xrc:691
 msgid "Direct Sound &B"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:689
+#: ../src/wx/xrc/MainMenu.xrc:695
 msgid "&Sound Channels"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:693
+#: ../src/wx/xrc/MainMenu.xrc:699
 msgid "&Help"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:695
+#: ../src/wx/xrc/MainMenu.xrc:701
 msgid "Report &Bugs"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:698
+#: ../src/wx/xrc/MainMenu.xrc:704
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:701
+#: ../src/wx/xrc/MainMenu.xrc:707
 msgid "Translations"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:709
+#: ../src/wx/xrc/MainMenu.xrc:715
 msgid "Check for updates"
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:712
+#: ../src/wx/xrc/MainMenu.xrc:718
 msgid "&Factory Reset..."
 msgstr ""
 
-#: ../src/wx/xrc/MainMenu.xrc:716
+#: ../src/wx/xrc/MainMenu.xrc:722
 msgid "&About..."
 msgstr ""
 
@@ -3530,6 +3538,10 @@ msgstr ""
 
 #: ../src/wx/xrc/NetLink.xrc:67
 msgid "Server:"
+msgstr ""
+
+#: ../src/wx/xrc/NetLink.xrc:81
+msgid "Port:"
 msgstr ""
 
 #: ../src/wx/xrc/OAMViewer.xrc:4

--- a/src/gba/GBA.cpp
+++ b/src/gba/GBA.cpp
@@ -1712,9 +1712,19 @@ const char* GetSaveDotCodeFile()
     return saveDotCodeFile;
 }
 
+void ResetLoadDotCodeFile()
+{
+    loadDotCodeFile = strdup("");
+}
+
 void SetLoadDotCodeFile(const char* szFile)
 {
     loadDotCodeFile = strdup(szFile);
+}
+
+void ResetSaveDotCodeFile()
+{
+    saveDotCodeFile = strdup("");
 }
 
 void SetSaveDotCodeFile(const char* szFile)

--- a/src/gba/GBA.cpp
+++ b/src/gba/GBA.cpp
@@ -1714,6 +1714,11 @@ const char* GetSaveDotCodeFile()
 
 void ResetLoadDotCodeFile()
 {
+	if(loadDotCodeFile)
+	{
+        free((char*)loadDotCodeFile);
+    }
+
     loadDotCodeFile = strdup("");
 }
 
@@ -1724,6 +1729,11 @@ void SetLoadDotCodeFile(const char* szFile)
 
 void ResetSaveDotCodeFile()
 {
+    if (saveDotCodeFile)
+    {
+        free((char*)saveDotCodeFile);
+    }
+
     saveDotCodeFile = strdup("");
 }
 

--- a/src/gba/GBA.h
+++ b/src/gba/GBA.h
@@ -162,7 +162,9 @@ extern void cpuEnableProfiling(int hz);
 
 const char* GetLoadDotCodeFile();
 const char* GetSaveDotCodeFile();
+void ResetLoadDotCodeFile();
 void SetLoadDotCodeFile(const char* szFile);
+void ResetSaveDotCodeFile();
 void SetSaveDotCodeFile(const char* szFile);
 
 // Updates romSize and realloc rom pointer if needed after soft-patching

--- a/src/gba/ereader.cpp
+++ b/src/gba/ereader.cpp
@@ -232,7 +232,7 @@ void BIOS_EReader_ScanCard(int swi_num)
 
         const char* loadDotCodeFile = GetLoadDotCodeFile();
 
-        if (loadDotCodeFile == 0) {
+        if (!*loadDotCodeFile) {
             reg[0].I = 0x301;
             return;
         }

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -837,11 +837,14 @@ EVT_HANDLER_MASK(RomInformation, "ROM information...", CMDEN_GB | CMDEN_GBA)
     }
 }
 
-static wxString loaddotcodefile_path;
-static wxString savedotcodefile_path;
-
-EVT_HANDLER_MASK(LoadDotCodeFile, "Load e-Reader Dot Code...", CMDEN_GBA)
+EVT_HANDLER_MASK(ResetLoadingDotCodeFile, "Reset Loading e-Reader Dot Code", CMDEN_GBA)
 {
+    ResetLoadDotCodeFile();
+}
+
+EVT_HANDLER_MASK(SetLoadingDotCodeFile, "Load e-Reader Dot Code...", CMDEN_GBA)
+{
+    static wxString loaddotcodefile_path;
     wxFileDialog dlg(this, _("Select Dot Code file"), loaddotcodefile_path, wxEmptyString,
         _(
                          "e-Reader Dot Code (*.bin;*.raw)|"
@@ -853,11 +856,17 @@ EVT_HANDLER_MASK(LoadDotCodeFile, "Load e-Reader Dot Code...", CMDEN_GBA)
         return;
 
     loaddotcodefile_path = dlg.GetPath();
-    SetLoadDotCodeFile(loaddotcodefile_path.mb_str(wxConvUTF8));
+    SetLoadDotCodeFile(loaddotcodefile_path.mb_str());
 }
 
-EVT_HANDLER_MASK(SaveDotCodeFile, "Save e-Reader Dot Code...", CMDEN_GBA)
+EVT_HANDLER_MASK(ResetSavingDotCodeFile, "Reset Saving e-Reader Dot Code", CMDEN_GBA)
 {
+    ResetLoadDotCodeFile();
+}
+
+EVT_HANDLER_MASK(SetSavingDotCodeFile, "Save e-Reader Dot Code...", CMDEN_GBA)
+{
+    static wxString savedotcodefile_path;
     wxFileDialog dlg(this, _("Select Dot Code file"), savedotcodefile_path, wxEmptyString,
         _(
                          "e-Reader Dot Code (*.bin;*.raw)|"
@@ -869,7 +878,7 @@ EVT_HANDLER_MASK(SaveDotCodeFile, "Save e-Reader Dot Code...", CMDEN_GBA)
         return;
 
     savedotcodefile_path = dlg.GetPath();
-    SetSaveDotCodeFile(savedotcodefile_path.mb_str(wxConvUTF8));
+    SetSaveDotCodeFile(savedotcodefile_path.mb_str());
 }
 
 static wxString batimp_path;

--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -28,10 +28,16 @@
       <object class="separator"/>
       <object class="wxMenu">
         <label>_e-Reader</label>
-        <object class="wxMenuItem" name="LoadDotCodeFile">
+        <object class="wxMenuItem" name="ResetLoadingDotCodeFile">
+          <label>_Reset Loading Dot Code</label>
+        </object>
+        <object class="wxMenuItem" name="SetLoadingDotCodeFile">
           <label>_Load Dot Code...</label>
         </object>
-        <object class="wxMenuItem" name="SaveDotCodeFile">
+        <object class="wxMenuItem" name="ResetSavingDotCodeFile">
+          <label>_Reset Saving Dot Code</label>
+        </object>
+        <object class="wxMenuItem" name="SetSavingDotCodeFile">
           <label>_Save Dot Code...</label>
         </object>
       </object>


### PR DESCRIPTION
This PR fix a issue with loading e-Reader dot code.

Specifically, it is as follows.
- Even if Dot code file is not specified, it tries to read as eternal and does not accept button input.
- In Japanese etc., the path of Dot code file is garbled internally.