### PR TITLE
Hide menubar + minor UI refactor.

### DIFF
--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-12 00:19+0000\n"
+"POT-Creation-Date: 2020-04-27 20:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -155,7 +155,7 @@ msgstr ""
 msgid "VBA cheat lists (*.clt)|*.clt|CHT cheat lists (*.cht)|*.cht"
 msgstr ""
 
-#: guiinit.cpp:256 panel.cpp:417
+#: guiinit.cpp:256 panel.cpp:424
 msgid "Loaded cheats"
 msgstr ""
 
@@ -308,40 +308,40 @@ msgstr ""
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: guiinit.cpp:2998
+#: guiinit.cpp:3006
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: guiinit.cpp:3206
+#: guiinit.cpp:3214
 msgid "Code"
 msgstr ""
 
-#: guiinit.cpp:3215
+#: guiinit.cpp:3223
 msgid "Description"
 msgstr ""
 
-#: guiinit.cpp:3289 xrc/CheatAdd.xrc:31
+#: guiinit.cpp:3297 xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: guiinit.cpp:3290
+#: guiinit.cpp:3298
 msgid "Old Value"
 msgstr ""
 
-#: guiinit.cpp:3291
+#: guiinit.cpp:3299
 msgid "New Value"
 msgstr ""
 
-#: guiinit.cpp:3799
+#: guiinit.cpp:3811
 msgid "Menu commands"
 msgstr ""
 
-#: guiinit.cpp:3822
+#: guiinit.cpp:3834
 msgid "Other commands"
 msgstr ""
 
-#: guiinit.cpp:3933
+#: guiinit.cpp:3945
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -611,7 +611,7 @@ msgstr ""
 msgid "Confirm import"
 msgstr ""
 
-#: cmdevents.cpp:907 panel.cpp:360
+#: cmdevents.cpp:907 panel.cpp:367
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Wrote battery %s"
 msgstr ""
 
-#: cmdevents.cpp:1100 panel.cpp:666
+#: cmdevents.cpp:1100 panel.cpp:673
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
@@ -790,32 +790,32 @@ msgstr ""
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: cmdevents.cpp:2618
+#: cmdevents.cpp:2626
 #, c-format
 msgid "Using pixel filter #%d"
 msgstr ""
 
-#: cmdevents.cpp:2633
+#: cmdevents.cpp:2641
 #, c-format
 msgid "Using interframe blending #%d"
 msgstr ""
 
-#: cmdevents.cpp:2672 panel.cpp:176 panel.cpp:277
+#: cmdevents.cpp:2680 panel.cpp:181 panel.cpp:284
 msgid "Could not initialize the sound driver!"
 msgstr ""
 
-#: cmdevents.cpp:2764
+#: cmdevents.cpp:2772
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: cmdevents.cpp:2765
+#: cmdevents.cpp:2773
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2017 VBA-M development team"
 msgstr ""
 
-#: cmdevents.cpp:2766
+#: cmdevents.cpp:2774
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -831,35 +831,35 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: cmdevents.cpp:3061
+#: cmdevents.cpp:3069
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: cmdevents.cpp:3067
+#: cmdevents.cpp:3075
 msgid "Network is not supported in local mode."
 msgstr ""
 
-#: opts.cpp:555 opts.cpp:860
+#: opts.cpp:560 opts.cpp:865
 #, c-format
 msgid "Invalid value %s for option %s; valid values are %s%s%s"
 msgstr ""
 
-#: opts.cpp:572 opts.cpp:872
+#: opts.cpp:577 opts.cpp:877
 #, c-format
 msgid "Invalid value %d for option %s; valid values are %d - %d"
 msgstr ""
 
-#: opts.cpp:579 opts.cpp:588 opts.cpp:880 opts.cpp:888
+#: opts.cpp:584 opts.cpp:593 opts.cpp:885 opts.cpp:893
 #, c-format
 msgid "Invalid value %f for option %s; valid values are %f - %f"
 msgstr ""
 
-#: opts.cpp:648 opts.cpp:669 opts.cpp:957 opts.cpp:983
+#: opts.cpp:653 opts.cpp:674 opts.cpp:962 opts.cpp:988
 #, c-format
 msgid "Invalid key binding %s for %s"
 msgstr ""
 
-#: opts.cpp:843
+#: opts.cpp:848
 #, c-format
 msgid "Invalid flag option %s - %s ignored"
 msgstr ""
