### PR TITLE
Abstract player_index into wxJoystick

### DIFF
--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2581,11 +2581,12 @@ void MainFrame::set_global_accels()
     // the menus will be added now
 
     // first, zero out menu item on all accels
-    std::unordered_set<unsigned> needed_joysticks;
+    std::set<wxJoystick> needed_joysticks;
     for (size_t i = 0; i < accels.size(); ++i) {
         accels[i].Set(accels[i].GetUkey(), accels[i].GetJoystick(), accels[i].GetFlags(), accels[i].GetKeyCode(), accels[i].GetCommand());
         if (accels[i].GetJoystick()) {
-            needed_joysticks.insert(accels[i].GetJoystick());
+            needed_joysticks.insert(
+                wxJoystick::FromLegacyPlayerIndex(accels[i].GetJoystick()));
         }
     }
     joy.PollJoysticks(needed_joysticks);

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1399,11 +1399,11 @@ void GameArea::OnSize(wxSizeEvent& ev)
     ev.Skip();
 }
 
-void GameArea::OnSDLJoy(wxSDLJoyEvent& ev)
+void GameArea::OnSDLJoy(wxJoyEvent& ev)
 {
     int key = ev.control_index();
     int mod = wxJoyKeyTextCtrl::DigitalButton(ev);
-    int joy = ev.player_index();
+    int joy = ev.joystick().player_index();
 
     // mutually exclusive key types unpress their opposite
     if (mod == WXJB_AXIS_PLUS) {

--- a/src/wx/sys.cpp
+++ b/src/wx/sys.cpp
@@ -239,7 +239,7 @@ void systemStopGamePlayback()
     mf->enable_menus();
 }
 
-// updates the joystick data (done in background using wxSDLJoy)
+// updates the joystick data (done in background using wxJoyPoller)
 bool systemReadJoypads()
 {
     return true;

--- a/src/wx/widgets/joyedit.cpp
+++ b/src/wx/widgets/joyedit.cpp
@@ -17,17 +17,17 @@ wxJoyKeyBinding newWxJoyKeyBinding(int key, int mod, int joy)
     return tmp;
 }
 
-int wxJoyKeyTextCtrl::DigitalButton(wxSDLJoyEvent& event)
+int wxJoyKeyTextCtrl::DigitalButton(wxJoyEvent& event)
 {
     int16_t sdlval = event.control_value();
-    wxSDLControl sdltype = event.control();
+    wxJoyControl sdltype = event.control();
 
     switch (sdltype) {
-    case WXSDLJOY_AXIS:
+    case wxJoyControl::Axis:
         // for val = 0 return arbitrary direction; val means "off"
         return sdlval > 0 ? WXJB_AXIS_PLUS : WXJB_AXIS_MINUS;
 
-    case WXSDLJOY_HAT:
+    case wxJoyControl::Hat:
 
         /* URDL = 1248 */
         switch (sdlval) {
@@ -59,7 +59,7 @@ int wxJoyKeyTextCtrl::DigitalButton(wxSDLJoyEvent& event)
             return WXJB_HAT_N; // arbitrary direction; val = 0 means "off"
         }
 
-    case WXSDLJOY_BUTTON:
+    case wxJoyControl::Button:
         return WXJB_BUTTON;
 
     default:
@@ -68,23 +68,23 @@ int wxJoyKeyTextCtrl::DigitalButton(wxSDLJoyEvent& event)
     }
 }
 
-void wxJoyKeyTextCtrl::OnJoy(wxSDLJoyEvent& event)
+void wxJoyKeyTextCtrl::OnJoy(wxJoyEvent& event)
 {
     static wxLongLong last_event = 0;
 
     int16_t val  = event.control_value();
-    wxSDLControl type = event.control();
+    wxJoyControl type = event.control();
 
     // Filter consecutive axis motions within 300ms, as this adds two bindings
     // +1/-1 instead of the one intended.
-    if (type == WXSDLJOY_AXIS && wxGetUTCTimeMillis() - last_event < 300)
+    if (type == wxJoyControl::Axis && wxGetUTCTimeMillis() - last_event < 300)
         return;
 
     last_event = wxGetUTCTimeMillis();
 
     int mod = DigitalButton(event);
     uint8_t key = event.control_index();
-    unsigned joy = event.player_index();
+    unsigned joy = event.joystick().player_index();
 
     if (!val || mod < 0)
         return;

--- a/src/wx/widgets/wx/joyedit.h
+++ b/src/wx/widgets/wx/joyedit.h
@@ -48,8 +48,8 @@ public:
 
     // key is event.GetControlIndex(), and joy is event.GetJoy() + 1
     // mod is derived from GetControlValue() and GetControlType():
-    // convert wxSDLJoyEvent's type+val into mod (WXJB_*)
-    static int DigitalButton(wxSDLJoyEvent& event);
+    // convert wxJoyEvent's type+val into mod (WXJB_*)
+    static int DigitalButton(wxJoyEvent& event);
     // convert mod+key to accel string, separated by -
     static wxString ToString(int mod, int key, int joy, bool isConfig = false);
     // convert multiple keys, separated by multikey
@@ -68,7 +68,7 @@ public:
     static wxString FromAccelToString(wxAcceleratorEntry_v keys, wxChar sep = wxT(','), bool isConfig = false);
 
 protected:
-    void OnJoy(wxSDLJoyEvent&);
+    void OnJoy(wxJoyEvent&);
 
     DECLARE_DYNAMIC_CLASS(wxJoyKeyTextCtrl);
     DECLARE_EVENT_TABLE();

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -877,13 +877,13 @@ int MainFrame::FilterEvent(wxEvent& event)
                 return wxEventFilter::Event_Processed;
         }
     }
