### PR TITLE
Add checkbox to Key Shortcuts to disable Fn keys

### DIFF
--- a/src/wx/xrc/AccelConfig.xrc
+++ b/src/wx/xrc/AccelConfig.xrc
@@ -105,24 +105,37 @@
                 <flag>wxALL|wxEXPAND</flag>
                 <border>5</border>
               </object>
+              <object class="sizeritem">
+                <object class="wxStdDialogButtonSizer">
+                  <object class="button">
+                    <object class="wxButton" name="wxID_OK"/>
+                  </object>
+                  <object class="button">
+                    <object class="wxButton" name="wxID_CANCEL"/>
+                  </object>
+                </object>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+              </object>
               <orient>wxVERTICAL</orient>
             </object>
             <flag>wxEXPAND</flag>
           </object>
-        </object>
-      </object>
-      <object class="sizeritem">
-        <object class="wxStdDialogButtonSizer">
-          <object class="button">
-            <object class="wxButton" name="wxID_OK"/>
+          <object class="sizeritem">
+            <object class="wxBoxSizer">
+              <object class="sizeritem">
+                <object class="wxCheckBox" name="ToggleFnKeyShortcuts">
+                  <label>Disable Function Keys</label>
+                </object>
+                <flag>wxALL</flag>
+                <border>5</border>
+              </object>
+              <orient>wxVERTICAL</orient>
+            </object>
           </object>
-          <object class="button">
-            <object class="wxButton" name="wxID_CANCEL"/>
-          </object>
-        </object>
-        <flag>wxALL|wxEXPAND</flag>
-        <border>5</border>
+        </object> 
       </object>
+
     </object>
   </object>
 </resource>


### PR DESCRIPTION
Added a checkbox to the Key Shortcuts window that, when checked, will temporarily remove keybinds involving F1 through F10. Once the box is unchecked, the default keybinds are restored.

A user is likely to hit a function key and accidentally load a save state, potentially losing game progress (see #900 and #781), so this addition does the work of manually having to remove these defaults or rebind those keys.