### PR TITLE
[rfc] Don't set wx-config prefix from CMAKE_PREFIX_PATH

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -204,10 +204,6 @@ else()
     #    set(CMAKE_CXX_LINK_EXECUTABLE "${CMAKE_CXX_LINK_EXECUTABLE} -luuid -lwinspool")
     #endif()
 
-    if(CMAKE_PREFIX_PATH)
-        set(wxWidgets_CONFIG_OPTIONS "--prefix=${CMAKE_PREFIX_PATH}")
-    endif()
-
     set(wxWidgets_USE_UNICODE ON)
 
     # Check for gtk4 then gtk3 packages first, some dists like arch rename the


### PR DESCRIPTION
I'm not sure what purpose this currently serves but I know that it
breaks the build when CMAKE_PREFIX_PATH is set to something nontrivial. The assignment is sort of nonsensical anyways since `CMAKE_PREFIX_PATH` is a colon-separated list of paths and the `--prefix` option expects just a single one. This predictably does not work if the cmake environment variable has more than one path in it.
Stop doing that.

Let me know if there are steps I can take to test that this doesn't break other distros builds, but it definitely unbreaks mine. For context, I am building with Nix which sets `CMAKE_PREFIX_PATH` to something very long 