-    else if (event.GetEventType() == wxEVT_SDLJOY && !menus_opened && !dialog_opened)
+    else if (event.GetEventType() == wxEVT_JOY && !menus_opened && !dialog_opened)
     {
-        wxSDLJoyEvent& je = (wxSDLJoyEvent&)event;
+        wxJoyEvent& je = (wxJoyEvent&)event;
         if (je.control_value() == 0) return -1; // joystick button UP
         uint8_t key = je.control_index();
         int mod = wxJoyKeyTextCtrl::DigitalButton(je);
-        int joy = je.player_index();
+        int joy = je.joystick().player_index();
         wxString label = wxJoyKeyTextCtrl::ToString(mod, key, joy);
         wxAcceleratorEntry_v accels = wxGetApp().GetAccels();
         for (size_t i = 0; i < accels.size(); ++i)
@@ -934,14 +934,15 @@ void MainFrame::SetJoystick()
     if (!emulating)
         return;
 
-    std::unordered_set<unsigned> needed_joysticks;
+    std::set<wxJoystick> needed_joysticks;
     for (int i = 0; i < 4; i++) {
         for (int j = 0; j < NUM_KEYS; j++) {
             wxJoyKeyBinding_v b = gopts.joykey_bindings[i][j];
             for (size_t k = 0; k < b.size(); k++) {
                 int jn = b[k].joy;
                 if (jn) {
-                    needed_joysticks.insert(jn);
+                    needed_joysticks.insert(
+                        wxJoystick::FromLegacyPlayerIndex(jn));
                 }
             }
         }

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -360,7 +360,7 @@ private:
     wxMenu* recent;
     wxAcceleratorEntryUnicode recent_accel[10];
     // joystick reader
-    wxSDLJoy joy;
+    wxJoyPoller joy;
     JoystickPoller* jpoll = nullptr;
 
     // helper function for adding menu to accel editor
@@ -647,7 +647,7 @@ protected:
     void OnIdle(wxIdleEvent&);
     void OnKeyDown(wxKeyEvent& ev);
     void OnKeyUp(wxKeyEvent& ev);
-    void OnSDLJoy(wxSDLJoyEvent& ev);
+    void OnSDLJoy(wxJoyEvent& ev);
     void PaintEv(wxPaintEvent& ev);
     void EraseBackground(wxEraseEvent& ev);
     void OnSize(wxSizeEvent& ev);


### PR DESCRIPTION
* Add `wxJoystick` to abstract what was previously referred to as
  `player_index`. This is a first step towards a larger refactor of
  input handling.
* Remove "SDL" from types that are not directly SDL-related, namely
  `wxSDLJoyEvent`, `wxSDLControl`.
* Rename `wxSDLJoy` into `wxJoyPoller`. This clarifies the use of this
  class.

Issue: #745