### PR TITLE
Fix autosaveloadcheats and rename pref to autosaveloadcheats

### DIFF
--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -288,7 +288,6 @@ struct option argOptions[] = {
 	{ "auto-frame-skip", required_argument, 0, OPT_AUTO_FRAME_SKIP },
 	{ "auto-load-most-recent", no_argument, &autoLoadMostRecent, 1 },
 	{ "auto-patch", no_argument, &autoPatch, 1 },
-	{ "auto-save-cheat-list", no_argument, &autoSaveLoadCheatList, 1 },
 	{ "auto-save-load-cheat-list", no_argument, &autoSaveLoadCheatList, 1 },
 	{ "autofire", required_argument, 0, OPT_AUTOFIRE },
 	{ "avi-record-dir", required_argument, 0, OPT_AVI_RECORD_DIR },
@@ -485,7 +484,7 @@ void LoadConfig()
 	autoFrameSkip = ReadPref("autoFrameSkip", 0);
 	autoLoadMostRecent = ReadPref("autoLoadMostRecent", 0);
 	autoPatch = ReadPref("autoPatch", 1);
-	autoSaveLoadCheatList = ReadPref("autoSaveCheatList", 1);
+	autoSaveLoadCheatList = ReadPref("autoSaveLoadCheatList", 1);
 	aviRecordDir = ReadPrefString("aviRecordDir");
 	batteryDir = ReadPrefString("batteryDir");
 	biosFileNameGB = ReadPrefString("biosFileGB");

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -258,7 +258,7 @@ opt_desc opts[] = {
     INTOPT("preferences/agbPrint", "AGBPrinter", wxTRANSLATE("Enable AGB debug print"), agbPrint, 0, 1),
     INTOPT("preferences/autoFrameSkip", "FrameSkipAuto", wxTRANSLATE("Auto skip frames."), autoFrameSkip, 0, 1),
     INTOPT("preferences/autoPatch", "ApplyPatches", wxTRANSLATE("Apply IPS/UPS/IPF patches if found"), autoPatch, 0, 1),
-    INTOPT("preferences/autoSaveCheatList", "", wxTRANSLATE("Automatically save and load cheat list"), autoSaveLoadCheatList, 0, 1),
+    BOOLOPT("preferences/autoSaveLoadCheatList", "", wxTRANSLATE("Automatically save and load cheat list"), gopts.autoload_cheats),
     INTOPT("preferences/borderAutomatic", "", wxTRANSLATE("Automatically enable border for Super GameBoy games"), gbBorderAutomatic, 0, 1),
     INTOPT("preferences/borderOn", "", wxTRANSLATE("Always enable border"), gbBorderOn, 0, 1),
     INTOPT("preferences/captureFormat", "", wxTRANSLATE("Screen capture file format"), captureFormat, 0, 1),


### PR DESCRIPTION
This corrects a slight oversight in the opts.cpp and makes the pref reflect the actual setting

fixes #80 