### PR TITLE
in Wx, the Option is Enable MMX, make the variable also enableMMX and…

### DIFF
--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -166,7 +166,7 @@ int captureFormat = 0;
 int cheatsEnabled = true;
 int cpuDisableSfx = false;
 int cpuSaveType = 0;
-int disableMMX;
+int enableMMX = 1;
 int disableStatusMessages = 0;
 int dsoundDisableHardwareAcceleration;
 int filterHeight;
@@ -307,7 +307,7 @@ struct option argOptions[] = {
 	{ "cpu-disable-sfx", no_argument, &cpuDisableSfx, 1 },
 	{ "cpu-save-type", required_argument, 0, OPT_CPU_SAVE_TYPE },
 	{ "debug", no_argument, 0, 'd' },
-	{ "disable-mmx", no_argument, &disableMMX, 1 },
+	{ "enable-mmx", no_argument, &enableMMX, 1 },
 	{ "disable-sfx", no_argument, &cpuDisableSfx, 1 },
 	{ "disable-status-messages", no_argument, &disableStatusMessages, 1 },
 	{ "dotcode-file-name-load", required_argument, 0, OPT_DOTCODE_FILE_NAME_LOAD },
@@ -495,7 +495,7 @@ void LoadConfig()
 	cheatsEnabled = ReadPref("cheatsEnabled", 0);
 	cpuDisableSfx = ReadPref("disableSfx", 0);
 	cpuSaveType = ReadPrefHex("saveType");
-	disableMMX = ReadPref("disableMMX", 0);
+	enableMMX = ReadPref("enableMMX", 1);
 	disableStatusMessages = ReadPrefHex("disableStatus");
 	filterMT = ReadPref("filterEnableMultiThreading", 0);
 	filter = ReadPref("filter", 0);

--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -166,7 +166,7 @@ int captureFormat = 0;
 int cheatsEnabled = true;
 int cpuDisableSfx = false;
 int cpuSaveType = 0;
-int enableMMX = 1;
+int enableMMX;
 int disableStatusMessages = 0;
 int dsoundDisableHardwareAcceleration;
 int filterHeight;

--- a/src/common/ConfigManager.h
+++ b/src/common/ConfigManager.h
@@ -56,7 +56,7 @@ extern int cheatsEnabled;
 extern int cpuDisableSfx;
 extern int cpuSaveType;
 extern int dinputKeyFocus;
-extern int disableMMX;
+extern int enableMMX;
 extern int disableStatusMessages;
 extern int dsoundDisableHardwareAcceleration;
 extern int filterHeight;

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2995,7 +2995,7 @@ EVT_HANDLER(ApplyPatches, "Apply IPS/UPS/IPF patches if found")
 EVT_HANDLER(MMX, "Enable MMX")
 {
 #ifdef MMX
-    GetMenuOptionInt("MMX", disableMMX, 1);
+    GetMenuOptionInt("MMX", enableMMX, 1);
     update_opts();
 #endif
 }

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -3067,7 +3067,7 @@ bool MainFrame::BindControls()
         MenuOptionIntMask("JoypadAutoholdR", autohold, KEYM_R);
         MenuOptionIntMask("JoypadAutoholdSelect", autohold, KEYM_SELECT);
         MenuOptionIntMask("JoypadAutoholdStart", autohold, KEYM_START);
-        MenuOptionIntMask("MMX", disableMMX, 1);
+        MenuOptionIntMask("MMX", enableMMX, 1);
         MenuOptionBool("EmulatorSpeedupToggle", turbo);
         MenuOptionIntRadioValue("LinkType0Nothing", gopts.gba_link_type, 0);
         MenuOptionIntRadioValue("LinkType1Cable", gopts.gba_link_type, 1);

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -264,7 +264,7 @@ opt_desc opts[] = {
     INTOPT("preferences/captureFormat", "", wxTRANSLATE("Screen capture file format"), captureFormat, 0, 1),
     INTOPT("preferences/cheatsEnabled", "", wxTRANSLATE("Enable cheats"), cheatsEnabled, 0, 1),
 #ifdef MMX
-    INTOPT("preferences/disableMMX", "MMX", wxTRANSLATE("Enable MMX"), disableMMX, 0, 1),
+    INTOPT("preferences/enableMMX", "MMX", wxTRANSLATE("Enable MMX"), enableMMX, 0, 1),
 #endif
     INTOPT("preferences/disableStatus", "NoStatusMsg", wxTRANSLATE("Disable on-screen status messages"), disableStatusMessages, 0, 1),
     INTOPT("preferences/emulatorType", "", wxTRANSLATE("Type of system to emulate"), gbEmulatorType, 0, 5),


### PR DESCRIPTION
… set its default to on.

The present ini variable is from vbam 1.x and is behaviourally backwards where setting disablemmx to true actually enables mmx, 2.x builds should not be using the ini from 1.x for various reasons.