### PR TITLE
error typedef Status fix for #904

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2165,6 +2165,9 @@ void BasicDrawingPanel::DrawImage(wxWindowDC& dc, wxImage* im)
 #include <OpenGL/OpenGL.h>
 #endif
 #ifdef __WXGTK__ // should actually check for X11, but GTK implies X11
+#ifndef Status
+#define Status int
+#endif
 #include <GL/glx.h>
 #endif
 #ifdef __WXMSW__


### PR DESCRIPTION
Fixes #904 for various Linux distributions including Arch and Ubuntu by defining ```Status``` required by _glext.h_ if it has not already been done.
```
vbam/visualboyadvance-m/src/wx/panel.cpp:2171:
/usr/include/GL/glxext.h:950:9: error: typedef ‘Status’ is initialized (use ‘decltype’ instead)
950 | typedef Status ( *PFNGLXGETTRANSPARENTINDEXSUNPROC) (Display *dpy, Window overlay, Window underlay, unsigned long *pTransparentIndex);
| ^~~~~~
```