### PR TITLE
Handle allocation quirk on non-null-returning allocators

### DIFF
--- a/src/gba/GBA.cpp
+++ b/src/gba/GBA.cpp
@@ -1443,19 +1443,23 @@ void SetMapMasks()
 #ifdef BKPT_SUPPORT
     for (int i = 0; i < 16; i++) {
         map[i].size = map[i].mask + 1;
-        if (map[i].size > 0) {
-            map[i].trace = (uint8_t*)calloc(map[i].size >> 3, sizeof(uint8_t));
+        map[i].trace = NULL;
+        map[i].breakPoints = NULL;
 
+        if ((map[i].size >> 1) > 0) {
             map[i].breakPoints = (uint8_t*)calloc(map[i].size >> 1, sizeof(uint8_t));
-
-            if (map[i].trace == NULL || map[i].breakPoints == NULL) {
+            if (map[i].breakPoints == NULL) {
                 systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
                     "TRACE");
             }
-        } else {
-            map[i].trace = NULL;
-            map[i].breakPoints = NULL;
+        }
 
+        if ((map[i].size >> 3) > 0) {
+            map[i].trace = (uint8_t*)calloc(map[i].size >> 3, sizeof(uint8_t));
+            if (map[i].trace == NULL) {
+                systemMessage(MSG_OUT_OF_MEMORY, N_("Failed to allocate memory for %s"),
+                    "TRACE");
+            }
         }
     }
     clearBreakRegList();


### PR DESCRIPTION
Some allocators return a non-null pointer when calling *alloc with zero size, that will segfault upon access.
Check for the size parameter before allocating anything to ensure that the breakpoint and trace fields will stay null when `size >> 3` or `size >> 1` is zero.