### PR TITLE
Decrease mouse sensitivity for menu hiding.

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2501,8 +2501,15 @@ void GameArea::MouseEvent(wxMouseEvent& ev)
 {
     mouse_active_time = systemGetClock();
 
-    ShowPointer();
-    ShowMenuBar();
+    wxPoint cur_pos = wxGetMousePosition();
+
+    // Ignore small movements.
+    if (!ev.Moving() || (std::abs(cur_pos.x - mouse_last_pos.x) >= 11 && std::abs(cur_pos.y - mouse_last_pos.y) >= 11)) {
+        ShowPointer();
+        ShowMenuBar();
+    }
+
+    mouse_last_pos = cur_pos;
 
     ev.Skip();
 }

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -639,6 +639,7 @@ protected:
     void MouseEvent(wxMouseEvent&);
     bool pointer_blanked, menu_bar_hidden = false;
     uint32_t mouse_active_time;
+    wxPoint mouse_last_pos;
 #ifdef __WXMSW__
     HMENU current_hmenu = nullptr;
 #endif


### PR DESCRIPTION
Ignore mouse movements of less than 11 pixels, to avoid spurious events
from mice in high DPI mode etc..

- Fix #675.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>