@@ -939,155 +939,155 @@ msgstr ""
 msgid "Error setting up server socket (%d)"
 msgstr ""
 
-#: panel.cpp:90
+#: panel.cpp:95
 #, c-format
 msgid "%s is not a valid ROM file"
 msgstr ""
 
-#: panel.cpp:91 panel.cpp:152 panel.cpp:215
+#: panel.cpp:96 panel.cpp:157 panel.cpp:222
 msgid "Problem loading file"
 msgstr ""
 
-#: panel.cpp:151
+#: panel.cpp:156
 #, c-format
 msgid "Unable to load Game Boy ROM %s"
 msgstr ""
 
-#: panel.cpp:191 panel.cpp:291
+#: panel.cpp:198 panel.cpp:298
 #, c-format
 msgid "Could not load BIOS %s"
 msgstr ""
 
-#: panel.cpp:214
+#: panel.cpp:221
 #, c-format
 msgid "Unable to load Game Boy Advance ROM %s"
 msgstr ""
 
-#: panel.cpp:449
+#: panel.cpp:456
 msgid " player "
 msgstr ""
 
-#: panel.cpp:614
+#: panel.cpp:621
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: panel.cpp:614
+#: panel.cpp:621
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: panel.cpp:638
+#: panel.cpp:645
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: panel.cpp:638
+#: panel.cpp:645
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: panel.cpp:842
+#: panel.cpp:849
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: panel.cpp:880
+#: panel.cpp:887
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: panel.cpp:885
+#: panel.cpp:892
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: panel.cpp:893
+#: panel.cpp:900
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: panel.cpp:897
+#: panel.cpp:904
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: panel.cpp:981
+#: panel.cpp:988
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: panel.cpp:1129
+#: panel.cpp:1146
 msgid "No memory for rewinding"
 msgstr ""
 
-#: panel.cpp:1139
+#: panel.cpp:1156
 msgid "Error writing rewind state"
 msgstr ""
 
-#: panel.cpp:2236
+#: panel.cpp:2253
 msgid "Failed to set glXSwapIntervalEXT"
 msgstr ""
 
-#: panel.cpp:2245
+#: panel.cpp:2262
 msgid "Failed to set glXSwapIntervalSGI"
 msgstr ""
 
-#: panel.cpp:2254
+#: panel.cpp:2271
 msgid "Failed to set glXSwapIntervalMESA"
 msgstr ""
 
-#: panel.cpp:2261
+#: panel.cpp:2278
 msgid "No support for wglGetExtensionsString"
 msgstr ""
 
-#: panel.cpp:2263
+#: panel.cpp:2280
 msgid "No support for WGL_EXT_swap_control"
 msgstr ""
 
-#: panel.cpp:2272
+#: panel.cpp:2289
 msgid "Failed to set wglSwapIntervalEXT"
 msgstr ""
 
-#: panel.cpp:2278
+#: panel.cpp:2295
 msgid "No VSYNC available on this platform"
 msgstr ""
 
-#: panel.cpp:2374
+#: panel.cpp:2391
 msgid "memory allocation error"
 msgstr ""
 
-#: panel.cpp:2377
+#: panel.cpp:2394
 msgid "error initializing codec"
 msgstr ""
 
-#: panel.cpp:2380
+#: panel.cpp:2397
 msgid "error writing to output file"
 msgstr ""
 
-#: panel.cpp:2383
+#: panel.cpp:2400
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: panel.cpp:2388
+#: panel.cpp:2405
 msgid "programming error; aborting!"
 msgstr ""
 
-#: panel.cpp:2400 panel.cpp:2429
+#: panel.cpp:2417 panel.cpp:2446
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: panel.cpp:2457
+#: panel.cpp:2474
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2463
+#: panel.cpp:2480
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2473
+#: panel.cpp:2490
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -3250,175 +3250,179 @@ msgstr ""
 msgid "&Key Shortcuts ..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:566
+#: xrc/MainMenu.xrc:565
+msgid "&UI Settings ..."
+msgstr ""
+
+#: xrc/MainMenu.xrc:569
 msgid "&Tools"
 msgstr ""
 
-#: xrc/MainMenu.xrc:568
+#: xrc/MainMenu.xrc:571
 msgid "&Cheats"
 msgstr ""
 
-#: xrc/MainMenu.xrc:570
+#: xrc/MainMenu.xrc:573
 msgid "List &cheats ..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:573
+#: xrc/MainMenu.xrc:576
 msgid "Find c&heat ..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:577
