### PR TITLE
SDL: Fix build with SDL 2.0.14 after KMOD_GUI change to enum

### DIFF
--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -878,7 +878,8 @@ void sdlInitVideo()
 
     sdlResizeVideo();
 }
-#if defined(KMOD_GUI)
+
+#ifndef KMOD_META
 #define KMOD_META KMOD_GUI
 #endif
 


### PR DESCRIPTION
Since SDL 2.0.14, KMOD_GUI is no longer a macro but an enum value:
https://hg.libsdl.org/SDL/rev/15a0bc9612e9

So this code broke as the enum value doesn't satisfy `defined()`.

---

Fixes this build issue when using `ENABLE_SDL=ON`:
```
/home/akien/Projects/mageia/Checkout/vbam/BUILD/visualboyadvance-m-2.1.4/src/sdl/SDL.cpp: In function 'void sdlPollEvents()':
/home/akien/Projects/mageia/Checkout/vbam/BUILD/visualboyadvance-m-2.1.4/src/sdl/SDL.cpp:884:45: error: 'KMOD_META' was not declared in this scope; did you mean 'KMOD_ALT'?
  884 | #define MOD_NOCTRL (KMOD_SHIFT | KMOD_ALT | KMOD_META)
      |                                             ^~~~~~~~~
/home/akien/Projects/mageia/Checkout/vbam/BUILD/visualboyadvance-m-2.1.4/src/sdl/SDL.cpp:1057:46: note: in expansion of macro 'MOD_NOCTRL'
 1057 |                 if (!(event.key.keysym.mod & MOD_NOCTRL) && (event.key.keysym.mod & KMOD_CTRL)) {
      |                                              ^~~~~~~~~~
```

I'm not familiar enough with the codebase, but I assume this redefinition of `KMOD_META` was done for compatibility with SDL 1.2. If that's no longer an aim of the project, you could likely use `KMOD_GUI` directly.