### PR TITLE
Follow up on #671.

### DIFF
--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -1085,14 +1085,6 @@ void gbWriteMemory(uint16_t address, uint8_t value)
                 gbSerialOn = 0;
                 gbMemory[0xff0f] = register_IF |= 8;
             }
-#ifdef OLD_GB_LINK
-            if (linkConnected) {
-                if (value & 1) {
-                    linkSendByte(0x100 | gbMemory[0xFF01]);
-                    Sleep(5);
-                }
-            }
-#endif
         }
 
         gbSerialBits = 0;

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -1060,36 +1060,37 @@ void gbWriteMemory(uint16_t address, uint8_t value)
     case 0x02: {
         gbSerialOn = (value & 0x80);
 #ifndef NO_LINK
-        //trying to detect whether the game has exited multiplay mode, pokemon blue start w/ 0x7e while pocket racing start w/ 0x7c
+        // trying to detect whether the game has exited multiplay mode, pokemon blue start w/ 0x7e while pocket racing start w/ 0x7c
         if (EmuReseted || (gbMemory[0xff02] & 0x7c) || (value & 0x7c) || (!(value & 0x81))) {
             LinkFirstTime = true;
         }
         EmuReseted = false;
         gbMemory[0xff02] = value;
-        if (gbSerialOn && (GetLinkMode() == LINK_GAMEBOY_IPC || GetLinkMode() == LINK_GAMEBOY_SOCKET
-        || GetLinkMode() == LINK_DISCONNECTED || winGbPrinterEnabled)) {
-
+#else
+        gbMemory[0xff02] = value;
+#endif // NO_LINK
+        if (gbSerialOn) {
             gbSerialTicks = GBSERIAL_CLOCK_TICKS;
-
+#ifndef NO_LINK
             LinkIsWaiting = true;
-
-            //Do data exchange, master initiate the transfer
-            //may cause visual artifact if not processed immediately, is it due to IRQ stuff or invalid data being exchanged?
-            if ((value & 1)) { //internal clock
-                if (gbSerialFunction) {
+            // May cause visual artifact if not processed immediately,
+            // is it due to IRQ stuff or invalid data being exchanged?
+            if (gbMemory[0xff02] & 1) {
+                if (gbSerialFunction && winGbPrinterEnabled) {
                     gbSIO_SC = value;
-                    gbMemory[0xff01] = gbSerialFunction(gbMemory[0xff01]); //gbSerialFunction/gbStartLink/gbPrinter
-                } else
-                    gbMemory[0xff01] = 0xff;
-                gbMemory[0xff02] &= 0x7f;
-                gbSerialOn = 0;
-                gbMemory[0xff0f] = register_IF |= 8;
+                    gbMemory[0xff01] = gbSerialFunction(gbMemory[0xff01]);
+                    gbMemory[0xff02] &= 0x7f;
+                    gbSerialOn = 0;
+                    gbMemory[0xff0f] = register_IF |= 8;
+                }
             }
+#else
+            LinkIsWaiting = false;
+#endif // NO_LINK
         }
 
         gbSerialBits = 0;
         return;
-#endif
     }
 
     case 0x04: {
@@ -5239,88 +5240,69 @@ void gbEmulate(int ticksToStop)
         static int SIOctr = 0;
         SIOctr++;
         if (SIOctr % 5)
-            //Transfer Started
-            if (gbSerialOn && (GetLinkMode() == LINK_GAMEBOY_IPC || GetLinkMode() == LINK_GAMEBOY_SOCKET)) {
-#ifdef OLD_GB_LINK
-                if (linkConnected) {
-                    gbSerialTicks -= clockTicks;
+        if (gbSerialOn) {
+            if(gbMemory[0xff02] & 1) { //internal clocks (master)
+                gbSerialTicks -= clockTicks;
+                // overflow
+                while (gbSerialTicks <= 0) {
+                    // shift serial byte to right and put a 1 bit in its place
+                    //      gbMemory[0xff01] = 0x80 | (gbMemory[0xff01]>>1);
+                    // increment number of shifted bits
+                    gbSerialBits++;
+                    if (gbSerialBits >= 8) {
+                        // end of transmission
+                        gbSerialTicks = 0;
+                        gbSerialBits = 0;
 
-                    while (gbSerialTicks <= 0) {
-                        // increment number of shifted bits
-                        gbSerialBits++;
-                        linkProc();
-                        if (gbSerialOn && (gbMemory[0xff02] & 1)) {
-                            if (gbSerialBits == 8) {
-                                gbSerialBits = 0;
+                        if (!winGbPrinterEnabled) {
+                            if (gbSerialFunction) // external device
+                                gbMemory[0xff01] = gbSerialFunction(gbMemory[0xff01]);
+                            else
                                 gbMemory[0xff01] = 0xff;
-                                gbMemory[0xff02] &= 0x7f;
-                                gbSerialOn = 0;
-                                gbMemory[0xff0f] = register_IF |= 8;
-                                gbSerialTicks = 0;
-                            }
-                        }
-                        gbSerialTicks += GBSERIAL_CLOCK_TICKS;
-                    }
-                } else {
-#endif
-                    if (gbMemory[0xff02] & 1) { //internal clocks (master)
-                        gbSerialTicks -= clockTicks;
-
-                        // overflow
-                        while (gbSerialTicks <= 0) {
-                            // shift serial byte to right and put a 1 bit in its place
-                            //      gbMemory[0xff01] = 0x80 | (gbMemory[0xff01]>>1);
-                            // increment number of shifted bits
-                            gbSerialBits++;
-                            if (gbSerialBits >= 8) {
-                                // end of transmission
-                                gbSerialTicks = 0;
-                                gbSerialBits = 0;
-                            } else
-                                gbSerialTicks += GBSERIAL_CLOCK_TICKS;
-                        }
-                    } else //external clocks (slave)
-                    {
-                        gbSerialTicks -= clockTicks;
-
-                        // overflow
-                        while (gbSerialTicks <= 0) {
-                            // shift serial byte to right and put a 1 bit in its place
-                            //      gbMemory[0xff01] = 0x80 | (gbMemory[0xff01]>>1);
-                            // increment number of shifted bits
-                            gbSerialBits++;
-                            if (gbSerialBits >= 8) {
-                                // end of transmission
-                                uint16_t dat = 0;
-                                if (LinkIsWaiting)
-                                    if (gbSerialFunction) { // external device
-                                        gbSIO_SC = gbMemory[0xff02];
-                                        if (!LinkFirstTime) {
-                                            dat = (gbSerialFunction(gbMemory[0xff01]) << 8) | 1;
-                                        } else //external clock not suppose to start a transfer, but there are time where both side using external clock and couldn't communicate properly
-                                        {
-                                            if (gbMemory)
-                                                gbSerialOn = (gbMemory[0xff02] & 0x80);
-                                            dat = gbLinkUpdate(gbMemory[0xff01], gbSerialOn);
-                                        }
-                                        gbMemory[0xff01] = (dat >> 8);
-                                    } //else
-                                gbSerialTicks = 0;
-                                if ((dat & 1) && (gbMemory[0xff02] & 0x80)) //(dat & 1)==1 when reply data received
-                                {
-                                    gbMemory[0xff02] &= 0x7f;
-                                    gbSerialOn = 0;
-                                    gbMemory[0xff0f] = register_IF |= 8;
-                                }
-                                gbSerialBits = 0;
-                            } else
-                                gbSerialTicks += GBSERIAL_CLOCK_TICKS;
+                            gbMemory[0xff02] &= 0x7f;
+                            gbSerialOn = 0;
+                            register_IF |= 8;
                         }
                     }
-#ifdef OLD_GB_LINK
+                    else gbSerialTicks += GBSERIAL_CLOCK_TICKS;
                 }
-#endif
             }
+            else //external clocks (slave)
+            {
+                gbSerialTicks -= clockTicks;
+                // overflow
+                while (gbSerialTicks <= 0) {
+                    // shift serial byte to right and put a 1 bit in its place
+                    //      gbMemory[0xff01] = 0x80 | (gbMemory[0xff01]>>1);
+                    // increment number of shifted bits
+                    gbSerialBits++;
+                    if (gbSerialBits >= 8) {
+                        // end of transmission
+                        uint16_t dat = 0;
+                        if (LinkIsWaiting)
+                            if (gbSerialFunction) { // external device
+                                gbSIO_SC = gbMemory[0xff02];
+                                if (!LinkFirstTime) {
+                                    dat = (gbSerialFunction(gbMemory[0xff01]) << 8) | 1;
+                                }
+                                else { //external clock not suppose to start a transfer, but there are time where both side using external clock and couldn't communicate properly
+			            gbSerialOn = (gbMemory[0xff02] & 0x80);
+			            dat = gbLinkUpdate(gbMemory[0xff01], gbSerialOn);
+			        }
+			        gbMemory[0xff01] = (dat >> 8);
+                            }
+                        gbSerialTicks = 0;
+                        if ((dat & 1) && (gbMemory[0xff02] & 0x80)) {
+                            gbMemory[0xff02] &= 0x7f;
+                            gbSerialOn = 0;
+                            gbMemory[0xff0f] = register_IF |= 8;
+                        }
+                        gbSerialBits = 0;
+                    }
+                    else gbSerialTicks += GBSERIAL_CLOCK_TICKS;
+                }
+            }
+	}
 #endif
         // TODO: evaluate and fix this
         // On VBA-M (gb core running twice as fast?), each vblank is uses 35112 cycles.

--- a/src/gb/gbGfx.cpp
+++ b/src/gb/gbGfx.cpp
@@ -231,7 +231,7 @@ void gbRenderLine()
 
             if (y >= inUseRegister_WY) {
 
-                if ((gbWindowLine == -1) || (gbWindowLine > 144))
+                if ((gbWindowLine == -1) /*|| (gbWindowLine > 144)*/)
                     gbWindowLine = 0;
 
                 int wx = register_WX;

--- a/src/gb/gbGfx.cpp
+++ b/src/gb/gbGfx.cpp
@@ -433,7 +433,7 @@ void gbDrawSpriteTile(int tile, int x, int y, int t, int flags,
     int a = 0;
     int b = 0;
 
-    if (gbCgbMode && (flags & 0x08)) {
+    if (gbCgbMode && (flags & 0x08) && !(gbMemory[0xff6c] & 1)) {
         a = bank1[address++];
         b = bank1[address++];
     } else {

--- a/src/gb/gbSGB.cpp
+++ b/src/gb/gbSGB.cpp
@@ -690,7 +690,7 @@ void gbSgbMultiRequest()
             gbSgbFourPlayers = 1;
         else
             gbSgbFourPlayers = 0;
-        gbSgbNextController = 0x0e;
+        gbSgbNextController = 0x0f;
     } else {
         gbSgbFourPlayers = 0;
         gbSgbMultiplayer = 0;

--- a/src/gb/gbSound.cpp
+++ b/src/gb/gbSound.cpp
@@ -104,7 +104,7 @@ static void reset_apu()
     Gb_Apu::mode_t mode = Gb_Apu::mode_dmg;
     if (gbHardware & 2)
         mode = Gb_Apu::mode_cgb;
-    if (gbHardware & 8 || declicking)
+    else if (gbHardware & 8)
         mode = Gb_Apu::mode_agb;
     gb_apu->reset(mode);
     gb_apu->reduce_clicks(declicking);

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2847,15 +2847,11 @@ EVT_HANDLER(RetainAspect, "Retain aspect ratio when resizing")
 EVT_HANDLER(Printer, "Enable printer emulation")
 {
     GetMenuOptionInt("Printer", winGbPrinterEnabled, 1);
-#if (defined __WIN32__ || defined _WIN32)
-#ifndef NO_LINK
-    gbSerialFunction = gbStartLink;
-#else
-    gbSerialFunction = NULL;
-#endif
-#endif
+
     if (winGbPrinterEnabled)
         gbSerialFunction = gbPrinterSend;
+    else
+        gbSerialFunction = NULL;
 
     update_opts();
 }

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1318,7 +1318,6 @@ void GameArea::OnKeyDown(wxKeyEvent& ev)
     if (process_key_press(true, kc, ev.GetModifiers())) {
         wxWakeUpIdle();
     }
-    ev.Skip();
 }
 
 void GameArea::OnKeyUp(wxKeyEvent& ev)

--- a/src/wx/wxutil.cpp
+++ b/src/wx/wxutil.cpp
@@ -6,8 +6,17 @@ int getKeyboardKeyCode(wxKeyEvent& event)
 {
     int uc = event.GetUnicodeKey();
     if (uc != WXK_NONE) {
-        if (uc < 32)
-            return WXK_NONE;
+        if (uc < 32) { // not all control chars
+            switch (uc) {
+                case WXK_BACK:
+                case WXK_TAB:
+                case WXK_RETURN:
+                case WXK_ESCAPE:
+                    return uc;
+                default:
+                    return WXK_NONE;
+            }
+        }
         return uc;
     }
     else {

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -852,7 +852,8 @@ int MainFrame::FilterEvent(wxEvent& event)
         int keyMod = ke.GetModifiers();
         wxAcceleratorEntry_v accels = wxGetApp().GetAccels();
         for (size_t i = 0; i < accels.size(); ++i)
-             if (keyCode == accels[i].GetKeyCode() && keyMod == accels[i].GetFlags())
+             if (keyCode == accels[i].GetKeyCode() && keyMod == accels[i].GetFlags()
+                 && accels[i].GetCommand() != XRCID("NOOP"))
              {
                  wxCommandEvent evh(wxEVT_COMMAND_MENU_SELECTED, accels[i].GetCommand());
                  evh.SetEventObject(this);


### PR DESCRIPTION
@rkitover The tests should be:

- [ ] unicode key as accel/input (`Ç`)
- [ ] normal/ASCII key as accel/input (`L`)
- [ ] special chars as accel/input (`TAB`, `CTRL`, `BACKSPACE`, `ENTER`)
- [ ] keys combinations as accel (`CTRL+Ç`, `ALT+A`) (No reason for this as input, unless this is a regression for something I changed)
- [ ] set a default keybinding to another input/accel (`KP_ENTER`,  `KP_ADD`)
- [ ] set a key to both accel/input: the accel should have priority over the input

I decided to write this here so I can remember/document what I tested. Please edit/add if you see something missing.
