### PR TITLE
Speedup/Turbo/Throttle fixes.

### DIFF
--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-03-13 14:40+0000\n"
+"POT-Creation-Date: 2020-03-27 09:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -111,238 +111,237 @@ msgstr ""
 msgid "Start!"
 msgstr ""
 
-#: guiinit.cpp:82 xrc/NetLink.xrc:99
+#: guiinit.cpp:96 xrc/NetLink.xrc:99
 msgid "Connect"
 msgstr ""
 
-#: guiinit.cpp:98
+#: guiinit.cpp:113
 msgid "You must enter a valid host name"
 msgstr ""
 
-#: guiinit.cpp:99
+#: guiinit.cpp:114
 msgid "Host name invalid"
 msgstr ""
 
-#: guiinit.cpp:117
+#: guiinit.cpp:132
 msgid "Waiting for clients..."
 msgstr ""
 
-#: guiinit.cpp:118
+#: guiinit.cpp:133
 #, c-format
 msgid "Server IP address is: %s\n"
 msgstr ""
 
-#: guiinit.cpp:120
+#: guiinit.cpp:135
 msgid "Waiting for connection..."
 msgstr ""
 
-#: guiinit.cpp:121
+#: guiinit.cpp:136
 #, c-format
 msgid "Connecting to %s\n"
 msgstr ""
 
-#: guiinit.cpp:154
+#: guiinit.cpp:169
 msgid ""
 "Error occurred.\n"
 "Please try again."
 msgstr ""
 
-#: guiinit.cpp:221 guiinit.cpp:274
+#: guiinit.cpp:236 guiinit.cpp:289
 msgid "Select cheat file"
 msgstr ""
 
-#: guiinit.cpp:222
+#: guiinit.cpp:237
 msgid "VBA cheat lists (*.clt)|*.clt|CHT cheat lists (*.cht)|*.cht"
 msgstr ""
 
-#: guiinit.cpp:241 panel.cpp:417
+#: guiinit.cpp:256 panel.cpp:417
 msgid "Loaded cheats"
 msgstr ""
 
-#: guiinit.cpp:275
+#: guiinit.cpp:290
 msgid "VBA cheat lists (*.clt)|*.clt"
 msgstr ""
 
-#: guiinit.cpp:293
+#: guiinit.cpp:308
 msgid "Saved cheats"
 msgstr ""
 
-#: guiinit.cpp:324 guiinit.cpp:343
+#: guiinit.cpp:339 guiinit.cpp:358
 msgid "Restore old values?"
 msgstr ""
 
-#: guiinit.cpp:325 guiinit.cpp:344
+#: guiinit.cpp:340 guiinit.cpp:359
 msgid "Removing cheats"
 msgstr ""
 
-#: guiinit.cpp:735 xrc/JoyPanel.xrc:364
+#: guiinit.cpp:750 xrc/JoyPanel.xrc:364
 msgid "GameShark"
 msgstr ""
 
-#: guiinit.cpp:736 cmdevents.cpp:676
+#: guiinit.cpp:751 cmdevents.cpp:676
 msgid "GameGenie"
 msgstr ""
 
-#: guiinit.cpp:738
+#: guiinit.cpp:753
 msgid "Generic Code"
 msgstr ""
 
-#: guiinit.cpp:739
+#: guiinit.cpp:754
 msgid "GameShark Advance"
 msgstr ""
 
-#: guiinit.cpp:740
+#: guiinit.cpp:755
 msgid "CodeBreaker Advance"
 msgstr ""
 
-#: guiinit.cpp:741
+#: guiinit.cpp:756
 msgid "Flashcart CHT"
 msgstr ""
 
-#: guiinit.cpp:809 guiinit.cpp:1064
+#: guiinit.cpp:824 guiinit.cpp:1079
 msgid "Number cannot be empty"
 msgstr ""
 
-#: guiinit.cpp:847
+#: guiinit.cpp:862
 #, c-format
 msgid "Search produced %d results.  Please refine better"
 msgstr ""
 
-#: guiinit.cpp:859
+#: guiinit.cpp:874
 msgid "Search produced no results"
 msgstr ""
 
-#: guiinit.cpp:1022
+#: guiinit.cpp:1037
 msgid "8-bit "
 msgstr ""
 
