### PR TITLE
Refactor wxSDLJoy

### DIFF
--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-05 19:36+0000\n"
+"POT-Creation-Date: 2020-09-05 21:42-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1156,17 +1156,7 @@ msgstr ""
 msgid "CONTROL"
 msgstr ""
 
-#: widgets/sdljoy.cpp:122
-#, c-format
-msgid "Connected game controller %d: %s"
-msgstr ""
-
-#: widgets/sdljoy.cpp:137
-#, c-format
-msgid "Disconnected game controller %d"
-msgstr ""
-
-#: widgets/sdljoy.cpp:214
+#: widgets/sdljoy.cpp:107
 #, c-format
 msgid "Connected joystick %d: %s"
 msgstr ""

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2736,7 +2736,7 @@ EVT_HANDLER(EmulatorDirectories, "Directories...")
 EVT_HANDLER(JoypadConfigure, "Joypad options...")
 {
     wxDialog* dlg = GetXRCDialog("JoypadConfig");
-    joy.Add();
+    joy.PollAllJoysticks();
 
     auto frame = wxGetApp().frame;
     bool joy_timer = frame->IsJoyPollTimerRunning();
@@ -2754,7 +2754,7 @@ EVT_HANDLER(JoypadConfigure, "Joypad options...")
 EVT_HANDLER(Customize, "Customize UI...")
 {
     wxDialog* dlg = GetXRCDialog("AccelConfig");
-    joy.Add();
+    joy.PollAllJoysticks();
 
     auto frame = wxGetApp().frame;
     bool joy_timer = frame->IsJoyPollTimerRunning();

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2582,12 +2582,14 @@ void MainFrame::set_global_accels()
     // the menus will be added now
 
     // first, zero out menu item on all accels
+    std::unordered_set<unsigned> needed_joysticks;
     for (size_t i = 0; i < accels.size(); ++i) {
         accels[i].Set(accels[i].GetUkey(), accels[i].GetJoystick(), accels[i].GetFlags(), accels[i].GetKeyCode(), accels[i].GetCommand());
         if (accels[i].GetJoystick()) {
-            joy.Add(accels[i].GetJoystick() - 1);
+            needed_joysticks.insert(accels[i].GetJoystick());
         }
     }
+    joy.PollJoysticks(needed_joysticks);
 
     // yet another O(n*m) loop.  I really ought to sort the accel arrays
     for (int i = 0; i < ncmds; i++) {

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1391,25 +1391,25 @@ void GameArea::OnSize(wxSizeEvent& ev)
 
 void GameArea::OnSDLJoy(wxSDLJoyEvent& ev)
 {
-    int key = ev.GetControlIndex();
+    int key = ev.control_index();
     int mod = wxJoyKeyTextCtrl::DigitalButton(ev);
-    int joy = ev.GetJoy() + 1;
+    int joy = ev.player_index();
 
     // mutually exclusive key types unpress their opposite
     if (mod == WXJB_AXIS_PLUS) {
         process_key_press(false, key, WXJB_AXIS_MINUS, joy);
-        process_key_press(ev.GetControlValue() != 0, key, mod, joy);
+        process_key_press(ev.control_value() != 0, key, mod, joy);
     } else if (mod == WXJB_AXIS_MINUS) {
         process_key_press(false, key, WXJB_AXIS_PLUS, joy);
-        process_key_press(ev.GetControlValue() != 0, key, mod, joy);
+        process_key_press(ev.control_value() != 0, key, mod, joy);
     } else if (mod >= WXJB_HAT_FIRST && mod <= WXJB_HAT_LAST) {
-        int value = ev.GetControlValue();
+        int value = ev.control_value();
         process_key_press(value & SDL_HAT_UP, key, WXJB_HAT_N, joy);
         process_key_press(value & SDL_HAT_DOWN, key, WXJB_HAT_S, joy);
         process_key_press(value & SDL_HAT_RIGHT, key, WXJB_HAT_E, joy);
         process_key_press(value & SDL_HAT_LEFT, key, WXJB_HAT_W, joy);
     } else
-        process_key_press(ev.GetControlValue() != 0, key, mod, joy);
+        process_key_press(ev.control_value() != 0, key, mod, joy);
 
     // tell Linux to turn off the screensaver/screen-blank if joystick button was pressed
     // this shouldn't be necessary of course

--- a/src/wx/widgets/joyedit.cpp
+++ b/src/wx/widgets/joyedit.cpp
@@ -19,8 +19,8 @@ wxJoyKeyBinding newWxJoyKeyBinding(int key, int mod, int joy)
 
 int wxJoyKeyTextCtrl::DigitalButton(wxSDLJoyEvent& event)
 {
-    int sdlval = event.GetControlValue();
-    int sdltype = event.GetControlType();
+    int16_t sdlval = event.control_value();
+    wxSDLControl sdltype = event.control();
 
     switch (sdltype) {
     case WXSDLJOY_AXIS:
@@ -72,8 +72,8 @@ void wxJoyKeyTextCtrl::OnJoy(wxSDLJoyEvent& event)
 {
     static wxLongLong last_event = 0;
 
-    int val  = event.GetControlValue();
-    int type = event.GetControlType();
+    int16_t val  = event.control_value();
+    wxSDLControl type = event.control();
 
     // Filter consecutive axis motions within 300ms, as this adds two bindings
     // +1/-1 instead of the one intended.
@@ -83,7 +83,8 @@ void wxJoyKeyTextCtrl::OnJoy(wxSDLJoyEvent& event)
     last_event = wxGetUTCTimeMillis();
 
     int mod = DigitalButton(event);
-    int key = event.GetControlIndex(), joy = event.GetJoy() + 1;
+    uint8_t key = event.control_index();
+    unsigned joy = event.player_index();
 
     if (!val || mod < 0)
         return;

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -109,8 +109,8 @@ static void get_config_path(wxPathList& path, bool exists = true)
     }
     else
     {
-	// config is in $HOME/.vbam/
-	add_nonstandard_path(old_config);
+        // config is in $HOME/.vbam/
+        add_nonstandard_path(old_config);
     }
 #endif
 
@@ -240,7 +240,7 @@ bool wxvbamApp::OnInit()
         return false;
 
     if (console_mode)
-	return true;
+        return true;
 
     // prepare for loading xrc files
     wxXmlResource* xr = wxXmlResource::Get();
@@ -449,13 +449,13 @@ bool wxvbamApp::OnInit()
         return false;
 
     if (x >= 0 && y >= 0 && width > 0 && height > 0)
-	frame->SetSize(x, y, width, height);
+        frame->SetSize(x, y, width, height);
 
     if (isMaximized)
         frame->Maximize();
 
     if (isFullscreen && wxGetApp().pending_load != wxEmptyString)
-	frame->ShowFullScreen(isFullscreen);
+        frame->ShowFullScreen(isFullscreen);
     frame->Show(true);
 
 #ifndef NO_ONLINEUPDATES
@@ -468,12 +468,12 @@ int wxvbamApp::OnRun()
 {
     if (console_mode)
     {
-	// we could check for our own error codes here...
-	return console_status;
+        // we could check for our own error codes here...
+        return console_status;
     }
     else
     {
-	return wxApp::OnRun();
+        return wxApp::OnRun();
     }
 }
 
@@ -512,30 +512,30 @@ void wxvbamApp::OnInitCmdLine(wxCmdLineParser& cl)
     static wxCmdLineEntryDesc opttab[] = {
         { wxCMD_LINE_OPTION, NULL, t("save-xrc"),
             N_("Save built-in XRC file and exit"),
-	    wxCMD_LINE_VAL_STRING, 0 },
+            wxCMD_LINE_VAL_STRING, 0 },
         { wxCMD_LINE_OPTION, NULL, t("save-over"),
             N_("Save built-in vba-over.ini and exit"),
-	    wxCMD_LINE_VAL_STRING, 0 },
+            wxCMD_LINE_VAL_STRING, 0 },
         { wxCMD_LINE_SWITCH, NULL, t("print-cfg-path"),
             N_("Print configuration path and exit"),
-	    wxCMD_LINE_VAL_NONE, 0 },
+            wxCMD_LINE_VAL_NONE, 0 },
         { wxCMD_LINE_SWITCH, t("f"), t("fullscreen"),
             N_("Start in full-screen mode"),
-	    wxCMD_LINE_VAL_NONE, 0 },
+            wxCMD_LINE_VAL_NONE, 0 },
         { wxCMD_LINE_OPTION, t("c"), t("config"),
             N_("Set a configuration file"),
-        wxCMD_LINE_VAL_STRING, 0 },
+            wxCMD_LINE_VAL_STRING, 0 },
 #if !defined(NO_LINK) && !defined(__WXMSW__)
         { wxCMD_LINE_SWITCH, t("s"), t("delete-shared-state"),
             N_("Delete shared link state first, if it exists"),
-	    wxCMD_LINE_VAL_NONE, 0 },
+            wxCMD_LINE_VAL_NONE, 0 },
 #endif
         // stupid wx cmd line parser doesn't support duplicate options
-        //	{ wxCMD_LINE_OPTION, t("o"),  t("option"),
-        //		_("Set configuration option; <opt>=<value> or help for list"),
+        //    { wxCMD_LINE_OPTION, t("o"),  t("option"),
+        //        _("Set configuration option; <opt>=<value> or help for list"),
         { wxCMD_LINE_SWITCH, t("o"), t("list-options"),
             N_("List all settable options and exit"),
-	    wxCMD_LINE_VAL_NONE, 0 },
+            wxCMD_LINE_VAL_NONE, 0 },
         { wxCMD_LINE_PARAM, NULL, NULL,
             N_("ROM file"), wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
         { wxCMD_LINE_PARAM, NULL, NULL,
@@ -720,8 +720,8 @@ wxString wxvbamApp::GetDataDir()
 wxvbamApp::~wxvbamApp() {
     if (home != NULL)
     {
-	free(home);
-	home = NULL;
+        free(home);
+        home = NULL;
     }
     delete overrides;
 
@@ -797,8 +797,8 @@ void MainFrame::OnMenu(wxContextMenuEvent& event)
         wxPoint p(event.GetPosition());
 #if 0 // wx actually recommends ignoring the position
 
-		if (p != wxDefaultPosition)
-			p = ScreenToClient(p);
+        if (p != wxDefaultPosition)
+            p = ScreenToClient(p);
 
 #endif
         PopupMenu(ctx_menu, p);
@@ -839,16 +839,16 @@ void MainFrame::OnSize(wxSizeEvent& event)
     bool isMaximized = IsMaximized();
     if (!isFullscreen && !isMaximized)
     {
-	if (height > 0 && width > 0)
-	{
-	    windowHeight = height;
-	    windowWidth = width;
-	}
-	if (x >= 0 && y >= 0)
-	{
-	    windowPositionX = x;
-	    windowPositionY = y;
-	}
+        if (height > 0 && width > 0)
+        {
+            windowHeight = height;
+            windowWidth = width;
+        }
+        if (x >= 0 && y >= 0)
+        {
+            windowPositionX = x;
+            windowPositionY = y;
+        }
     }
     else
     {
@@ -876,25 +876,26 @@ int MainFrame::FilterEvent(wxEvent& event)
                  evh.SetEventObject(this);
                  GetEventHandler()->ProcessEvent(evh);
                  return true;
-	     }
+         }
     }
     else if (event.GetEventType() == wxEVT_SDLJOY && !menus_opened && !dialog_opened)
     {
         wxSDLJoyEvent& je = (wxSDLJoyEvent&)event;
-        if (je.GetControlValue() == 0) return -1; // joystick button UP
-        int key = je.GetControlIndex();
+        if (je.control_value() == 0) return -1; // joystick button UP
+        uint8_t key = je.control_index();
         int mod = wxJoyKeyTextCtrl::DigitalButton(je);
-        int joy = je.GetJoy() + 1;
+        int joy = je.player_index();
         wxString label = wxJoyKeyTextCtrl::ToString(mod, key, joy);
         wxAcceleratorEntry_v accels = wxGetApp().GetAccels();
-        for (size_t i = 0; i < accels.size(); ++i) {
-             if (label == accels[i].GetUkey())
-             {
-                 wxCommandEvent evh(wxEVT_COMMAND_MENU_SELECTED, accels[i].GetCommand());
-                 evh.SetEventObject(this);
-                 GetEventHandler()->ProcessEvent(evh);
-                 return true;
-	     }
+        for (size_t i = 0; i < accels.size(); ++i)
+        {
+            if (label == accels[i].GetUkey())
+            {
+                wxCommandEvent evh(wxEVT_COMMAND_MENU_SELECTED, accels[i].GetCommand());
+                evh.SetEventObject(this);
+                GetEventHandler()->ProcessEvent(evh);
+                return true;
+            }
         }
     }
     return -1;
@@ -916,8 +917,8 @@ wxString MainFrame::GetGamePath(wxString path)
 
     if (!wxIsWritable(game_path))
     {
-	game_path = wxGetApp().GetAbsolutePath(wxString((get_xdg_user_data_home() + DOT_DIR).c_str(), wxConvLibc));
-	wxFileName::Mkdir(game_path, 0777, wxPATH_MKDIR_FULL);
+        game_path = wxGetApp().GetAbsolutePath(wxString((get_xdg_user_data_home() + DOT_DIR).c_str(), wxConvLibc));
+        wxFileName::Mkdir(game_path, 0777, wxPATH_MKDIR_FULL);
     }
 
     return game_path;
@@ -927,23 +928,26 @@ void MainFrame::SetJoystick()
 {
     /* Remove all attached joysticks to avoid errors while
      * destroying and creating the GameArea `panel`. */
-    joy.Remove();
+    joy.StopPolling();
 
     set_global_accels();
 
     if (!emulating)
         return;
 
-    for (int i = 0; i < 4; i++)
+    std::unordered_set<unsigned> needed_joysticks;
+    for (int i = 0; i < 4; i++) {
         for (int j = 0; j < NUM_KEYS; j++) {
             wxJoyKeyBinding_v b = gopts.joykey_bindings[i][j];
             for (size_t k = 0; k < b.size(); k++) {
                 int jn = b[k].joy;
                 if (jn) {
-                    joy.Add(jn - 1);
+                    needed_joysticks.insert(jn);
                 }
             }
         }
+    }
+    joy.PollJoysticks(needed_joysticks);
 }
 
 void MainFrame::StopJoyPollTimer()


### PR DESCRIPTION
This is a major refactor of the wxSDLJoy class.
* Move handling of SDL objects creation and destruction to its own
  class. This simplifies the lifespan of SDL-related objects.
* Re-add handling of HATs. This is necessary for DirectInput
  controllers.
* Fix a crash on joystick disconnect.
* Rename the public API for wxSDLJoy to be clearer.
* Add documentation for every class related to wxSDLJoy.
* Change some tabs to white spaces in wxvbam.cpp.