+#: xrc/MainMenu.xrc:580
 msgid "A&utomatically save/load cheats"
 msgstr ""
 
-#: xrc/MainMenu.xrc:581
+#: xrc/MainMenu.xrc:584
 msgid "&Enable cheats"
 msgstr ""
 
-#: xrc/MainMenu.xrc:588
+#: xrc/MainMenu.xrc:591
 msgid "&Break into GDB"
 msgstr ""
 
-#: xrc/MainMenu.xrc:592
+#: xrc/MainMenu.xrc:595
 msgid "&Configure port..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:595
+#: xrc/MainMenu.xrc:598
 msgid "&Break on load"
 msgstr ""
 
-#: xrc/MainMenu.xrc:600
+#: xrc/MainMenu.xrc:603
 msgid "&Disconnect"
 msgstr ""
 
-#: xrc/MainMenu.xrc:602
+#: xrc/MainMenu.xrc:605
 msgid "&GDB"
 msgstr ""
 
-#: xrc/MainMenu.xrc:605
+#: xrc/MainMenu.xrc:608
 msgid "&Disassemble..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:608
+#: xrc/MainMenu.xrc:611
 msgid "&Logging..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:611
+#: xrc/MainMenu.xrc:614
 msgid "&IO Viewer..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:614
+#: xrc/MainMenu.xrc:617
 msgid "&Map Viewer..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:617
+#: xrc/MainMenu.xrc:620
 msgid "M&emory Viewer..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:620
+#: xrc/MainMenu.xrc:623
 msgid "&OAM Viewer..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:623
+#: xrc/MainMenu.xrc:626
 msgid "&Palette Viewer..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:626
+#: xrc/MainMenu.xrc:629
 msgid "&Tile Viewer..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:631
+#: xrc/MainMenu.xrc:634
 msgid "Show all video layers"
 msgstr ""
 
-#: xrc/MainMenu.xrc:635
+#: xrc/MainMenu.xrc:638
 msgid "BG &0"
 msgstr ""
 
-#: xrc/MainMenu.xrc:640
+#: xrc/MainMenu.xrc:643
 msgid "BG &1"
 msgstr ""
 
-#: xrc/MainMenu.xrc:645
+#: xrc/MainMenu.xrc:648
 msgid "BG &2"
 msgstr ""
 
-#: xrc/MainMenu.xrc:650
+#: xrc/MainMenu.xrc:653
 msgid "BG &3"
 msgstr ""
 
-#: xrc/MainMenu.xrc:655
+#: xrc/MainMenu.xrc:658
 msgid "&OBJ"
 msgstr ""
 
-#: xrc/MainMenu.xrc:660
+#: xrc/MainMenu.xrc:663
 msgid "&WIN 0"
 msgstr ""
 
-#: xrc/MainMenu.xrc:665
+#: xrc/MainMenu.xrc:668
 msgid "W&IN 1"
 msgstr ""
 
-#: xrc/MainMenu.xrc:670
+#: xrc/MainMenu.xrc:673
 msgid "O&BJ WIN"
 msgstr ""
 
-#: xrc/MainMenu.xrc:674
+#: xrc/MainMenu.xrc:677
 msgid "&View Layers"
 msgstr ""
 
-#: xrc/MainMenu.xrc:678
+#: xrc/MainMenu.xrc:681
 msgid "Channel &1"
 msgstr ""
 
-#: xrc/MainMenu.xrc:683
+#: xrc/MainMenu.xrc:686
 msgid "Channel &2"
 msgstr ""
 
-#: xrc/MainMenu.xrc:688
+#: xrc/MainMenu.xrc:691
 msgid "Channel &3"
 msgstr ""
 
-#: xrc/MainMenu.xrc:693
+#: xrc/MainMenu.xrc:696
 msgid "Channel &4"
 msgstr ""
 
-#: xrc/MainMenu.xrc:698
+#: xrc/MainMenu.xrc:701
 msgid "Direct Sound &A"
 msgstr ""
 
-#: xrc/MainMenu.xrc:703
+#: xrc/MainMenu.xrc:706
 msgid "Direct Sound &B"
 msgstr ""
 
-#: xrc/MainMenu.xrc:707
+#: xrc/MainMenu.xrc:710
 msgid "&Sound Channels"
 msgstr ""
 
-#: xrc/MainMenu.xrc:711
+#: xrc/MainMenu.xrc:714
 msgid "&Help"
 msgstr ""
 