-#: guiinit.cpp:1026
+#: guiinit.cpp:1041
 msgid "16-bit "
 msgstr ""
 
-#: guiinit.cpp:1030
+#: guiinit.cpp:1045
 msgid "32-bit "
 msgstr ""
 
-#: guiinit.cpp:1036
+#: guiinit.cpp:1051
 msgid "signed decimal"
 msgstr ""
 
-#: guiinit.cpp:1040
+#: guiinit.cpp:1055
 msgid "unsigned decimal"
 msgstr ""
 
-#: guiinit.cpp:1044
+#: guiinit.cpp:1059
 msgid "unsigned hexadecimal"
 msgstr ""
 
-#: guiinit.cpp:1522
+#: guiinit.cpp:1537
 #, c-format
 msgid "%d frames = %.2f ms"
 msgstr ""
 
-#: guiinit.cpp:1534
+#: guiinit.cpp:1549
 msgid "Default device"
 msgstr ""
 
-#: guiinit.cpp:1721
+#: guiinit.cpp:1736
 msgid "Desktop mode"
 msgstr ""
 
-#: guiinit.cpp:1728
+#: guiinit.cpp:1743
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: guiinit.cpp:1841 cmdevents.cpp:746 xrc/DisplayConfig.xrc:85
+#: guiinit.cpp:1856 cmdevents.cpp:746 xrc/DisplayConfig.xrc:85
 #: xrc/DisplayConfig.xrc:135 xrc/DisplayConfig.xrc:221
 #: xrc/GameBoyAdvanceConfig.xrc:32 xrc/GameBoyAdvanceConfig.xrc:204
-#: xrc/GeneralConfig.xrc:114 xrc/SoundConfig.xrc:219 xrc/SoundConfig.xrc:309
-#: xrc/SpeedupConfig.xrc:45 xrc/SpeedupConfig.xrc:120
+#: xrc/SoundConfig.xrc:219 xrc/SoundConfig.xrc:309
 msgid "None"
 msgstr ""
 
-#: guiinit.cpp:1882
+#: guiinit.cpp:1897
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: guiinit.cpp:1902 xrc/DisplayConfig.xrc:107
+#: guiinit.cpp:1917 xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: guiinit.cpp:1930
+#: guiinit.cpp:1945
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: guiinit.cpp:1931
+#: guiinit.cpp:1946
 msgid "Plugin selection error"
 msgstr ""
 
-#: guiinit.cpp:2130
+#: guiinit.cpp:2145
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: guiinit.cpp:2130
+#: guiinit.cpp:2145
 msgid "Confirm"
 msgstr ""
 
-#: guiinit.cpp:2724
+#: guiinit.cpp:2681
 msgid "Main icon not found"
 msgstr ""
 
-#: guiinit.cpp:2734
+#: guiinit.cpp:2691
 msgid "Browse"
 msgstr ""
 
-#: guiinit.cpp:2748
+#: guiinit.cpp:2705
 msgid "Main display panel not found"
 msgstr ""
 
-#: guiinit.cpp:2897
+#: guiinit.cpp:2854
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: guiinit.cpp:2911
+#: guiinit.cpp:2868
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: guiinit.cpp:3041
+#: guiinit.cpp:2998
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: guiinit.cpp:3242
+#: guiinit.cpp:3206
 msgid "Code"
 msgstr ""
 
-#: guiinit.cpp:3251
+#: guiinit.cpp:3215
 msgid "Description"
 msgstr ""
 
-#: guiinit.cpp:3325 xrc/CheatAdd.xrc:31
+#: guiinit.cpp:3289 xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: guiinit.cpp:3326
+#: guiinit.cpp:3290
 msgid "Old Value"
 msgstr ""
 
-#: guiinit.cpp:3327
+#: guiinit.cpp:3291
 msgid "New Value"
 msgstr ""
 
-#: guiinit.cpp:3847
+#: guiinit.cpp:3799
 msgid "Menu commands"
 msgstr ""
 
-#: guiinit.cpp:3870
+#: guiinit.cpp:3822
 msgid "Other commands"
 msgstr ""
 
-#: guiinit.cpp:3981
+#: guiinit.cpp:3933
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -839,27 +838,27 @@ msgstr ""
 msgid "Network is not supported in local mode."
 msgstr ""
 
