### PR TITLE
Force Adwaita:dark on GTK, disable vsync.

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -1115,6 +1115,19 @@ if(APPLE)
     endif()
 endif()
 
+if(NOT WIN32 AND NOT APPLE)
+        add_custom_command(
+            TARGET visualboyadvance-m
+            POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy   ${CMAKE_BINARY_DIR}/visualboyadvance-m ${CMAKE_BINARY_DIR}/visualboyadvance-m.real
+            COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_BINARY_DIR}/visualboyadvance-m
+            COMMAND ${CMAKE_COMMAND} -E copy   ${CMAKE_CURRENT_SOURCE_DIR}/linux-shell-wrapper.sh ${CMAKE_BINARY_DIR}/visualboyadvance-m
+            COMMAND chmod +x ${CMAKE_BINARY_DIR}/visualboyadvance-m
+        )
+
+        install(PROGRAMS ${CMAKE_BINARY_DIR}/visualboyadvance-m.real DESTINATION bin)
+endif()
+
 if(UPSTREAM_RELEASE AND APPLE)
     if(NOT CMAKE_BUILD_TYPE MATCHES Debug)
         find_program(STRIP_PROGRAM strip)

--- a/src/wx/linux-shell-wrapper.sh
+++ b/src/wx/linux-shell-wrapper.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Force Adwaita-dark theme for GTK2 and 3+, other themes can cause serious
+# issues:
+
+# For GTK2:
+if [ -e /usr/share/themes/Adwaita-dark/gtk-2.0/gtkrc ]; then
+	GTK2_RC_FILES=/usr/share/themes/Adwaita-dark/gtk-2.0/gtkrc
+fi
+
+# For GTK3+:
+GTK_THEME=Adwaita:dark
+
+# Turn off vsync:
+
+# for mesa drivers.
+vblank_mode=0
+
+# for Nvidia drivers.
+__GL_SYNC_TO_VBLANK=0
+
+export GTK2_RC_FILES GTK_THEME vblank_mode __GL_SYNC_TO_VBLANK
+
+${0%/*}/visualboyadvance-m.real "$@"


### PR DESCRIPTION
Add shell script wrapper on unix to set environment variables for GTK 2
and 3+ theme to Adwaita:dark. This fixes various Gnome etc. theme
incompatibilities that can make the app unusable.

Also set environment variables to turn off vsync on both mesa and Nvidia
drivers.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>

@ZachBacon your thoughts please, based on your packaging expertise.

@denisfa this is at least a minor improvement for the vsync issue, right?