### PR TITLE
Fix Arch installdeps

### DIFF
--- a/installdeps
+++ b/installdeps
@@ -176,6 +176,8 @@ linux_installdeps() {
         solus_installdeps
     elif [ -f /etc/gentoo-release ]; then
         gentoo_installdeps
+    elif [ -x /usr/bin/pacman ]; then
+        archlinux_installdeps
     elif [ -f /etc/os-release ]; then
         case "$(. /etc/os-release; echo "${ID_LIKE:-$ID}")" in
             *suse*)
@@ -184,9 +186,10 @@ linux_installdeps() {
             nixos)
                 nixos_installdeps
                 ;;
+            *)
+                error "Don't know how to install deps on your version of Linux"
+                ;;
         esac
-    elif [ -x /usr/bin/pacman ]; then
-        archlinux_installdeps
     else
         error "Don't know how to install deps on your version of Linux"
     fi


### PR DESCRIPTION
I don't know if this is right or not, but I am running an Arch system and tried running `./installdeps` and nothing happened. So I went into the script and figured that it got stuck in the `elif [ -f /etc/os-release ];` block. This file exists on Arch as well, so the block is executed, but arch is not listed in the `case` block, so the script exited without doing anything. And it's only checking for pacman after that, so it never ran `arch_installdeps`.

Don't know if this is the 100% correct fix, but it's working for me now and should also catch cases like that in the future.