-#: opts.cpp:550 opts.cpp:855
+#: opts.cpp:552 opts.cpp:857
 #, c-format
 msgid "Invalid value %s for option %s; valid values are %s%s%s"
 msgstr ""
 
-#: opts.cpp:567 opts.cpp:867
+#: opts.cpp:569 opts.cpp:869
 #, c-format
 msgid "Invalid value %d for option %s; valid values are %d - %d"
 msgstr ""
 
-#: opts.cpp:574 opts.cpp:583 opts.cpp:875 opts.cpp:883
+#: opts.cpp:576 opts.cpp:585 opts.cpp:877 opts.cpp:885
 #, c-format
 msgid "Invalid value %f for option %s; valid values are %f - %f"
 msgstr ""
 
-#: opts.cpp:643 opts.cpp:664 opts.cpp:952 opts.cpp:978
+#: opts.cpp:645 opts.cpp:666 opts.cpp:954 opts.cpp:980
 #, c-format
 msgid "Invalid key binding %s for %s"
 msgstr ""
 
-#: opts.cpp:838
+#: opts.cpp:840
 #, c-format
 msgid "Invalid flag option %s - %s ignored"
 msgstr ""
@@ -1072,22 +1071,22 @@ msgstr ""
 msgid "programming error; aborting!"
 msgstr ""
 
-#: panel.cpp:2404 panel.cpp:2435
+#: panel.cpp:2399 panel.cpp:2429
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: panel.cpp:2463
+#: panel.cpp:2457
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2469
+#: panel.cpp:2463
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2479
+#: panel.cpp:2473
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -2386,6 +2385,10 @@ msgstr ""
 msgid "0 = no throttle"
 msgstr ""
 
+#: xrc/GeneralConfig.xrc:114 xrc/SpeedupConfig.xrc:45
+msgid "Full Speed/No Limit"
+msgstr ""
+
 #: xrc/GeneralConfig.xrc:115 xrc/SpeedupConfig.xrc:46
 msgid "25%"
 msgstr ""
@@ -3506,15 +3509,15 @@ msgstr ""
 msgid "Players:"
 msgstr ""
 
-#: xrc/NetLink.xrc:41 xrc/SpeedupConfig.xrc:122
+#: xrc/NetLink.xrc:41
 msgid "2"
 msgstr ""
 
-#: xrc/NetLink.xrc:49 xrc/SpeedupConfig.xrc:123
+#: xrc/NetLink.xrc:49
 msgid "3"
 msgstr ""
 
-#: xrc/NetLink.xrc:56 xrc/SpeedupConfig.xrc:124
+#: xrc/NetLink.xrc:56
 msgid "4"
 msgstr ""
 
@@ -3687,117 +3690,5 @@ msgid "Speedup Throttle"
 msgstr ""
 
 #: xrc/SpeedupConfig.xrc:84
-msgid "Speedup Frame Skip"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:102
-msgid "# of frames:"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:121
-msgid "1"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:125
-msgid "5"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:126
-msgid "6"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:127
-msgid "7"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:128
-msgid "8"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:129
-msgid "9"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:130
-msgid "10"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:131
-msgid "11"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:132
-msgid "12"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:133
-msgid "13"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:134
-msgid "14"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:135
-msgid "15"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:136
-msgid "16"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:137
-msgid "17"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:138
-msgid "18"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:139
-msgid "19"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:140
-msgid "20"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:141
-msgid "21"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:142
-msgid "22"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:143
-msgid "23"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:144
-msgid "24"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:145
-msgid "25"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:146
-msgid "26"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:147
-msgid "27"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:148
-msgid "28"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:149
-msgid "29"
-msgstr ""
-
-#: xrc/SpeedupConfig.xrc:150
-msgid "30"
+msgid "Frame skip"
 msgstr ""

--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -114,7 +114,7 @@ enum named_opts
 	OPT_WINDOW_POSITION_Y,
 	OPT_WINDOW_WIDTH,
 	OPT_SPEEDUP_THROTTLE,
-	OPT_SPEEDUP_FRAME_SKIP
+	OPT_NO_SPEEDUP_THROTTLE_FRAME_SKIP
 };
 
 #define SOUND_MAX_VOLUME 2.0
