### PR TITLE
SDL frontend fixes and cleanup

### DIFF
--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -323,23 +323,29 @@ bool sdlCheckDirectory(const char* dir)
 
 char* sdlGetFilename(char* name)
 {
-    char path[1024] = ""; // avoid warning about uninitialised value
+    char path[1024];
     char *filename = strrchr(name, FILE_SEP);
     if (filename)
-        strncpy(path, filename + 1, strlen(filename));
+        strcpy(path, filename + 1);
     else
-        sprintf(path, "%s", name);
+        strcpy(path, name);
     return strdup(path);
 }
 
 char* sdlGetFilePath(char* name)
 {
-    char path[1024] = ""; // avoid warning about uninitialised value
+    char path[1024];
     char *filename = strrchr(name, FILE_SEP);
-    if (filename)
-        strncpy(path, name, strlen(name) - strlen(filename));
-    else
-        sprintf(path, "%c%c", '.', FILE_SEP);
+    if (filename) {
+		size_t length = strlen(name) - strlen(filename);
+        memcpy(path, name, length);
+        path[length] = '\0';
+	}
+    else {
+		path[0] = '.';
+		path[1] = FILE_SEP;
+		path[2] = '\0';
+	}
     return strdup(path);
 }
 

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -307,17 +307,17 @@ bool sdlCheckDirectory(const char* dir)
 
     if (stat(dir, &buf) == 0)
     {
-	if (!(buf.st_mode & S_IFDIR))
-	{
-	    fprintf(stderr, "Error: %s is not a directory\n", dir);
-	    return false;
-	}
-	return true;
+        if (!(buf.st_mode & S_IFDIR))
+        {
+            fprintf(stderr, "Error: %s is not a directory\n", dir);
+            return false;
+        }
+        return true;
     }
     else
     {
-	fprintf(stderr, "Error: %s does not exist\n", dir);
-	return false;
+        fprintf(stderr, "Error: %s does not exist\n", dir);
+        return false;
     }
 }
 
@@ -471,7 +471,7 @@ static void sdlOpenGLVideoResize()
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER,
         openGL == 2 ? GL_LINEAR : GL_NEAREST);
 
-    // Calculate texture size as a the smallest working power of two
+    // Calculate texture size as the smallest working power of two
     float n1 = log10((float)destWidth) / log10(2.0f);
     float n2 = log10((float)destHeight) / log10(2.0f);
     float n = (n1 > n2) ? n1 : n2;

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -366,7 +366,7 @@ FILE* sdlFindFile(const char* name)
 
     fprintf(stdout, "Searching for file %s\n", name);
 
-    if (GETCWD(buffer, 2048)) {
+    if (GETCWD(buffer, sizeof(buffer))) {
         fprintf(stdout, "Searching current directory: %s\n", buffer);
     }
 
@@ -398,8 +398,8 @@ FILE* sdlFindFile(const char* name)
 
         if (path != NULL) {
             fprintf(stdout, "Searching PATH\n");
-            strncpy(buffer, path, 4096);
-            buffer[4095] = 0;
+            strncpy(buffer, path, sizeof(buffer));
+            buffer[sizeof(buffer) - 1] = 0;
             char* tok = strtok(buffer, PATH_SEP);
 
             while (tok) {

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -384,10 +384,10 @@ FILE* sdlFindFile(const char* name)
     }
 
 #ifdef _WIN32
-    char* home = getenv("USERPROFILE");
-    if (home != NULL) {
-        fprintf(stdout, "Searching user profile directory: %s\n", home);
-        sprintf(path, "%s%c%s", home, FILE_SEP, name);
+    char* profileDir = getenv("USERPROFILE");
+    if (profileDir != NULL) {
+        fprintf(stdout, "Searching user profile directory: %s\n", profileDir);
+        sprintf(path, "%s%c%s", profileDir, FILE_SEP, name);
         f = fopen(path, "r");
         if (f != NULL)
             return f;

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -337,15 +337,15 @@ char* sdlGetFilePath(const char* name)
     char path[1024];
     const char *filename = strrchr(name, FILE_SEP);
     if (filename) {
-		size_t length = strlen(name) - strlen(filename);
+        size_t length = strlen(name) - strlen(filename);
         memcpy(path, name, length);
         path[length] = '\0';
-	}
+    }
     else {
-		path[0] = '.';
-		path[1] = FILE_SEP;
-		path[2] = '\0';
-	}
+        path[0] = '.';
+        path[1] = FILE_SEP;
+        path[2] = '\0';
+    }
     return strdup(path);
 }
 
@@ -739,7 +739,7 @@ void sdlWriteBattery()
     bool result = emulator.emuWriteBattery(buffer);
 
     if (result)
-	systemMessage(0, "Wrote battery '%s'", buffer);
+        systemMessage(0, "Wrote battery '%s'", buffer);
 
     freeSafe(gameFile);
     freeSafe(gameDir);
@@ -1516,7 +1516,7 @@ void SetHomeConfigDir()
     sprintf(homeConfigDir, "%s%s", get_xdg_user_config_home().c_str(), DOT_DIR);
     struct stat s;
     if (stat(homeDataDir, &s) == -1 || !S_ISDIR(s.st_mode))
-	mkdir(homeDataDir, 0755);
+        mkdir(homeDataDir, 0755);
 }
 
 void SetHomeDataDir()
@@ -1524,7 +1524,7 @@ void SetHomeDataDir()
     sprintf(homeDataDir, "%s%s", get_xdg_user_data_home().c_str(), DOT_DIR);
     struct stat s;
     if (stat(homeDataDir, &s) == -1 || !S_ISDIR(s.st_mode))
-	mkdir(homeDataDir, 0755);
+        mkdir(homeDataDir, 0755);
 }
 
 int main(int argc, char** argv)
@@ -2136,7 +2136,7 @@ void systemScreenCapture(int a)
     }
 
     if (result)
-	systemScreenMessage("Screen capture");
+        systemScreenMessage("Screen capture");
 
     freeSafe(gameFile);
     freeSafe(gameDir);

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -321,10 +321,10 @@ bool sdlCheckDirectory(const char* dir)
     }
 }
 
-char* sdlGetFilename(char* name)
+char* sdlGetFilename(const char* name)
 {
     char path[1024];
-    char *filename = strrchr(name, FILE_SEP);
+    const char *filename = strrchr(name, FILE_SEP);
     if (filename)
         strcpy(path, filename + 1);
     else
@@ -332,10 +332,10 @@ char* sdlGetFilename(char* name)
     return strdup(path);
 }
 
-char* sdlGetFilePath(char* name)
+char* sdlGetFilePath(const char* name)
 {
     char path[1024];
-    char *filename = strrchr(name, FILE_SEP);
+    const char *filename = strrchr(name, FILE_SEP);
     if (filename) {
 		size_t length = strlen(name) - strlen(filename);
         memcpy(path, name, length);


### PR DESCRIPTION
This silences a compiler warning (encountered on GCC 10.2), which complained about `strncpy`'s length parameter being determined by the length of the source string.

I've also fixed some bugged logic on Windows, where the profile path is used instead of the `argv[0]` path because of a shadowed variable. This bug presumably prevents the PATH from ever being searched, and it also seems to have broken the logic for searching the executable directory.