### PR TITLE
Joystick refactor pt. Deux: Support Joysticks.

### DIFF
--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-27 20:23+0000\n"
+"POT-Creation-Date: 2020-05-04 01:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -831,11 +831,11 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: cmdevents.cpp:3069
+#: cmdevents.cpp:3076
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: cmdevents.cpp:3075
+#: cmdevents.cpp:3082
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -1016,78 +1016,78 @@ msgstr ""
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: panel.cpp:1146
+#: panel.cpp:1150
 msgid "No memory for rewinding"
 msgstr ""
 
-#: panel.cpp:1156
+#: panel.cpp:1160
 msgid "Error writing rewind state"
 msgstr ""
 
-#: panel.cpp:2253
+#: panel.cpp:2257
 msgid "Failed to set glXSwapIntervalEXT"
 msgstr ""
 
-#: panel.cpp:2262
+#: panel.cpp:2266
 msgid "Failed to set glXSwapIntervalSGI"
 msgstr ""
 
-#: panel.cpp:2271
+#: panel.cpp:2275
 msgid "Failed to set glXSwapIntervalMESA"
 msgstr ""
 
-#: panel.cpp:2278
+#: panel.cpp:2282
 msgid "No support for wglGetExtensionsString"
 msgstr ""
 
-#: panel.cpp:2280
+#: panel.cpp:2284
 msgid "No support for WGL_EXT_swap_control"
 msgstr ""
 
-#: panel.cpp:2289
+#: panel.cpp:2293
 msgid "Failed to set wglSwapIntervalEXT"
 msgstr ""
 
-#: panel.cpp:2295
+#: panel.cpp:2299
 msgid "No VSYNC available on this platform"
 msgstr ""
 
-#: panel.cpp:2391
+#: panel.cpp:2395
 msgid "memory allocation error"
 msgstr ""
 
-#: panel.cpp:2394
+#: panel.cpp:2398
 msgid "error initializing codec"
 msgstr ""
 
-#: panel.cpp:2397
+#: panel.cpp:2401
 msgid "error writing to output file"
 msgstr ""
 
-#: panel.cpp:2400
+#: panel.cpp:2404
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: panel.cpp:2405
+#: panel.cpp:2409
 msgid "programming error; aborting!"
 msgstr ""
 
-#: panel.cpp:2417 panel.cpp:2446
+#: panel.cpp:2421 panel.cpp:2450
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: panel.cpp:2474
+#: panel.cpp:2478
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2480
+#: panel.cpp:2484
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2490
+#: panel.cpp:2494
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -1148,14 +1148,24 @@ msgstr ""
 msgid "CONTROL"
 msgstr ""
 
-#: widgets/sdljoy.cpp:115
+#: widgets/sdljoy.cpp:129
 #, c-format
 msgid "Connected game controller %d"
 msgstr ""
 
-#: widgets/sdljoy.cpp:129
+#: widgets/sdljoy.cpp:143
 #, c-format
 msgid "Disconnected game controller %d"
+msgstr ""
+
+#: widgets/sdljoy.cpp:229
+#, c-format
+msgid "Connected joystick %d"
+msgstr ""
+
+#: widgets/sdljoy.cpp:246
+#, c-format
+msgid "Disconnected joystick %d"
 msgstr ""
 
 #: xaudio2.cpp:35

--- a/src/wx/widgets/joyedit.cpp
+++ b/src/wx/widgets/joyedit.cpp
@@ -68,7 +68,18 @@ int wxJoyKeyTextCtrl::DigitalButton(wxSDLJoyEvent& event)
 
 void wxJoyKeyTextCtrl::OnJoy(wxSDLJoyEvent& event)
 {
-    short val = event.GetControlValue();
+    static wxLongLong last_event = 0;
+
+    int val  = event.GetControlValue();
+    int type = event.GetControlType();
+
+    // Filter consecutive axis motions within 300ms, as this adds two bindings
+    // +1/-1 instead of the one intended.
+    if (type == WXSDLJOY_AXIS && wxGetUTCTimeMillis() - last_event < 300)
+        return;
+
+    last_event = wxGetUTCTimeMillis();
+
     int mod = DigitalButton(event);
     int key = event.GetControlIndex(), joy = event.GetJoy() + 1;
 

--- a/src/wx/widgets/wx/sdljoy.h
+++ b/src/wx/widgets/wx/sdljoy.h
@@ -9,19 +9,39 @@
 //
 //   The target window will receive EVT_SDLJOY events of type wxSDLJoyEvent.
 
+#include <cstddef>
 #include <array>
 #include <vector>
 #include <unordered_map>
 #include <wx/time.h>
 #include <wx/event.h>
 #include <wx/timer.h>
+#include <SDL_joystick.h>
 #include <SDL_gamecontroller.h>
 #include "../common/contains.h"
 
+struct wxSDLJoyDev {
+    private:
+        union {
+            SDL_GameController* dev_gc = nullptr;
+            SDL_Joystick*       dev_js;
+        };
+    public:
+        operator SDL_GameController*&();
+        SDL_GameController*& operator=(SDL_GameController* ptr);
+
+        operator SDL_Joystick*&();
+        SDL_Joystick*& operator=(SDL_Joystick* ptr);
+
+        operator bool();
+
+        std::nullptr_t& operator=(std::nullptr_t&& null_ptr);
+};
+
 struct wxSDLJoyState {
-    SDL_GameController* dev = nullptr;
-    std::array<int16_t, SDL_CONTROLLER_AXIS_MAX>   axis{};
-    std::array<uint8_t, SDL_CONTROLLER_BUTTON_MAX> button{};
+    wxSDLJoyDev dev;
+    std::unordered_map<uint8_t, int16_t> axis{};
+    std::unordered_map<uint8_t, uint8_t> button{};
 };
 
 class wxSDLJoy : public wxTimer {


### PR DESCRIPTION
Add support for non-GameController SDL Joysticks.

Add proxy class wxSDLJoyDev to support using either SDL_GameController*
or SDL_Joystick* values in joystate.dev.

Add pretty much identical SDL code to support SDL_Joystick* when the
device cannot be opened as an SDL_GameController*, without changing the
API. SDL_Joystick* devices operate almost identically to SDL_Controller*
devices with their own default mappings, for both events and polling.

Filter axis motion events in the bindings editor widget for subsequent
events within 300ms. This gets rid of the double binding for +1/-1 when
the stick is moved to a direction.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>