@@ -256,8 +256,8 @@ uint32_t autoFrameSkipLastTime;
 uint32_t movieLastJoypad;
 uint32_t movieNextJoypad;
 uint32_t throttle = 100;
-uint32_t speedup_throttle = 0;
-uint32_t speedup_frame_skip = 9;
+uint32_t speedup_throttle = 100;
+bool speedup_throttle_frame_skip = true;
 
 const char* preparedCheatCodes[MAX_CHEATS];
 
@@ -391,8 +391,8 @@ struct option argOptions[] = {
 	{ "synchronize", required_argument, 0, OPT_SYNCHRONIZE },
 	{ "thread-priority", required_argument, 0, OPT_THREAD_PRIORITY },
 	{ "throttle", required_argument, 0, 'T' },
-	{ "speedup_throttle", required_argument, 0, OPT_SPEEDUP_THROTTLE },
-	{ "speedup_frame_skip", required_argument, 0, OPT_SPEEDUP_FRAME_SKIP },
+	{ "speedup-throttle", required_argument, 0, OPT_SPEEDUP_THROTTLE },
+	{ "no-speedup-throttle-frame-skip", no_argument, 0, OPT_NO_SPEEDUP_THROTTLE_FRAME_SKIP },
 	{ "triple-buffering", no_argument, &tripleBuffering, 1 },
 	{ "use-bios", no_argument, &useBios, 1 },
 	{ "use-bios-file-gb", no_argument, &useBiosFileGB, 1 },
@@ -554,8 +554,8 @@ void LoadConfig()
 	soundRecordDir = ReadPrefString("soundRecordDir");
 	threadPriority = ReadPref("priority", 2);
 	throttle = ReadPref("throttle", 100);
-        speedup_throttle = ReadPref("speedup_throttle", 0);
-        speedup_frame_skip = ReadPref("speedup_frame_skip", 9);
+	speedup_throttle = ReadPref("speedupThrottle", 100);
+	speedup_throttle_frame_skip = ReadPref("speedupThrottleFrameSkip", 1);
 	tripleBuffering = ReadPref("tripleBuffering", 0);
 	useBios = ReadPrefHex("useBiosGBA");
 	useBiosFileGB = ReadPref("useBiosGB", 0);
@@ -1364,9 +1364,8 @@ int ReadOpts(int argc, char ** argv)
                         if (optarg)
                             speedup_throttle = atoi(optarg);
                         break;
-                case OPT_SPEEDUP_FRAME_SKIP:
-                        if (optarg)
-                            speedup_frame_skip = atoi(optarg);
+                case OPT_NO_SPEEDUP_THROTTLE_FRAME_SKIP:
+			speedup_throttle_frame_skip = false;
                         break;
 		}
 	}

--- a/src/common/ConfigManager.h
+++ b/src/common/ConfigManager.h
@@ -147,7 +147,7 @@ extern uint32_t movieLastJoypad;
 extern uint32_t movieNextJoypad;
 extern uint32_t throttle;
 extern uint32_t speedup_throttle;