-#: xrc/MainMenu.xrc:713
+#: xrc/MainMenu.xrc:716
 msgid "Report &Bugs"
 msgstr ""
 
-#: xrc/MainMenu.xrc:716
+#: xrc/MainMenu.xrc:719
 msgid "VBA-M Support &Forum"
 msgstr ""
 
-#: xrc/MainMenu.xrc:719
+#: xrc/MainMenu.xrc:722
 msgid "Translations"
 msgstr ""
 
-#: xrc/MainMenu.xrc:727
+#: xrc/MainMenu.xrc:730
 msgid "Check for updates"
 msgstr ""
 
-#: xrc/MainMenu.xrc:730
+#: xrc/MainMenu.xrc:733
 msgid "&Factory Reset..."
 msgstr ""
 
-#: xrc/MainMenu.xrc:734
+#: xrc/MainMenu.xrc:737
 msgid "&About..."
 msgstr ""
 
@@ -3700,4 +3704,12 @@ msgstr ""
 
 #: xrc/SpeedupConfig.xrc:84
 msgid "Frame skip"
+msgstr ""
+
+#: xrc/UIConfig.xrc:4
+msgid "User Interface Settings"
+msgstr ""
+
+#: xrc/UIConfig.xrc:9
+msgid "Hide Menu Bar"
 msgstr ""

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -623,6 +623,7 @@ set(
     xrc/SoundConfig.xrc
     xrc/TileViewer.xrc
     xrc/SpeedupConfig.xrc
+    xrc/UIConfig.xrc
 )
 
 # wxrc does not support xrs files in -c output (> 10x compression)

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2326,6 +2326,14 @@ EVT_HANDLER(SpeedupConfigure, "Speedup / Turbo options...")
         update_opts();
 }
 
+EVT_HANDLER(UIConfigure, "UI Settings...")
+{
+    wxDialog* dlg = GetXRCDialog("UIConfig");
+
+    if (ShowModal(dlg) == wxID_OK)
+        update_opts();
+}
+
 EVT_HANDLER(GameBoyConfigure, "Game Boy options...")
 {
     wxDialog* dlg = GetXRCDialog("GameBoyConfig");

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2907,14 +2907,22 @@ bool MainFrame::BindControls()
         // remove this item from the menu completely
         wxMenuItem* gdbmi = XRCITEM("GDBMenu");
         gdbmi->GetMenu()->Remove(gdbmi);
-        gdbmi = NULL;
+        gdbmi = nullptr;
 #endif
 #ifdef NO_LINK
         // remove this item from the menu completely
         wxMenuItem* linkmi = XRCITEM("LinkMenu");
         linkmi->GetMenu()->Remove(linkmi);
-        linkmi = NULL;
+        linkmi = nullptr;
 #endif
+
+#ifdef __WXMAC__
+        // Remove UI Config menu item, because it only has an option that does nothing on mac.
+        wxMenuItem* ui_config_mi = XRCITEM("UIConfigure");
+        ui_config_mi->GetMenu()->Remove(ui_config_mi);
+        ui_config_mi = nullptr;
+#endif
+
 
         // if a recent menu is present, save its location
         wxMenuItem* recentmi = XRCITEM("RecentMenu");
@@ -3424,6 +3432,10 @@ bool MainFrame::BindControls()
             d->Connect(wxEVT_SHOW, wxShowEventHandler(SpeedupThrottleCtrl_t::Init),
                 NULL, &speedup_throttle_ctrl);
             d->Fit();
+        }
+        d = LoadXRCDialog("UIConfig");
+        {
+            getcbb("HideMenuBar", gopts.hide_menu_bar);
         }
 #define getcbbe(n, o) getbe(n, o, cb, wxCheckBox, CB)
         wxBoolIntEnValidator* bienval;

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -306,6 +306,9 @@ opt_desc opts[] = {
     INTOPT("geometry/windowX", "X", wxTRANSLATE("Window axis X position at startup"), windowPositionX, -1, 99999),
     INTOPT("geometry/windowY", "Y", wxTRANSLATE("Window axis Y position at startup"), windowPositionY, -1, 99999),
 
+    /// UI
+    BOOLOPT("ui/hideMenuBar", "", wxTRANSLATE("Hide menu bar when mouse is inactive"), gopts.hide_menu_bar),
+
     /// Sound
     ENUMOPT("Sound/AudioAPI", "", wxTRANSLATE("Sound API; if unsupported, default API will be used"), gopts.audio_api, wxTRANSLATE("sdl|openal|directsound|xaudio2|faudio")),
     STROPT("Sound/AudioDevice", "", wxTRANSLATE("Device ID of chosen audio device for chosen driver"), gopts.audio_dev),
@@ -366,6 +369,8 @@ opts_t::opts_t()
     link_host = "127.0.0.1";
     server_ip = "*";
     link_port = 5738;
+
+    hide_menu_bar = true;
 }
 
 // for binary_search() and friends

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -84,6 +84,9 @@ extern struct opts_t {
     /// Recent
     wxFileHistory* recent;
 
+    /// UI Config
+    bool hide_menu_bar;
+
     /// wxWindows
     // wxWidgets-generated options (opaque)
 } gopts;

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -305,7 +305,7 @@ public:
     // call this to update the viewers once a frame:
     void UpdateViewers();
 
