### PR TITLE
limit max filesize and header check for valid rom files

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -54,6 +54,8 @@ static int(ZEXPORT *utilGzReadFunc)(gzFile, voidp, unsigned int) = NULL;
 static int(ZEXPORT *utilGzCloseFunc)(gzFile) = NULL;
 static z_off_t(ZEXPORT *utilGzSeekFunc)(gzFile, z_off_t, int) = NULL;
 
+#define MAX_CART_SIZE 0x2000000 // 32MB
+
 bool FileExists(const char *filename)
 {
 #ifdef _WIN32
@@ -635,6 +637,9 @@ uint8_t *utilLoad(const char *file, bool (*accept)(const char *), uint8_t *data,
         if (size == 0)
                 size = fileSize;
 
+        if (size > MAX_CART_SIZE)
+                return NULL;
+        
         uint8_t *image = data;
 
         if (image == NULL) {

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -778,6 +778,34 @@ static const uint16_t gbColorizationPaletteData[32][3][4] = {
 #define GBSAVE_GAME_VERSION_12 12
 #define GBSAVE_GAME_VERSION GBSAVE_GAME_VERSION_12
 
+
+static bool gbCheckRomHeader(void)
+{
+    uint8_t nlogo[16] = {
+        0xCE, 0xED, 0x66, 0x66, 0xCC, 0x0D, 0x00, 0x0B,
+        0x03, 0x73, 0x00, 0x83, 0x00, 0x0C, 0x00, 0x0D
+    };
+
+    // Game Genie
+    if ((gbRom[2] == 0x6D) && (gbRom[5] == 0x47) && (gbRom[6] == 0x65) && (gbRom[7] == 0x6E) &&
+            (gbRom[8] == 0x69) && (gbRom[9] == 0x65) && (gbRom[0xA] == 0x28) && (gbRom[0xB] == 0x54)) {
+        return true;
+
+    // Game Shark
+    } else if (((gbRom[0x104] == 0x44) && (gbRom[0x156] == 0xEA) && (gbRom[0x158] == 0x7F) && (gbRom[0x159] == 0xEA) && (gbRom[0x15B] == 0x7F)) ||
+            ((gbRom[0x165] == 0x3E) && (gbRom[0x166] == 0xD9) && (gbRom[0x16D] == 0xE1) && (gbRom[0x16E] == 0x7F))) {
+        return true;
+
+    // check for 1st 16 bytes of nintendo logo
+    } else {
+        uint8_t header[16];
+        memcpy(header, &gbRom[0x104], 16);
+        if (!memcmp(header, nlogo, 16))
+            return true;
+    }
+    return false;
+}
+
 void setColorizerHack(bool value)
 {
     allow_colorizer_hack = value;
@@ -4153,6 +4181,9 @@ bool gbLoadRom(const char* szFile)
         bios = NULL;
     }
     bios = (uint8_t*)calloc(1, 0x900);
+
+    if (!gbCheckRomHeader())
+        return false;
 
     return gbUpdateSizes();
 }


### PR DESCRIPTION
https://github.com/visualboyadvance-m/visualboyadvance-m/issues/612
https://github.com/visualboyadvance-m/visualboyadvance-m/issues/611
https://github.com/visualboyadvance-m/visualboyadvance-m/issues/610
https://github.com/visualboyadvance-m/visualboyadvance-m/issues/609
These roms are invalid in a number of ways. An additional header check
should prevent loading invalid roms.

https://github.com/visualboyadvance-m/visualboyadvance-m/issues/613
File is over 1GB which is far to large for know max cart size. GBC is 8MB,
GBA max is 32MB. Limiting the file size that can be opened to 32MB prevents
issue.

strange that asan on libretro port does not cause asan from aborting. is vba-m
doing any extra checks that the one used as parameter to -fsanitize? In any case
these are just quick fixes for these common cases, and common i meant is that rom is expected to
be a known one.