### PR TITLE
Use proper functions and checks for OpenGL VSYNC.

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2220,23 +2220,32 @@ void GLDrawingPanel::DrawingPanelInit()
     glClearColor(0.0, 0.0, 0.0, 1.0);
 // non-portable vsync code
 #if defined(__WXGTK__)
+    static PFNGLXSWAPINTERVALEXTPROC glXSwapIntervalEXT = NULL;
     static PFNGLXSWAPINTERVALSGIPROC glXSwapIntervalSGI = NULL;
     static PFNGLXSWAPINTERVALMESAPROC glXSwapIntervalMESA = NULL;
 
     char* glxQuery = (char*)glXQueryExtensionsString(glXGetCurrentDisplay(), 0);
 
+    if (strstr(glxQuery, "GLX_EXT_swap_control") != NULL)
+    {
+        glXSwapIntervalEXT = reinterpret_cast<PFNGLXSWAPINTERVALEXTPROC>(glXGetProcAddress((const GLubyte*)"glXSwapIntervalEXT"));
+        if (glXSwapIntervalEXT)
+            glXSwapIntervalEXT(glXGetCurrentDisplay(), glXGetCurrentDrawable(), vsync);
+        else
+            systemScreenMessage(_("Failed to set glXSwapIntervalEXT"));
+    }
     if (strstr(glxQuery, "GLX_SGI_swap_control") != NULL)
     {
-        glXSwapIntervalSGI = reinterpret_cast<PFNGLXSWAPINTERVALSGIPROC>(glXGetProcAddress(reinterpret_cast<const unsigned char*>("glXSwapIntervalSGI")));
+        glXSwapIntervalSGI = reinterpret_cast<PFNGLXSWAPINTERVALSGIPROC>(glXGetProcAddress((const GLubyte*)("glXSwapIntervalSGI")));
 
         if (glXSwapIntervalSGI)
             glXSwapIntervalSGI(vsync);
         else
             systemScreenMessage(_("Failed to set glXSwapIntervalSGI"));
     }
-    else if (strstr(glxQuery, "GLX_MESA_swap_control") != NULL)
+    if (strstr(glxQuery, "GLX_MESA_swap_control") != NULL)
     {
-        glXSwapIntervalMESA = reinterpret_cast<PFNGLXSWAPINTERVALMESAPROC>(glXGetProcAddress(reinterpret_cast<const unsigned char*>("glXSwapIntervalMESA")));
+        glXSwapIntervalMESA = reinterpret_cast<PFNGLXSWAPINTERVALMESAPROC>(glXGetProcAddress((const GLubyte*)("glXSwapIntervalMESA")));
 
         if (glXSwapIntervalMESA)
             glXSwapIntervalMESA(vsync);


### PR DESCRIPTION
@rkitover Would you mind testing this solution for vsync? It worked on my linux (nvidia proprietary) and `Windows 10` (optimus).

I have a notebook with intel HD graphics. As soon as I finish installing Linux, I will test this there too.

I am not interested yet on changing the structure of our output module classes. I will be reviewing that soon, but I would prefer to start from zero. If you agree, I will delete the `vsync` branch.

```
The vsync has to be {dis,en}abled before a ROM is loaded or we need to
restart the output module to apply it.

We also support MESA based installations (Intel HD Graphics, AMD/ATI and
Nouveau) on Linux.
```