### PR TITLE
Input followup

### DIFF
--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2124,7 +2124,7 @@ public:
             if ((sys_accels[i].GetFlags() == selmod && sys_accels[i].GetKeyCode() == selkey)
                 || (seljoy != 0 && sys_accels[i].GetUkey() == selstr)) // joystick system bindings?
             {
-                wxAcceleratorEntryUnicode ne(sys_accels[i].GetUkey(), sys_accels[i].GetJoystick(), selmod, selkey, XRCID("NOOP"));
+                wxAcceleratorEntryUnicode ne(selstr, seljoy, selmod, selkey, XRCID("NOOP"));
                 user_accels.push_back(ne);
             }
 
@@ -2597,6 +2597,7 @@ void MainFrame::set_global_accels()
         // the last is chosen so menu overrides non-menu and user overrides
         // system
         int cmd = cmdtab[i].cmd_id;
+        if (cmd == XRCID("NOOP")) continue;
         int last_accel = -1;
 
         for (size_t j = 0; j < accels.size(); ++j)

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1318,7 +1318,6 @@ void GameArea::OnKeyDown(wxKeyEvent& ev)
     if (process_key_press(true, kc, ev.GetModifiers())) {
         wxWakeUpIdle();
     }
-    ev.Skip();
 }
 
 void GameArea::OnKeyUp(wxKeyEvent& ev)

--- a/src/wx/wxhead.h
+++ b/src/wx/wxhead.h
@@ -68,7 +68,7 @@
 static inline void DoSetAccel(wxMenuItem* mi, wxAcceleratorEntryUnicode* acc)
 {
     // cannot use SDL keybinding as text without wx assertion error
-    if (!acc || acc->GetJoystick() != 0) return;
+    if (acc && acc->GetJoystick() != 0) return;
 
     wxString lab = mi->GetItemLabel();
     size_t tab = lab.find(wxT('\t'));

--- a/src/wx/wxutil.cpp
+++ b/src/wx/wxutil.cpp
@@ -6,8 +6,17 @@ int getKeyboardKeyCode(wxKeyEvent& event)
 {
     int uc = event.GetUnicodeKey();
     if (uc != WXK_NONE) {
-        if (uc < 32)
-            return WXK_NONE;
+        if (uc < 32) { // not all control chars
+            switch (uc) {
+                case WXK_BACK:
+                case WXK_TAB:
+                case WXK_RETURN:
+                case WXK_ESCAPE:
+                    return uc;
+                default:
+                    return WXK_NONE;
+            }
+        }
         return uc;
     }
     else {

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -852,7 +852,8 @@ int MainFrame::FilterEvent(wxEvent& event)
         int keyMod = ke.GetModifiers();
         wxAcceleratorEntry_v accels = wxGetApp().GetAccels();
         for (size_t i = 0; i < accels.size(); ++i)
-             if (keyCode == accels[i].GetKeyCode() && keyMod == accels[i].GetFlags())
+             if (keyCode == accels[i].GetKeyCode() && keyMod == accels[i].GetFlags()
+                 && accels[i].GetCommand() != XRCID("NOOP"))
              {
                  wxCommandEvent evh(wxEVT_COMMAND_MENU_SELECTED, accels[i].GetCommand());
                  evh.SetEventObject(this);


### PR DESCRIPTION
@rkitover Now it is correct.

The tests should be:

- [x] unicode key as accel/input (`Ç`)
- [x] normal/ASCII key as accel/input (`L`)
- [x] special chars as accel/input (`TAB`, `CTRL`, `BACKSPACE`, `ENTER`)
- [x] keys combinations as accel (`CTRL+Ç`, `ALT+A`) (No reason for this as input, unless this is a regression for something I changed)
- [x] set a default keybinding to another input/accel (`KP_ENTER`,  `KP_ADD`)
- [x] set a key to both accel/input: the accel should have priority over the input
- [x] `SPACE` and `DELETE` also work as both game input and accels

I decided to write this here so I can remember/document what I tested. Please edit/add if you see something missing.