### PR TITLE
Initial support for GC and Switch controllers.

### DIFF
--- a/src/wx/widgets/wx/sdljoy.h
+++ b/src/wx/widgets/wx/sdljoy.h
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <array>
 #include <vector>
+#include <string>
 #include <unordered_map>
 #include <wx/time.h>
 #include <wx/event.h>
@@ -41,6 +42,7 @@ struct wxSDLJoyState {
     wxSDLJoyDev dev;
     uint8_t index = 0;
     bool is_gc = true;
+    std::string name;
     SDL_JoystickID instance = 0;
     std::unordered_map<uint8_t, int16_t> axis{};
     std::unordered_map<uint8_t, uint8_t> button{};


### PR DESCRIPTION
Add the capability to treat some GameController devices as joysticks,
because they only send joystick events.

Make a set of names, as returned by SDL, with the names for the Switch
Pro controller and the Mayflash GameCube adapter and use them as
joysticks, filtering out GameController events for them.

Do some minor refactoring and improvements as well, like using the
`is_gc` bool member of state instead of calling
`SDL_IsGameController()`.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>