### PR TITLE
add a missing break; in half word reads

### DIFF
--- a/src/gba/GBAinline.h
+++ b/src/gba/GBAinline.h
@@ -289,6 +289,7 @@ static inline uint32_t CPUReadHalfWord(uint32_t address)
             // no need to swap this
             value = flashRead(address) * 0x0101;
         }
+    break;
     // default
     default:
     unreadable:


### PR DESCRIPTION
Fixes illegal halfword and byte reads (Croket! 2 slowdown) #804