### PR TITLE
fix x86 builds crashing when /Gs set by Optimizations, turns on full optimizations for x86

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -787,7 +787,7 @@ elseif(MSVC)
 
         if(CMAKE_BUILD_TYPE STREQUAL Release)
             if(X86_32)
-                add_compiler_flags(${runtime} /Ot /Oy /GF /Gy /Ob3)
+                add_compiler_flags(${runtime} /O2 /Ob3)
             else()
                 add_compiler_flags(${runtime} /O2 /Ob3)
             endif()

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2308,7 +2308,7 @@ void GLDrawingPanel::DrawingPanelInit()
             systemScreenMessage(_("Failed to set glXSwapIntervalMESA"));
     }
 #elif defined(__WXMSW__)
-    typedef char* (*wglext)();
+    typedef const char* (*wglext)();
     wglext wglGetExtensionsStringEXT = (wglext)wglGetProcAddress("wglGetExtensionsStringEXT");
     if (wglGetExtensionsStringEXT == NULL) {
         systemScreenMessage(_("No support for wglGetExtensionsStringEXT"));
@@ -2317,7 +2317,7 @@ void GLDrawingPanel::DrawingPanelInit()
         systemScreenMessage(_("No support for WGL_EXT_swap_control"));
     }
 
-    typedef bool (*PFNWGLSWAPINTERVALEXTPROC)(int);
+    typedef BOOL (__stdcall *PFNWGLSWAPINTERVALEXTPROC)(BOOL);
     static PFNWGLSWAPINTERVALEXTPROC wglSwapIntervalEXT = NULL;
     wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC)wglGetProcAddress("wglSwapIntervalEXT");
     if (wglSwapIntervalEXT)


### PR DESCRIPTION
turns out bools are not BOOLS, and PFNWGLSWAPINTERVALEXTPROC is a BOOL

also glGetExtensionsStringEXT expects a Const Char*

Resolves a case of undefined behavior that allows x86 builds to run as fast as x64.