### PR TITLE
Fix changing aspect ratio option.

### DIFF
--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2818,6 +2818,13 @@ EVT_HANDLER(Bilinear, "Use bilinear filter with 3d renderer")
 EVT_HANDLER(RetainAspect, "Retain aspect ratio when resizing")
 {
     GetMenuOptionBool("RetainAspect", gopts.retain_aspect);
+
+    // Force new panel with new aspect ratio options.
+    if (panel->panel) {
+        panel->panel->Destroy();
+        panel->panel = nullptr;
+    }
+
     update_opts();
 }
 

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1052,21 +1052,25 @@ void GameArea::OnIdle(wxIdleEvent& event)
         AdjustMinSize();
         AdjustSize(false);
 
-        unsigned frame_priority = 0;
+        unsigned frame_priority = gopts.retain_aspect ? 0 : 1;
+
+        GetSizer()->Clear();
 
         // add spacers on top and bottom to center panel vertically
         // but not on 2.8 which does not handle this correctly
+        if (gopts.retain_aspect)
 #if wxCHECK_VERSION(2, 9, 0)
-        GetSizer()->Add(0, 0, wxEXPAND);
+            GetSizer()->Add(0, 0, wxEXPAND);
 #else
-        frame_priority = 1;
+            frame_priority = 1;
 #endif
 
         // this triggers an assertion dialog in <= 3.1.2 in debug mode
         GetSizer()->Add(w, frame_priority, gopts.retain_aspect ? (wxSHAPED | wxALIGN_CENTER | wxEXPAND) : wxEXPAND);
 
 #if wxCHECK_VERSION(2, 9, 0)
-        GetSizer()->Add(0, 0, wxEXPAND);
+        if (gopts.retain_aspect)
+            GetSizer()->Add(0, 0, wxEXPAND);
 #endif
 
         Layout();


### PR DESCRIPTION
When toggling "retain aspect ratio", destroy the drawing panel so it is
recreated with the desired aspect ratio settings.

Only add the vertical spacers when aspect ratio is on, they are not
needed when it's off.

Set the sizer priority of the DrawingPanel to 1 if aspect ratio is off
so that wxEXPAND always works.

Clear the GameArea sizer when attaching a new DrawingPanel, this is so
that the vertical spacers used when aspect ratio is on are not included
when aspect ratio is off.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>