### PR TITLE
Fix possible SEGFAULT in SoundReset

### DIFF
--- a/src/gba/Sound.cpp
+++ b/src/gba/Sound.cpp
@@ -518,6 +518,8 @@ int soundGetEnable()
 
 void soundReset()
 {
+    if (!soundDriver)
+        return;
     soundDriver->reset();
 
     remake_stereo_buffer();


### PR DESCRIPTION
A fedora user reported a segfault that traced to the "soundDriver->reset();" line in soundReset.
I assume this is because soundDriver is probably null and there's no sound driver to reset.
I noticed you usually check if it's null before doing something, so I have it just return if there's no sound driver.

Feel free to re-implement if my assumption is wrong here.
Thanks!