### PR TITLE
Introduce wxUserInput class

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -728,6 +728,7 @@ set(
     wxutil.cpp
     widgets/keyedit.cpp
     widgets/joyedit.cpp
+    widgets/userinput.cpp
     widgets/sdljoy.cpp
     widgets/wxmisc.cpp
     # probably ought to be in common
@@ -761,6 +762,7 @@ set(
     widgets/wx/keyedit.h
     widgets/wx/joyedit.h
     widgets/wx/sdljoy.h
+    widgets/wx/userinput.h
     widgets/wx/webupdatedef.h
     widgets/wx/wxmisc.h
     # probably ought to be in common

--- a/src/wx/widgets/userinput.cpp
+++ b/src/wx/widgets/userinput.cpp
@@ -1,0 +1,94 @@
+#include "wx/userinput.h"
+
+#include "wx/string.h"
+#include "wxutil.h"
+
+// static
+wxUserInput wxUserInput::Invalid() {
+    return wxUserInput(Device::Invalid, 0, 0, 0);
+}
+
+// static
+wxUserInput wxUserInput::FromKeyEvent(const wxKeyEvent& event) {
+    return wxUserInput(Device::Keyboard,
+                       event.GetModifiers(),
+                       getKeyboardKeyCode(event),
+                       0);
+}
+
+// static
+wxUserInput wxUserInput::FromJoyEvent(const wxJoyEvent& event) {
+    return wxUserInput(Device::Joystick,
+                       wxJoyKeyTextCtrl::DigitalButton(event),
+                       event.control_index(),
+                       event.joystick().player_index());
+}
+
+// static
+wxUserInput wxUserInput::FromLegacyJoyKeyBinding(const wxJoyKeyBinding& binding) {
+    return wxUserInput(binding.joy == 0 ? Device::Keyboard : Device::Joystick,
+                       binding.mod,
+                       binding.key,
+                       binding.joy);
+}
+
+// static
+wxUserInput wxUserInput::FromString(const wxString& string) {
+    // TODO: Move the implementation here once all callers have been updated.
+    int mod = 0;
+    int key = 0;
+    int joy = 0;
+    if (!wxJoyKeyTextCtrl::FromString(string, mod, key, joy)) {
+        return wxUserInput::Invalid();
+    }
+    return wxUserInput::FromLegacyJoyKeyBinding({key, mod, joy});
+}
+
+wxString wxUserInput::ToString() {
+    if (!config_string_.IsNull()) {
+        return config_string_;
+    }
+
+    // TODO: Move the implementation here once all callers have been updated.
+    config_string_ = wxJoyKeyTextCtrl::ToString(mod_, key_, joy_);
+    return config_string_;
+}
+
+bool wxUserInput::operator==(const wxUserInput& other) const {
+    return device_ == other.device_ && mod_ == other.mod_ &&
+           key_ == other.key_ && joy_ == other.joy_;
+}
+bool wxUserInput::operator!=(const wxUserInput& other) const {
+    return !(*this == other);
+}
+bool wxUserInput::operator<(const wxUserInput& other) const {
+    if (device_ < other.device_) {
+        return device_ < other.device_;
+    }
+    if (joy_ != other.joy_) {
+        return joy_ < other.joy_;
+    }
+    if (key_ != other.key_) {
+        return key_ < other.key_;
+    }
+    if (mod_ != other.mod_) {
+        return mod_ < other.mod_;
+    }
+    return false;
+}
+bool wxUserInput::operator<=(const wxUserInput& other) const {
+    return !(*this > other);
+}
+bool wxUserInput::operator>(const wxUserInput& other) const {
+    return other < *this;
+}
+bool wxUserInput::operator>=(const wxUserInput& other) const {
+    return !(*this < other);
+}
+
+// Actual underlying constructor.
+wxUserInput::wxUserInput(Device device, int mod, uint8_t key, unsigned joy) :
+    device_(device),
+    mod_(mod),
+    key_(key),
+    joy_(joy) {}

--- a/src/wx/widgets/wx/joyedit.h
+++ b/src/wx/widgets/wx/joyedit.h
@@ -49,7 +49,7 @@ public:
     // key is event.GetControlIndex(), and joy is event.GetJoy() + 1
     // mod is derived from GetControlValue() and GetControlType():
     // convert wxJoyEvent's type+val into mod (WXJB_*)
-    static int DigitalButton(wxJoyEvent& event);
+    static int DigitalButton(const wxJoyEvent& event);
     // convert mod+key to accel string, separated by -
     static wxString ToString(int mod, int key, int joy, bool isConfig = false);
     // convert multiple keys, separated by multikey

--- a/src/wx/widgets/wx/userinput.h
+++ b/src/wx/widgets/wx/userinput.h
@@ -1,0 +1,71 @@
+#ifndef _WX_USER_INPUT_H_
+#define _WX_USER_INPUT_H_
+
+#include <optional>
+
+#include "wx/joyedit.h"
+#include "wx/sdljoy.h"
+
+// Abstraction for a user input, which can come from a keyboard or a joystick.
+// This class implements comparison operators so it can be used in sets and as
+// a key in maps.
+//
+// TODO: Right now, this class is implemented as a thin wrapper around the key,
+// mod and joy user input representation used in many places in the code base.
+// This is to ease a transition away from the wxJoyKeyBinding type, which
+// wxUserInput will eventually replace.
+class wxUserInput {
+public:
+    // The device type for a user control.
+    enum class Device {
+        Invalid = 0,
+        Keyboard,
+        Joystick,
+        Last = Joystick
+    };
+
+    // Invalid wxUserInput, mainly used for comparison.
+    static wxUserInput Invalid();
+
+    // Constructor from a wxKeyEvent.
+    static wxUserInput FromKeyEvent(const wxKeyEvent& event);
+
+    // Constructor from a wxJoyEvent.
+    static wxUserInput FromJoyEvent(const wxJoyEvent& event);
+
+    // Constructor from a configuration string. Returns wxUserInput::Invalid()
+    // on parsing failure.
+    static wxUserInput FromString(const wxString& string);
+
+    // TODO: Remove this once all uses of wxJoyKeyBinding have been removed.
+    static wxUserInput FromLegacyJoyKeyBinding(const wxJoyKeyBinding& binding);
+
+    // Converts to a configuration string. Computed on first call, and cached
+    // for further calls.
+    wxString ToString();
+
+    // TODO: Remove these accessors once all callers have been removed.
+    int mod() const { return mod_; }
+    int key() const { return key_; }
+    int joy() const { return joy_; }
+
+    bool operator==(const wxUserInput& other) const;
+    bool operator!=(const wxUserInput& other) const;
+    bool operator<(const wxUserInput& other) const;
+    bool operator<=(const wxUserInput& other) const;
+    bool operator>(const wxUserInput& other) const;
+    bool operator>=(const wxUserInput& other) const;
+
+private:
+    wxUserInput(Device device, int mod, uint8_t key, unsigned joy);
+
+    Device device_;
+    int mod_;
+    uint8_t key_;
+    unsigned joy_;
+
+    wxString config_string_;
+};
+
+
+#endif  /* _WX_USER_INPUT_H */

--- a/src/wx/wxutil.cpp
+++ b/src/wx/wxutil.cpp
@@ -2,7 +2,7 @@
 #include "../common/contains.h"
 
 
-int getKeyboardKeyCode(wxKeyEvent& event)
+int getKeyboardKeyCode(const wxKeyEvent& event)
 {
     int uc = event.GetUnicodeKey();
     if (uc != WXK_NONE) {

--- a/src/wx/wxutil.h
+++ b/src/wx/wxutil.h
@@ -3,7 +3,7 @@
 
 #include <wx/event.h>
 
-int getKeyboardKeyCode(wxKeyEvent& event);
+int getKeyboardKeyCode(const wxKeyEvent& event);
 
 #include <wx/accel.h>
 

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -27,6 +27,7 @@
 
 // The built-in vba-over.ini
 #include "builtin-over.h"
+#include "wx/userinput.h"
 
 IMPLEMENT_APP(wxvbamApp)
 IMPLEMENT_DYNAMIC_CLASS(MainFrame, wxFrame)
@@ -881,10 +882,7 @@ int MainFrame::FilterEvent(wxEvent& event)
     {
         wxJoyEvent& je = (wxJoyEvent&)event;
         if (je.control_value() == 0) return -1; // joystick button UP
-        uint8_t key = je.control_index();
-        int mod = wxJoyKeyTextCtrl::DigitalButton(je);
-        int joy = je.joystick().player_index();
-        wxString label = wxJoyKeyTextCtrl::ToString(mod, key, joy);
+        wxString label = wxUserInput::FromJoyEvent(je).ToString();
         wxAcceleratorEntry_v accels = wxGetApp().GetAccels();
         for (size_t i = 0; i < accels.size(); ++i)
         {


### PR DESCRIPTION
This introduces a new abstraction for any user input. The long-term goal
is to replace every usage of "custom" {key, mod, joy} triplets in the
code base with this new class.

This class implements comparison operators, allowing for faster access
in a set or as a key in a map, compared to the vectors currently used.

Issue: #745