-extern uint32_t speedup_frame_skip;
+extern bool speedup_throttle_frame_skip;
 
 extern int preparedCheats;
 extern const char *preparedCheatCodes[MAX_CHEATS];

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -292,7 +292,7 @@ opt_desc opts[] = {
     INTOPT("preferences/skipSaveGameBattery", "", wxTRANSLATE("Do not overwrite native (battery) save when loading state"), skipSaveGameBattery, 0, 1),
     UINTOPT("preferences/throttle", "", wxTRANSLATE("Throttle game speed, even when accelerated (0-500%, 0 = no throttle)"), throttle, 0, 600),
     UINTOPT("preferences/speedupThrottle", "", wxTRANSLATE("Set throttle for speedup key (0-600%, 0 = no throttle)"), speedup_throttle, 0, 600),
-    UINTOPT("preferences/speedupFrameSkip", "", wxTRANSLATE("Set frame skip for speedup key (0-30)"), speedup_frame_skip, 0, 30),
+    BOOLOPT("preferences/speedupThrottleFrameSkip", "", wxTRANSLATE("Use frame skip for speedup throttle"), speedup_throttle_frame_skip),
     INTOPT("preferences/useBiosGB", "BootRomGB", wxTRANSLATE("Use the specified BIOS file for GB"), useBiosFileGB, 0, 1),
     INTOPT("preferences/useBiosGBA", "BootRomEn", wxTRANSLATE("Use the specified BIOS file"), useBiosFileGBA, 0, 1),
     INTOPT("preferences/useBiosGBC", "BootRomGBC", wxTRANSLATE("Use the specified BIOS file for GBC"), useBiosFileGBC, 0, 1),

--- a/src/wx/xrc/GeneralConfig.xrc
+++ b/src/wx/xrc/GeneralConfig.xrc
@@ -111,7 +111,7 @@
               <object class="sizeritem">
                 <object class="wxChoice" name="ThrottleSel">
                   <content>
-                    <item>None</item>
+                    <item>Full Speed/No Limit</item>
                     <item>25%</item>
                     <item>50%</item>
                     <item>75%</item>

--- a/src/wx/xrc/SpeedupConfig.xrc
+++ b/src/wx/xrc/SpeedupConfig.xrc
@@ -42,7 +42,7 @@
               <object class="sizeritem">
                 <object class="wxChoice" name="SpeedupThrottleSel">
                   <content>
-                    <item>None</item>
+                    <item>Full Speed/No Limit</item>
                     <item>25%</item>
                     <item>50%</item>
                     <item>75%</item>
@@ -80,84 +80,10 @@
         <border>5</border>
       </object>
       <object class="sizeritem">
-        <object class="wxStaticText">
-          <label>Speedup Frame Skip</label>
-          <font>
-            <weight>bold</weight>
-          </font>
+        <object class="wxCheckBox" name="SpeedupThrottleFrameSkip">
+          <label>Frame skip</label>
         </object>
         <flag>wxALL</flag>
-        <border>5</border>
-      </object>
-      <object class="sizeritem">
-        <object class="wxBoxSizer">
-          <orient>wxVERTICAL</orient>
-          <object class="sizeritem">
-            <flag>wxALL|wxEXPAND</flag>
-            <border>5</border>
-            <object class="wxBoxSizer">
-              <orient>wxHORIZONTAL</orient>
-              <object class="sizeritem">
-                <object class="wxStaticText">
-                  <label># of frames:</label>
-                  <size>60,-1d</size>
-                </object>
-                <flag>wxALL|wxALIGN_CENTRE_VERTICAL</flag>
-                <border>5</border>
-              </object>
-              <object class="sizeritem">
-                <object class="wxSpinCtrl" name="SpeedupFrameSkip">
-                  <value>9</value>
-                  <min>0</min>
-                  <max>30</max>
-                </object>
-                <flag>wxALL|wxALIGN_CENTRE_VERTICAL</flag>
-                <border>5</border>
-              </object>
-              <object class="sizeritem">
-                <object class="wxChoice" name="SpeedupFrameSkipSel">
-                  <content>
-                    <item>None</item>
-                    <item>1</item>
-                    <item>2</item>
-                    <item>3</item>
-                    <item>4</item>
-                    <item>5</item>
-                    <item>6</item>
-                    <item>7</item>
-                    <item>8</item>
-                    <item>9</item>
-                    <item>10</item>
-                    <item>11</item>
-                    <item>12</item>
-                    <item>13</item>
-                    <item>14</item>
-                    <item>15</item>
-                    <item>16</item>
-                    <item>17</item>
-                    <item>18</item>
-                    <item>19</item>
-                    <item>20</item>
-                    <item>21</item>
-                    <item>22</item>
-                    <item>23</item>
-                    <item>24</item>
-                    <item>25</item>
-                    <item>26</item>
-                    <item>27</item>
-                    <item>28</item>
-                    <item>29</item>
-                    <item>30</item>
-                  </content>
-                  <size>40,-1d</size>
-                </object>
-                <flag>wxALL|wxALIGN_CENTRE_VERTICAL</flag>
-                <border>5</border>
-              </object>
-            </object>
-          </object>
-        </object>
-        <flag>wxALL|wxEXPAND</flag>
         <border>5</border>
       </object>
       <object class="sizeritem">


### PR DESCRIPTION
In the Speedup/Turbo config panel, make frameskip the first choice,
followed by throttle, and add a warning that throttle may not work due
to vsync.

Fix throttle=0 (unlimited speed) settings for both the Speedup/Turbo
config panel and the general throttle setting and make 100 the default.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>