-    virtual bool MenusOpened() { return menus_opened != 0; }
+    virtual bool MenusOpened() { return menus_opened; }
 
     virtual void SetMenusOpened(bool state);
 
@@ -315,7 +315,7 @@ public:
 
     bool IsPaused(bool incendental = false)
     {
-        return (paused && !pause_next && !incendental) || menus_opened || dialog_opened;
+        return (paused && !pause_next && !incendental) || dialog_opened;
     }
 
     void PollJoysticks() { joy.Poll(); }
@@ -331,9 +331,8 @@ protected:
 private:
     GameArea* panel;
 
-    // the various reasons the game might be paused
-    bool paused;
-    int menus_opened, dialog_opened;
+    bool paused, menus_opened;
+    int dialog_opened;
 
     bool autoLoadMostRecent;
     // copy of top-level menu bar as a context menu
@@ -473,6 +472,11 @@ enum audioapi { AUD_SDL,
 #define OSD_TIME 3000
 
 class DrawingPanelBase;
+
+#ifdef __WXMSW__
+// For saving menu handle.
+#include <windows.h>
+#endif
 
 class GameArea : public wxPanel, public HiDPIAware {
 public:
@@ -628,14 +632,16 @@ protected:
 public:
     void ShowPointer();
     void HidePointer();
+    void HideMenuBar();
+    void ShowMenuBar();
 
 protected:
-    void MouseEvent(wxMouseEvent&)
-    {
-        ShowPointer();
-    }
-    bool pointer_blanked;
+    void MouseEvent(wxMouseEvent&);
+    bool pointer_blanked, menu_bar_hidden = false;
     uint32_t mouse_active_time;
+#ifdef __WXMSW__
+    HMENU current_hmenu = nullptr;
+#endif
 
     DECLARE_DYNAMIC_CLASS(GameArea)
     DECLARE_EVENT_TABLE()

--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -561,6 +561,9 @@
         <object class="wxMenuItem" name="Customize">
           <label>_Key Shortcuts ...</label>
         </object>
+        <object class="wxMenuItem" name="UIConfigure">
+          <label>_UI Settings ...</label>
+        </object>
     </object>
     <object class="wxMenu">
       <label>_Tools</label>

--- a/src/wx/xrc/UIConfig.xrc
+++ b/src/wx/xrc/UIConfig.xrc
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">
+  <object class="wxDialog" name="UIConfig">
+    <title>User Interface Settings</title>
+    <object class="wxBoxSizer">
+      <orient>wxVERTICAL</orient>
+      <object class="sizeritem">
+        <object class="wxCheckBox" name="HideMenuBar">
+          <label>Hide Menu Bar</label>
+        </object>
+        <flag>wxALL</flag>
+        <border>5</border>
+      </object>
+      <object class="sizeritem">
+        <flag>wxALL|wxEXPAND</flag>
+        <border>5</border>
+        <object class="wxStdDialogButtonSizer">
+          <object class="button">
+            <object class="wxButton" name="wxID_OK"/>
+          </object>
+          <object class="button">
+            <object class="wxButton" name="wxID_CANCEL"/>
+          </object>
+        </object>
+      </object>
+    </object>
+  </object>
+</resource>


### PR DESCRIPTION
Add ui/hideMenuBar boolean option, defaulting to on, which hides the
main menubar when the mouse is idle or outside the frame.

This is disabled on mac, because on macs the main menubar is not part of
the application window.

Fix pointer hiding/unhiding by connecting panel events to the gamearea
mouse event handler.

Clean up the pausing when menus are opened code, make it actually work
on Windows.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>