### PR TITLE
Use constant aliases in MainFrame::FilterEvent()

### DIFF
--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -869,14 +869,14 @@ int MainFrame::FilterEvent(wxEvent& event)
         int keyMod = ke.GetModifiers();
         wxAcceleratorEntry_v accels = wxGetApp().GetAccels();
         for (size_t i = 0; i < accels.size(); ++i)
-             if (keyCode == accels[i].GetKeyCode() && keyMod == accels[i].GetFlags()
-                 && accels[i].GetCommand() != XRCID("NOOP"))
-             {
-                 wxCommandEvent evh(wxEVT_COMMAND_MENU_SELECTED, accels[i].GetCommand());
-                 evh.SetEventObject(this);
-                 GetEventHandler()->ProcessEvent(evh);
-                 return true;
-         }
+            if (keyCode == accels[i].GetKeyCode() && keyMod == accels[i].GetFlags()
+                && accels[i].GetCommand() != XRCID("NOOP"))
+            {
+                wxCommandEvent evh(wxEVT_COMMAND_MENU_SELECTED, accels[i].GetCommand());
+                evh.SetEventObject(this);
+                GetEventHandler()->ProcessEvent(evh);
+                return wxEventFilter::Event_Processed;
+        }
     }
     else if (event.GetEventType() == wxEVT_SDLJOY && !menus_opened && !dialog_opened)
     {
@@ -894,11 +894,11 @@ int MainFrame::FilterEvent(wxEvent& event)
                 wxCommandEvent evh(wxEVT_COMMAND_MENU_SELECTED, accels[i].GetCommand());
                 evh.SetEventObject(this);
                 GetEventHandler()->ProcessEvent(evh);
-                return true;
+                return wxEventFilter::Event_Processed;
             }
         }
     }
-    return -1;
+    return wxEventFilter::Event_Skip;
 }
 
 wxString MainFrame::GetGamePath(wxString path)


### PR DESCRIPTION
Previously, this function returned -1 or "true" but wxWidgets
defines constants for the returned values for FilterEvent()
overrides so use these instead.