### PR TITLE
[options] Refactor INI options

### DIFF
--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-21 17:52+0000\n"
+"POT-Creation-Date: 2022-09-06 21:07-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,55 +17,55 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: wxvbam.cpp:225
+#: wxvbam.cpp:227
 msgid "visualboyadvance-m"
 msgstr ""
 
-#: wxvbam.cpp:446
+#: wxvbam.cpp:448
 msgid "Could not create main window"
 msgstr ""
 
-#: wxvbam.cpp:517
+#: wxvbam.cpp:519
 msgid "Save built-in XRC file and exit"
 msgstr ""
 
-#: wxvbam.cpp:520
+#: wxvbam.cpp:522
 msgid "Save built-in vba-over.ini and exit"
 msgstr ""
 
-#: wxvbam.cpp:523
+#: wxvbam.cpp:525
 msgid "Print configuration path and exit"
 msgstr ""
 
-#: wxvbam.cpp:526
+#: wxvbam.cpp:528
 msgid "Start in full-screen mode"
 msgstr ""
 
-#: wxvbam.cpp:529
+#: wxvbam.cpp:531
 msgid "Set a configuration file"
 msgstr ""
 
-#: wxvbam.cpp:533
+#: wxvbam.cpp:535
 msgid "Delete shared link state first, if it exists"
 msgstr ""
 
-#: wxvbam.cpp:540
+#: wxvbam.cpp:542
 msgid "List all settable options and exit"
 msgstr ""
 
-#: wxvbam.cpp:543
+#: wxvbam.cpp:545
 msgid "ROM file"
 msgstr ""
 
-#: wxvbam.cpp:545
+#: wxvbam.cpp:547
 msgid "<config>=<value>"
 msgstr ""
 
-#: wxvbam.cpp:576
+#: wxvbam.cpp:578
 msgid "Configuration/build error: can't find built-in xrc"
 msgstr ""
 
-#: wxvbam.cpp:584
+#: wxvbam.cpp:586
 #, c-format
 msgid ""
 "Wrote built-in configuration to %s.\n"
@@ -74,11 +74,11 @@ msgid ""
 "built-in:"
 msgstr ""
 
-#: wxvbam.cpp:599
+#: wxvbam.cpp:601
 msgid "Configuration is read from, in order:"
 msgstr ""
 
-#: wxvbam.cpp:613
+#: wxvbam.cpp:615
 #, c-format
 msgid ""
 "Wrote built-in override file to %s\n"
@@ -86,13 +86,13 @@ msgid ""
 "from search path:"
 msgstr ""
 
-#: wxvbam.cpp:619
+#: wxvbam.cpp:621
 msgid ""
 "\n"
 "\tbuilt-in"
 msgstr ""
 
-#: wxvbam.cpp:630
+#: wxvbam.cpp:636
 msgid ""
 "Options set from the command line are saved if any configuration changes are "
 "made in the user interface.\n"
@@ -101,255 +101,255 @@ msgid ""
 "\n"
 msgstr ""
 
-#: wxvbam.cpp:651
+#: wxvbam.cpp:644
 msgid ""
 "The commands available for the Keyboard/* option are:\n"
 "\n"
 msgstr ""
 
-#: wxvbam.cpp:663
+#: wxvbam.cpp:655
 msgid "Configuration file not found."
 msgstr ""
 
-#: wxvbam.cpp:696
+#: wxvbam.cpp:688
 msgid "Bad configuration option or multiple ROM files given:\n"
 msgstr ""
 
-#: guiinit.cpp:83
+#: guiinit.cpp:84
 msgid "Start!"
 msgstr ""
 
-#: guiinit.cpp:102 xrc/NetLink.xrc:99
+#: guiinit.cpp:103 xrc/NetLink.xrc:99
 msgid "Connect"
 msgstr ""
 
-#: guiinit.cpp:119
+#: guiinit.cpp:120
 msgid "You must enter a valid host name"
 msgstr ""
 
-#: guiinit.cpp:120
+#: guiinit.cpp:121
 msgid "Host name invalid"
 msgstr ""
 
-#: guiinit.cpp:138
+#: guiinit.cpp:139
 msgid "Waiting for clients..."
 msgstr ""
 
-#: guiinit.cpp:139
+#: guiinit.cpp:140
 #, c-format
 msgid "Server IP address is: %s\n"
 msgstr ""
 
-#: guiinit.cpp:141
+#: guiinit.cpp:142
 msgid "Waiting for connection..."
 msgstr ""
 
-#: guiinit.cpp:142
+#: guiinit.cpp:143
 #, c-format
 msgid "Connecting to %s\n"
 msgstr ""
 
-#: guiinit.cpp:175
+#: guiinit.cpp:176
 msgid ""
 "Error occurred.\n"
 "Please try again."
 msgstr ""
 
-#: guiinit.cpp:242 guiinit.cpp:295
+#: guiinit.cpp:243 guiinit.cpp:296
 msgid "Select cheat file"
 msgstr ""
 
-#: guiinit.cpp:243
+#: guiinit.cpp:244
 msgid "VBA cheat lists (*.clt)|*.clt|CHT cheat lists (*.cht)|*.cht"
 msgstr ""
 
-#: guiinit.cpp:262 panel.cpp:449
+#: guiinit.cpp:263 panel.cpp:449
 msgid "Loaded cheats"
 msgstr ""
 
-#: guiinit.cpp:296
+#: guiinit.cpp:297
 msgid "VBA cheat lists (*.clt)|*.clt"
 msgstr ""
 
-#: guiinit.cpp:314
+#: guiinit.cpp:315
 msgid "Saved cheats"
 msgstr ""
 
-#: guiinit.cpp:345 guiinit.cpp:364
+#: guiinit.cpp:346 guiinit.cpp:365
 msgid "Restore old values?"
 msgstr ""
 
-#: guiinit.cpp:346 guiinit.cpp:365
+#: guiinit.cpp:347 guiinit.cpp:366
 msgid "Removing cheats"
 msgstr ""
 
-#: guiinit.cpp:756 xrc/JoyPanel.xrc:364
+#: guiinit.cpp:757 xrc/JoyPanel.xrc:364
 msgid "GameShark"
 msgstr ""
 
-#: guiinit.cpp:757 cmdevents.cpp:678
+#: guiinit.cpp:758 cmdevents.cpp:675
 msgid "GameGenie"
 msgstr ""
 
-#: guiinit.cpp:759
+#: guiinit.cpp:760
 msgid "Generic Code"
 msgstr ""
 
-#: guiinit.cpp:760
+#: guiinit.cpp:761
 msgid "GameShark Advance"
 msgstr ""
 
-#: guiinit.cpp:761
+#: guiinit.cpp:762
 msgid "CodeBreaker Advance"
 msgstr ""
 
-#: guiinit.cpp:762
+#: guiinit.cpp:763
 msgid "Flashcart CHT"
 msgstr ""
 
-#: guiinit.cpp:830 guiinit.cpp:1085
+#: guiinit.cpp:831 guiinit.cpp:1086
 msgid "Number cannot be empty"
 msgstr ""
 
-#: guiinit.cpp:868
+#: guiinit.cpp:869
 #, c-format
 msgid "Search produced %d results.  Please refine better"
 msgstr ""
 
-#: guiinit.cpp:880
+#: guiinit.cpp:881
 msgid "Search produced no results"
 msgstr ""
 
-#: guiinit.cpp:1043
+#: guiinit.cpp:1044
 msgid "8-bit "
 msgstr ""
 
-#: guiinit.cpp:1047
+#: guiinit.cpp:1048
 msgid "16-bit "
 msgstr ""
 
-#: guiinit.cpp:1051
+#: guiinit.cpp:1052
 msgid "32-bit "
 msgstr ""
 
-#: guiinit.cpp:1057
+#: guiinit.cpp:1058
 msgid "signed decimal"
 msgstr ""
 
-#: guiinit.cpp:1061
+#: guiinit.cpp:1062
 msgid "unsigned decimal"
 msgstr ""
 
-#: guiinit.cpp:1065
+#: guiinit.cpp:1066
 msgid "unsigned hexadecimal"
 msgstr ""
 
-#: guiinit.cpp:1543
+#: guiinit.cpp:1544
 #, c-format
 msgid "%d frames = %.2f ms"
 msgstr ""
 
-#: guiinit.cpp:1555
+#: guiinit.cpp:1556
 msgid "Default device"
 msgstr ""
 
-#: guiinit.cpp:1726
+#: guiinit.cpp:1727
 msgid "Desktop mode"
 msgstr ""
 
-#: guiinit.cpp:1733
+#: guiinit.cpp:1734
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: guiinit.cpp:1846 cmdevents.cpp:748 xrc/DisplayConfig.xrc:85
+#: guiinit.cpp:1847 cmdevents.cpp:745 xrc/DisplayConfig.xrc:85
 #: xrc/DisplayConfig.xrc:135 xrc/DisplayConfig.xrc:221
 #: xrc/GameBoyAdvanceConfig.xrc:32 xrc/GameBoyAdvanceConfig.xrc:204
 #: xrc/SoundConfig.xrc:219 xrc/SoundConfig.xrc:309
 msgid "None"
 msgstr ""
 
-#: guiinit.cpp:1887
+#: guiinit.cpp:1888
 #, c-format
 msgid "No usable rpi plugins found in %s"
 msgstr ""
 
-#: guiinit.cpp:1907 xrc/DisplayConfig.xrc:107
+#: guiinit.cpp:1908 xrc/DisplayConfig.xrc:107
 msgid "Plugin"
 msgstr ""
 
-#: guiinit.cpp:1935
+#: guiinit.cpp:1936
 msgid "Please select a plugin or a different filter"
 msgstr ""
 
-#: guiinit.cpp:1936
+#: guiinit.cpp:1937
 msgid "Plugin selection error"
 msgstr ""
 
-#: guiinit.cpp:2149
+#: guiinit.cpp:2150
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: guiinit.cpp:2149
+#: guiinit.cpp:2150
 msgid "Confirm"
 msgstr ""
 
-#: guiinit.cpp:2740
+#: guiinit.cpp:2741
 msgid "Main icon not found"
 msgstr ""
 
-#: guiinit.cpp:2750
+#: guiinit.cpp:2751
 msgid "Browse"
 msgstr ""
 
-#: guiinit.cpp:2764
+#: guiinit.cpp:2765
 msgid "Main display panel not found"
 msgstr ""
 
-#: guiinit.cpp:2941
+#: guiinit.cpp:2942
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: guiinit.cpp:2955
+#: guiinit.cpp:2956
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: guiinit.cpp:3094
+#: guiinit.cpp:3097
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: guiinit.cpp:3302
+#: guiinit.cpp:3305
 msgid "Code"
 msgstr ""
 
-#: guiinit.cpp:3311
+#: guiinit.cpp:3314
 msgid "Description"
 msgstr ""
 
-#: guiinit.cpp:3385 xrc/CheatAdd.xrc:31
+#: guiinit.cpp:3388 xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: guiinit.cpp:3386
+#: guiinit.cpp:3389
 msgid "Old Value"
 msgstr ""
 
-#: guiinit.cpp:3387
+#: guiinit.cpp:3390
 msgid "New Value"
 msgstr ""
 
-#: guiinit.cpp:3918
+#: guiinit.cpp:3917
 msgid "Menu commands"
 msgstr ""
 
-#: guiinit.cpp:3941
+#: guiinit.cpp:3940
 msgid "Other commands"
 msgstr ""
 
-#: guiinit.cpp:4052
+#: guiinit.cpp:4051
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -851,29 +851,19 @@ msgstr ""
 msgid "Network is not supported in local mode."
 msgstr ""
 
-#: opts.cpp:649 opts.cpp:951
-#, c-format
-msgid "Invalid value %s for option %s; valid values are %s%s%s"
-msgstr ""
-
-#: opts.cpp:666 opts.cpp:963
-#, c-format
-msgid "Invalid value %d for option %s; valid values are %d - %d"
-msgstr ""
-
-#: opts.cpp:673 opts.cpp:682 opts.cpp:971 opts.cpp:979
-#, c-format
-msgid "Invalid value %f for option %s; valid values are %f - %f"
-msgstr ""
-
-#: opts.cpp:739 opts.cpp:760 opts.cpp:1047
+#: opts.cpp:492 opts.cpp:513 opts.cpp:745
 #, c-format
 msgid "Invalid key binding %s for %s"
 msgstr ""
 
-#: opts.cpp:934
+#: opts.cpp:668 opts.cpp:677 opts.cpp:686 opts.cpp:695 vbam-options.cpp:313
 #, c-format
-msgid "Invalid flag option %s - %s ignored"
+msgid "Invalid value %s for option %s"
+msgstr ""
+
+#: opts.cpp:767
+#, c-format
+msgid "Unknown option %s with value %s"
 msgstr ""
 
 #: sys.cpp:195 sys.cpp:256
@@ -1108,6 +1098,456 @@ msgstr ""
 #: panel.cpp:2429
 #, c-format
 msgid "Error in video recording (%s); aborting"
+msgstr ""
+
+#: vbam-options.cpp:218
+#, c-format
+msgid "Invalid value %f for option %s; valid values are %f - %f"
+msgstr ""
+
+#: vbam-options.cpp:232 vbam-options.cpp:246
+#, c-format
+msgid "Invalid value %d for option %s; valid values are %d - %d"
+msgstr ""
+
+#: vbam-options.cpp:297
+#, c-format
+msgid "Invalid value %d for option %s; valid values are %s"
+msgstr ""
+
+#: vbam-options-static.cpp:342
+msgid "Use bilinear filter with 3d renderer"
+msgstr ""
+
+#: vbam-options-static.cpp:343
+msgid "Full-screen filter to apply"
+msgstr ""
+
+#: vbam-options-static.cpp:344
+msgid "Filter plugin library"
+msgstr ""
+
+#: vbam-options-static.cpp:345
+msgid "Interframe blending function"
+msgstr ""
+
+#: vbam-options-static.cpp:346
+msgid "Keep window on top"
+msgstr ""
+
+#: vbam-options-static.cpp:347
+msgid "Maximum number of threads to run filters in"
+msgstr ""
+
+#: vbam-options-static.cpp:348
+msgid "Render method; if unsupported, simple method will be used"
+msgstr ""
+
+#: vbam-options-static.cpp:349
+msgid "Default scale factor"
+msgstr ""
+
+#: vbam-options-static.cpp:350
+msgid "Retain aspect ratio when resizing"
+msgstr ""
+
+#: vbam-options-static.cpp:353
+msgid "BIOS file to use for GB, if enabled"
+msgstr ""
+
+#: vbam-options-static.cpp:354
+msgid "GB color enhancement, if enabled"
+msgstr ""
+
+#: vbam-options-static.cpp:355
+msgid "Enable DX Colorization Hacks"
+msgstr ""
+
+#: vbam-options-static.cpp:356 vbam-options-static.cpp:368
+msgid "Apply LCD filter, if enabled"
+msgstr ""
+
+#: vbam-options-static.cpp:357
+msgid "BIOS file to use for GBC, if enabled"
+msgstr ""
+
+#: vbam-options-static.cpp:358
+msgid ""
+"The default palette, as 8 comma-separated 4-digit hex integers (rgb555)."
+msgstr ""
+
+#: vbam-options-static.cpp:359
+msgid ""
+"The first user palette, as 8 comma-separated 4-digit hex integers (rgb555)."
+msgstr ""
+
+#: vbam-options-static.cpp:360
+msgid ""
+"The second user palette, as 8 comma-separated 4-digit hex integers (rgb555)."
+msgstr ""
+
+#: vbam-options-static.cpp:361
+msgid "Automatically gather a full page before printing"
+msgstr ""
+
+#: vbam-options-static.cpp:362
+msgid "Automatically save printouts as screen captures with -print suffix"
+msgstr ""
+
+#: vbam-options-static.cpp:363 vbam-options-static.cpp:379
+msgid "Directory to look for ROM files"
+msgstr ""
+
+#: vbam-options-static.cpp:364
+msgid "Directory to look for GBC ROM files"
+msgstr ""
+
+#: vbam-options-static.cpp:367
+msgid "BIOS file to use, if enabled"
+msgstr ""
+
+#: vbam-options-static.cpp:370
+msgid "Enable link at boot"
+msgstr ""
+
+#: vbam-options-static.cpp:371
+msgid "Enable faster network protocol by default"
+msgstr ""
+
+#: vbam-options-static.cpp:372
+msgid "Default network link client host"
+msgstr ""
+
+#: vbam-options-static.cpp:373
+msgid "Default network link server IP to bind"
+msgstr ""
+
+#: vbam-options-static.cpp:374
+msgid "Default network link port (server and client)"
+msgstr ""
+
+#: vbam-options-static.cpp:375
+msgid "Default network protocol"
+msgstr ""
+
+#: vbam-options-static.cpp:376
+msgid "Link timeout (ms)"
+msgstr ""
+
+#: vbam-options-static.cpp:377
+msgid "Link cable type"
+msgstr ""
+
+#: vbam-options-static.cpp:382
+msgid "Automatically load last saved state"
+msgstr ""
+
+#: vbam-options-static.cpp:383
+msgid ""
+"Directory to store game save files (relative paths are relative to ROM; "
+"blank is config dir)"
+msgstr ""
+
+#: vbam-options-static.cpp:384
+msgid "Freeze recent load list"
+msgstr ""
+
+#: vbam-options-static.cpp:385
+msgid ""
+"Directory to store A/V and game recordings (relative paths are relative to "
+"ROM)"
+msgstr ""
+
+#: vbam-options-static.cpp:386
+msgid "Number of seconds between rewind snapshots (0 to disable)"
+msgstr ""
+
+#: vbam-options-static.cpp:387
+msgid "Directory to store screenshots (relative paths are relative to ROM)"
+msgstr ""
+
+#: vbam-options-static.cpp:388
+msgid ""
+"Directory to store saved state files (relative paths are relative to "
+"BatteryDir)"
+msgstr ""
+
+#: vbam-options-static.cpp:389
+msgid "Enable status bar"
+msgstr ""
+
+#: vbam-options-static.cpp:392
+msgid ""
+"The parameter Joypad/<n>/<button> contains a comma-separated list of key "
+"names which map to joypad #<n> button <button>.  Button is one of Up, Down, "
+"Left, Right, A, B, L, R, Select, Start, MotionUp, MotionDown, MotionLeft, "
+"MotionRight, AutoA, AutoB, Speed, Capture, GS"
+msgstr ""
+
+#: vbam-options-static.cpp:393
+msgid "The autofire toggle period, in frames (1/60 s)"
+msgstr ""
+
+#: vbam-options-static.cpp:394
+msgid "The number of the stick to use in single-player mode"
+msgstr ""
+
+#: vbam-options-static.cpp:397
+msgid ""
+"The parameter Keyboard/<cmd> contains a comma-separated list of key names (e."
+"g. Alt-Shift-F1).  When the named key is pressed, the command <cmd> is "
+"executed."
+msgstr ""
+
+#: vbam-options-static.cpp:400
+msgid "Enable AGB debug print"
+msgstr ""
+
+#: vbam-options-static.cpp:401
+msgid "Auto skip frames."
+msgstr ""
+
+#: vbam-options-static.cpp:402
+msgid "Apply IPS/UPS/IPF patches if found"
+msgstr ""
+
+#: vbam-options-static.cpp:403
+msgid "Automatically save and load cheat list"
+msgstr ""
+
+#: vbam-options-static.cpp:404
+msgid "Automatically enable border for Super GameBoy games"
+msgstr ""
+
+#: vbam-options-static.cpp:405
+msgid "Always enable border"
+msgstr ""
+
+#: vbam-options-static.cpp:406
+msgid "Screen capture file format"
+msgstr ""
+
+#: vbam-options-static.cpp:407
+msgid "Enable cheats"
+msgstr ""
+
+#: vbam-options-static.cpp:409 xrc/MainMenu.xrc:355
+msgid "Enable MMX"
+msgstr ""
+
+#: vbam-options-static.cpp:411
+msgid "Disable on-screen status messages"
+msgstr ""
+
+#: vbam-options-static.cpp:412
+msgid "Type of system to emulate"
+msgstr ""
+
+#: vbam-options-static.cpp:413
+msgid "Flash size 0 = 64KB 1 = 128KB"
+msgstr ""
+
+#: vbam-options-static.cpp:414
+msgid "Skip frames.  Values are 0-9 or -1 to skip automatically based on time."
+msgstr ""
+
+#: vbam-options-static.cpp:415
+msgid "Fullscreen mode color depth (0 = any)"
+msgstr ""
+
+#: vbam-options-static.cpp:416
+msgid "Fullscreen mode frequency (0 = any)"
+msgstr ""
+
+#: vbam-options-static.cpp:417
+msgid "Fullscreen mode height (0 = desktop)"
+msgstr ""
+
+#: vbam-options-static.cpp:418
+msgid "Fullscreen mode width (0 = desktop)"
+msgstr ""
+
+#: vbam-options-static.cpp:419
+msgid "The palette to use"
+msgstr ""
+
+#: vbam-options-static.cpp:420
+msgid "Enable printer emulation"
+msgstr ""
+
+#: vbam-options-static.cpp:421
+msgid "Break into GDB after loading the game."
+msgstr ""
+
+#: vbam-options-static.cpp:422
+msgid "Port to connect GDB to."
+msgstr ""
+
+#: vbam-options-static.cpp:424
+msgid "Number of players in network"
+msgstr ""
+
+#: vbam-options-static.cpp:426
+msgid "Maximum scale factor (0 = no limit)"
+msgstr ""
+
+#: vbam-options-static.cpp:427
+msgid "Pause game when main window loses focus"
+msgstr ""
+
+#: vbam-options-static.cpp:428
+msgid "Enable RTC (vba-over.ini override is rtcEnabled"
+msgstr ""
+
+#: vbam-options-static.cpp:429
+msgid "Native save (\"battery\") hardware type"
+msgstr ""
+
+#: vbam-options-static.cpp:430
+msgid "Show speed indicator"
+msgstr ""
+
+#: vbam-options-static.cpp:431
+msgid "Draw on-screen messages transparently"
+msgstr ""
+
+#: vbam-options-static.cpp:432
+msgid "Skip BIOS initialization"
+msgstr ""
+
+#: vbam-options-static.cpp:433
+msgid "Do not overwrite cheat list when loading state"
+msgstr ""
+
+#: vbam-options-static.cpp:434
+msgid "Do not overwrite native (battery) save when loading state"
+msgstr ""
+
+#: vbam-options-static.cpp:435
+msgid "Throttle game speed, even when accelerated (0-450%, 0 = no throttle)"
+msgstr ""
+
+#: vbam-options-static.cpp:436
+msgid "Set throttle for speedup key (0-3000%, 0 = no throttle)"
+msgstr ""
+
+#: vbam-options-static.cpp:437
+msgid "Number of frames to skip with speedup (instead of speedup throttle)"
+msgstr ""
+
+#: vbam-options-static.cpp:438
+msgid "Use frame skip for speedup throttle"
+msgstr ""
+
+#: vbam-options-static.cpp:439
+msgid "Use the specified BIOS file for GB"
+msgstr ""
+
+#: vbam-options-static.cpp:440
+msgid "Use the specified BIOS file"
+msgstr ""
+
+#: vbam-options-static.cpp:441
+msgid "Use the specified BIOS file for GBC"
+msgstr ""
+
+#: vbam-options-static.cpp:442
+msgid "Wait for vertical sync"
+msgstr ""
+
+#: vbam-options-static.cpp:445
+msgid "Enter fullscreen mode at startup"
+msgstr ""
+
+#: vbam-options-static.cpp:446
+msgid "Window maximized"
+msgstr ""
+
+#: vbam-options-static.cpp:447
+msgid "Window height at startup"
+msgstr ""
+
+#: vbam-options-static.cpp:448
+msgid "Window width at startup"
+msgstr ""
+
+#: vbam-options-static.cpp:449
+msgid "Window axis X position at startup"
+msgstr ""
+
+#: vbam-options-static.cpp:450
+msgid "Window axis Y position at startup"
+msgstr ""
+
+#: vbam-options-static.cpp:453
+msgid "Capture key events while on background"
+msgstr ""
+
+#: vbam-options-static.cpp:454
+msgid "Capture joy events while on background"
+msgstr ""
+
+#: vbam-options-static.cpp:455
+msgid "Hide menu bar when mouse is inactive"
+msgstr ""
+
+#: vbam-options-static.cpp:458
+msgid "Sound API; if unsupported, default API will be used"
+msgstr ""
+
+#: vbam-options-static.cpp:459
+msgid "Device ID of chosen audio device for chosen driver"
+msgstr ""
+
+#: vbam-options-static.cpp:460
+msgid "Number of sound buffers"
+msgstr ""
+
+#: vbam-options-static.cpp:461
+msgid "Bit mask of sound channels to enable"
+msgstr ""
+
+#: vbam-options-static.cpp:462
+msgid "GBA sound filtering (%)"
+msgstr ""
+
+#: vbam-options-static.cpp:463
+msgid "GBA sound interpolation"
+msgstr ""
+
+#: vbam-options-static.cpp:464
+msgid "GB sound declicking"
+msgstr ""
+
+#: vbam-options-static.cpp:465
+msgid "GB echo effect (%)"
+msgstr ""
+
+#: vbam-options-static.cpp:466
+msgid "Enable GB sound effects"
+msgstr ""
+
+#: vbam-options-static.cpp:467
+msgid "GB stereo effect (%)"
+msgstr ""
+
+#: vbam-options-static.cpp:468
+msgid "GB surround sound effect (%)"
+msgstr ""
+
+#: vbam-options-static.cpp:469
+msgid "Sound sample rate (kHz)"
+msgstr ""
+
+#: vbam-options-static.cpp:470
+msgid "Sound volume (%)"
+msgstr ""
+
+#: vbam-options-static.cpp:669 vbam-options-static.cpp:688
+#: vbam-options-static.cpp:711 vbam-options-static.cpp:732
+#: vbam-options-static.cpp:752
+#, c-format
+msgid "Invalid value %s for option %s; valid values are %s"
 msgstr ""
 
 #: viewsupt.cpp:776
@@ -3022,10 +3462,6 @@ msgstr ""
 
 #: xrc/MainMenu.xrc:351
 msgid "&Retain aspect ratio"
-msgstr ""
-
-#: xrc/MainMenu.xrc:355
-msgid "Enable MMX"
 msgstr ""
 
 #: xrc/MainMenu.xrc:360

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -733,6 +733,8 @@ set(
     opts.cpp
     sys.cpp
     panel.cpp
+    vbam-options.cpp
+    vbam-options-static.cpp
     viewsupt.cpp
     wayland.cpp
     strutils.cpp
@@ -767,6 +769,8 @@ set(
     filters.h
     ioregs.h
     opts.h
+    vbam-options.h
+    vbam-options-internal.h
     viewsupt.h
     wxhead.h
     wayland.h

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -31,24 +31,26 @@ bool cmditem_lt(const struct cmditem& cmd1, const struct cmditem& cmd2)
     return wxStrcmp(cmd1.cmd, cmd2.cmd) < 0;
 }
 
-void MainFrame::GetMenuOptionBool(const wxString& menuName, bool field)
+void MainFrame::GetMenuOptionBool(const wxString& menuName, bool* field)
 {
-    field = !field;
+    assert(field);
+    *field = !*field;
     int id = wxXmlResource::GetXRCID(menuName);
 
     for (size_t i = 0; i < checkable_mi.size(); i++) {
         if (checkable_mi[i].cmd != id)
             continue;
 
-        field = checkable_mi[i].mi->IsChecked();
+        *field = checkable_mi[i].mi->IsChecked();
         break;
     }
 }
 
-void MainFrame::GetMenuOptionInt(const wxString& menuName, int field, int mask)
+void MainFrame::GetMenuOptionInt(const wxString& menuName, int* field, int mask)
 {
+    assert(field);
     int value = mask;
-    bool is_checked = ((field) & (mask)) != (value);
+    bool is_checked = ((*field) & (mask)) != (value);
     int id = wxXmlResource::GetXRCID(menuName);
 
     for (size_t i = 0; i < checkable_mi.size(); i++) {
@@ -59,7 +61,7 @@ void MainFrame::GetMenuOptionInt(const wxString& menuName, int field, int mask)
         break;
     }
 
-    field = ((field) & ~(mask)) | (is_checked ? (value) : 0);
+    *field = ((*field) & ~(mask)) | (is_checked ? (value) : 0);
 }
 
 void MainFrame::SetMenuOption(const wxString& menuName, int value)
@@ -192,8 +194,8 @@ EVT_HANDLER(RecentReset, "Reset recent ROM list")
 
 EVT_HANDLER(RecentFreeze, "Freeze recent ROM list (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("RecentFreeze", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("RecentFreeze", &menuPress);
     toggleBooleanVar(&menuPress, &gopts.recent_freeze);
     SetMenuOption("RecentFreeze", gopts.recent_freeze ? 1 : 0);
     update_opts();
@@ -1471,8 +1473,8 @@ EVT_HANDLER(wxID_EXIT, "Exit")
 // Emulation menu
 EVT_HANDLER(Pause, "Pause (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("Pause", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("Pause", &menuPress);
     toggleBooleanVar(&menuPress, &paused);
     SetMenuOption("Pause", paused ? 1 : 0);
 
@@ -1491,8 +1493,8 @@ EVT_HANDLER(Pause, "Pause (toggle)")
 // new
 EVT_HANDLER_MASK(EmulatorSpeedupToggle, "Turbo mode (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
-    GetMenuOptionBool("EmulatorSpeedupToggle", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("EmulatorSpeedupToggle", &menuPress);
     toggleBooleanVar(&menuPress, &turbo);
     SetMenuOption("EmulatorSpeedupToggle", turbo ? 1 : 0);
 }
@@ -1510,156 +1512,156 @@ EVT_HANDLER(ToggleFullscreen, "Full screen (toggle)")
 
 EVT_HANDLER(JoypadAutofireA, "Autofire A (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("JoypadAutofireA", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("JoypadAutofireA", &menuPress);
     toggleBitVar(&menuPress, &autofire, KEYM_A);
     SetMenuOption("JoypadAutofireA", menuPress ? 1 : 0);
-    GetMenuOptionInt("JoypadAutofireA", autofire, KEYM_A);
+    GetMenuOptionInt("JoypadAutofireA", &autofire, KEYM_A);
 }
 
 EVT_HANDLER(JoypadAutofireB, "Autofire B (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("JoypadAutofireB", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("JoypadAutofireB", &menuPress);
     toggleBitVar(&menuPress, &autofire, KEYM_B);
     SetMenuOption("JoypadAutofireB", menuPress ? 1 : 0);
-    GetMenuOptionInt("JoypadAutofireB", autofire, KEYM_B);
+    GetMenuOptionInt("JoypadAutofireB", &autofire, KEYM_B);
 }
 
 EVT_HANDLER(JoypadAutofireL, "Autofire L (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("JoypadAutofireL", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("JoypadAutofireL", &menuPress);
     toggleBitVar(&menuPress, &autofire, KEYM_L);
     SetMenuOption("JoypadAutofireL", menuPress ? 1 : 0);
-    GetMenuOptionInt("JoypadAutofireL", autofire, KEYM_L);
+    GetMenuOptionInt("JoypadAutofireL", &autofire, KEYM_L);
 }
 
 EVT_HANDLER(JoypadAutofireR, "Autofire R (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("JoypadAutofireR", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("JoypadAutofireR", &menuPress);
     toggleBitVar(&menuPress, &autofire, KEYM_R);
     SetMenuOption("JoypadAutofireR", menuPress ? 1 : 0);
-    GetMenuOptionInt("JoypadAutofireR", autofire, KEYM_R);
+    GetMenuOptionInt("JoypadAutofireR", &autofire, KEYM_R);
 }
 
 EVT_HANDLER(JoypadAutoholdUp, "Autohold Up (toggle)")
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "JoypadAutoholdUp";
     int keym = KEYM_UP;
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &autohold, keym);
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, autohold, keym);
+    GetMenuOptionInt(keyName, &autohold, keym);
 }
 
 EVT_HANDLER(JoypadAutoholdDown, "Autohold Down (toggle)")
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "JoypadAutoholdDown";
     int keym = KEYM_DOWN;
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &autohold, keym);
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, autohold, keym);
+    GetMenuOptionInt(keyName, &autohold, keym);
 }
 
 EVT_HANDLER(JoypadAutoholdLeft, "Autohold Left (toggle)")
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "JoypadAutoholdLeft";
     int keym = KEYM_LEFT;
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &autohold, keym);
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, autohold, keym);
+    GetMenuOptionInt(keyName, &autohold, keym);
 }
 
 EVT_HANDLER(JoypadAutoholdRight, "Autohold Right (toggle)")
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "JoypadAutoholdRight";
     int keym = KEYM_RIGHT;
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &autohold, keym);
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, autohold, keym);
+    GetMenuOptionInt(keyName, &autohold, keym);
 }
 
 EVT_HANDLER(JoypadAutoholdA, "Autohold A (toggle)")
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "JoypadAutoholdA";
     int keym = KEYM_A;
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &autohold, keym);
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, autohold, keym);
+    GetMenuOptionInt(keyName, &autohold, keym);
 }
 
 EVT_HANDLER(JoypadAutoholdB, "Autohold B (toggle)")
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "JoypadAutoholdB";
     int keym = KEYM_B;
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &autohold, keym);
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, autohold, keym);
+    GetMenuOptionInt(keyName, &autohold, keym);
 }
 
 EVT_HANDLER(JoypadAutoholdL, "Autohold L (toggle)")
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "JoypadAutoholdL";
     int keym = KEYM_L;
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &autohold, keym);
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, autohold, keym);
+    GetMenuOptionInt(keyName, &autohold, keym);
 }
 
 EVT_HANDLER(JoypadAutoholdR, "Autohold R (toggle)")
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "JoypadAutoholdR";
     int keym = KEYM_R;
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &autohold, keym);
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, autohold, keym);
+    GetMenuOptionInt(keyName, &autohold, keym);
 }
 
 EVT_HANDLER(JoypadAutoholdSelect, "Autohold Select (toggle)")
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "JoypadAutoholdSelect";
     int keym = KEYM_SELECT;
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &autohold, keym);
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, autohold, keym);
+    GetMenuOptionInt(keyName, &autohold, keym);
 }
 
 EVT_HANDLER(JoypadAutoholdStart, "Autohold Start (toggle)")
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "JoypadAutoholdStart";
     int keym = KEYM_START;
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &autohold, keym);
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, autohold, keym);
+    GetMenuOptionInt(keyName, &autohold, keym);
 }
 
 #include "background-input.h"
 
 EVT_HANDLER(AllowKeyboardBackgroundInput, "Allow keyboard background input (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("AllowKeyboardBackgroundInput", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("AllowKeyboardBackgroundInput", &menuPress);
     toggleBooleanVar(&menuPress, &allowKeyboardBackgroundInput);
     SetMenuOption("AllowKeyboardBackgroundInput", allowKeyboardBackgroundInput ? 1 : 0);
 
@@ -1676,8 +1678,8 @@ EVT_HANDLER(AllowKeyboardBackgroundInput, "Allow keyboard background input (togg
 
 EVT_HANDLER(AllowJoystickBackgroundInput, "Allow joystick background input (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("AllowJoystickBackgroundInput", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("AllowJoystickBackgroundInput", &menuPress);
     toggleBooleanVar(&menuPress, &allowJoystickBackgroundInput);
     SetMenuOption("AllowJoystickBackgroundInput", allowJoystickBackgroundInput ? 1 : 0);
 
@@ -1691,8 +1693,8 @@ EVT_HANDLER_MASK(LoadGameRecent, "Load most recent save", CMDEN_SAVST)
 
 EVT_HANDLER(LoadGameAutoLoad, "Auto load most recent save (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("LoadGameAutoLoad", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("LoadGameAutoLoad", &menuPress);
     toggleBooleanVar(&menuPress, &gopts.autoload_state);
     SetMenuOption("LoadGameAutoLoad", gopts.autoload_state ? 1 : 0);
     update_opts();
@@ -1769,22 +1771,22 @@ EVT_HANDLER_MASK(Load, "Load state...", CMDEN_GB | CMDEN_GBA)
 // new
 EVT_HANDLER(KeepSaves, "Do not load battery saves (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("KeepSaves", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("KeepSaves", &menuPress);
     toggleBitVar(&menuPress, &skipSaveGameBattery, 1);
     SetMenuOption("KeepSaves", menuPress ? 1 : 0);
-    GetMenuOptionInt("KeepSaves", skipSaveGameBattery, 1);
+    GetMenuOptionInt("KeepSaves", &skipSaveGameBattery, 1);
     update_opts();
 }
 
 // new
 EVT_HANDLER(KeepCheats, "Do not change cheat list (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("KeepCheats", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("KeepCheats", &menuPress);
     toggleBitVar(&menuPress, &skipSaveGameCheats, 1);
     SetMenuOption("KeepCheats", menuPress ? 1 : 0);
-    GetMenuOptionInt("KeepCheats", skipSaveGameCheats, 1);
+    GetMenuOptionInt("KeepCheats", &skipSaveGameCheats, 1);
     update_opts();
 }
 
@@ -1945,8 +1947,8 @@ EVT_HANDLER_MASK(CheatsSearch, "Create cheat...", CMDEN_GB | CMDEN_GBA)
 // new
 EVT_HANDLER(CheatsAutoSaveLoad, "Auto save/load cheats (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("CheatsAutoSaveLoad", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("CheatsAutoSaveLoad", &menuPress);
     toggleBooleanVar(&menuPress, &gopts.autoload_cheats);
     SetMenuOption("CheatsAutoSaveLoad", gopts.autoload_cheats ? 1 : 0);
     update_opts();
@@ -1956,18 +1958,18 @@ EVT_HANDLER(CheatsAutoSaveLoad, "Auto save/load cheats (toggle)")
 // changed for convenience to match internal variable functionality
 EVT_HANDLER(CheatsEnable, "Enable cheats (toggle)")
 {
-    bool menuPress;
-    GetMenuOptionBool("CheatsEnable", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("CheatsEnable", &menuPress);
     toggleBitVar(&menuPress, &cheatsEnabled, 1);
     SetMenuOption("CheatsEnable", menuPress ? 1 : 0);
-    GetMenuOptionInt("CheatsEnable", cheatsEnabled, 1);
+    GetMenuOptionInt("CheatsEnable", &cheatsEnabled, 1);
     update_opts();
 }
 
 EVT_HANDLER(ColorizerHack, "Enable Colorizer Hack (toggle)")
 {
     int val = 0;
-    GetMenuOptionInt("ColorizerHack", val, 1);
+    GetMenuOptionInt("ColorizerHack", &val, 1);
 
     if (val == 1 && useBiosFileGB == 1) {
         wxLogError(_("Cannot use Colorizer Hack when GB BIOS File is enabled."));
@@ -1983,96 +1985,96 @@ EVT_HANDLER(ColorizerHack, "Enable Colorizer Hack (toggle)")
 // Debug menu
 EVT_HANDLER_MASK(VideoLayersBG0, "Video layer BG0 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "VideoLayersBG0";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &layerSettings, (1 << 8));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, layerSettings, (1 << 8));
+    GetMenuOptionInt(keyName, &layerSettings, (1 << 8));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersBG1, "Video layer BG1 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "VideoLayersBG1";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &layerSettings, (1 << 9));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, layerSettings, (1 << 9));
+    GetMenuOptionInt(keyName, &layerSettings, (1 << 9));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersBG2, "Video layer BG2 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "VideoLayersBG2";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &layerSettings, (1 << 10));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, layerSettings, (1 << 10));
+    GetMenuOptionInt(keyName, &layerSettings, (1 << 10));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersBG3, "Video layer BG3 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "VideoLayersBG3";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &layerSettings, (1 << 11));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, layerSettings, (1 << 11));
+    GetMenuOptionInt(keyName, &layerSettings, (1 << 11));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersOBJ, "Video layer OBJ (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "VideoLayersOBJ";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &layerSettings, (1 << 12));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, layerSettings, (1 << 12));
+    GetMenuOptionInt(keyName, &layerSettings, (1 << 12));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersWIN0, "Video layer WIN0 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "VideoLayersWIN0";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &layerSettings, (1 << 13));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, layerSettings, (1 << 13));
+    GetMenuOptionInt(keyName, &layerSettings, (1 << 13));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersWIN1, "Video layer WIN1 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "VideoLayersWIN1";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &layerSettings, (1 << 14));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, layerSettings, (1 << 14));
+    GetMenuOptionInt(keyName, &layerSettings, (1 << 14));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
 EVT_HANDLER_MASK(VideoLayersOBJWIN, "Video layer OBJWIN (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "VideoLayersOBJWIN";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &layerSettings, (1 << 15));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, layerSettings, (1 << 15));
+    GetMenuOptionInt(keyName, &layerSettings, (1 << 15));
     layerEnable = DISPCNT & layerSettings;
     CPUUpdateRenderBuffers(false);
 }
@@ -2103,72 +2105,72 @@ EVT_HANDLER_MASK(VideoLayersReset, "Show all video layers", CMDEN_GB | CMDEN_GBA
 
 EVT_HANDLER_MASK(SoundChannel1, "Sound Channel 1 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "SoundChannel1";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &gopts.sound_en, (1 << 0));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 0));
+    GetMenuOptionInt(keyName, &gopts.sound_en, (1 << 0));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
 
 EVT_HANDLER_MASK(SoundChannel2, "Sound Channel 2 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "SoundChannel2";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &gopts.sound_en, (1 << 1));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 1));
+    GetMenuOptionInt(keyName, &gopts.sound_en, (1 << 1));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
 
 EVT_HANDLER_MASK(SoundChannel3, "Sound Channel 3 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "SoundChannel3";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &gopts.sound_en, (1 << 2));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 2));
+    GetMenuOptionInt(keyName, &gopts.sound_en, (1 << 2));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
 
 EVT_HANDLER_MASK(SoundChannel4, "Sound Channel 4 (toggle)", CMDEN_GB | CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "SoundChannel4";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &gopts.sound_en, (1 << 3));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 3));
+    GetMenuOptionInt(keyName, &gopts.sound_en, (1 << 3));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
 
 EVT_HANDLER_MASK(DirectSoundA, "Direct Sound A (toggle)", CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "DirectSoundA";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &gopts.sound_en, (1 << 8));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 8));
+    GetMenuOptionInt(keyName, &gopts.sound_en, (1 << 8));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
 
 EVT_HANDLER_MASK(DirectSoundB, "Direct Sound B (toggle)", CMDEN_GBA)
 {
-    bool menuPress;
+    bool menuPress = false;
     char keyName[] = "DirectSoundB";
-    GetMenuOptionBool(keyName, menuPress);
+    GetMenuOptionBool(keyName, &menuPress);
     toggleBitVar(&menuPress, &gopts.sound_en, (1 << 9));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, gopts.sound_en, (1 << 9));
+    GetMenuOptionInt(keyName, &gopts.sound_en, (1 << 9));
     soundSetEnable(gopts.sound_en);
     update_opts();
 }
@@ -2315,7 +2317,7 @@ EVT_HANDLER(DebugGDBPort, "Configure port...")
 EVT_HANDLER(DebugGDBBreakOnLoad, "Break on load")
 {
 #ifndef NO_DEBUGGER
-    GetMenuOptionInt("DebugGDBBreakOnLoad", gdbBreakOnLoad, 1);
+    GetMenuOptionInt("DebugGDBBreakOnLoad", &gdbBreakOnLoad, 1);
     update_opts();
 #endif
 }
@@ -2976,7 +2978,7 @@ EVT_HANDLER(wxID_ABOUT, "About...")
 
 EVT_HANDLER(Bilinear, "Use bilinear filter with 3d renderer")
 {
-    GetMenuOptionBool("Bilinear", gopts.bilinear);
+    GetMenuOptionBool("Bilinear", &gopts.bilinear);
     // Force new panel with new bilinear option
     if (panel->panel) {
         panel->panel->Destroy();
@@ -2987,7 +2989,7 @@ EVT_HANDLER(Bilinear, "Use bilinear filter with 3d renderer")
 
 EVT_HANDLER(RetainAspect, "Retain aspect ratio when resizing")
 {
-    GetMenuOptionBool("RetainAspect", gopts.retain_aspect);
+    GetMenuOptionBool("RetainAspect", &gopts.retain_aspect);
 
     // Force new panel with new aspect ratio options.
     if (panel->panel) {
@@ -3000,7 +3002,7 @@ EVT_HANDLER(RetainAspect, "Retain aspect ratio when resizing")
 
 EVT_HANDLER(Printer, "Enable printer emulation")
 {
-    GetMenuOptionInt("Printer", winGbPrinterEnabled, 1);
+    GetMenuOptionInt("Printer", &winGbPrinterEnabled, 1);
 #if (defined __WIN32__ || defined _WIN32)
 #ifndef NO_LINK
     gbSerialFunction = gbStartLink;
@@ -3016,25 +3018,25 @@ EVT_HANDLER(Printer, "Enable printer emulation")
 
 EVT_HANDLER(PrintGather, "Automatically gather a full page before printing")
 {
-    GetMenuOptionBool("PrintGather", gopts.print_auto_page);
+    GetMenuOptionBool("PrintGather", &gopts.print_auto_page);
     update_opts();
 }
 
 EVT_HANDLER(PrintSnap, "Automatically save printouts as screen captures with -print suffix")
 {
-    GetMenuOptionBool("PrintSnap", gopts.print_screen_cap);
+    GetMenuOptionBool("PrintSnap", &gopts.print_screen_cap);
     update_opts();
 }
 
 EVT_HANDLER(GBASoundInterpolation, "GBA sound interpolation")
 {
-    GetMenuOptionBool("GBASoundInterpolation", soundInterpolation);
+    GetMenuOptionBool("GBASoundInterpolation", &soundInterpolation);
     update_opts();
 }
 
 EVT_HANDLER(GBDeclicking, "GB sound declicking")
 {
-    GetMenuOptionBool("GBDeclicking", gopts.gb_declick);
+    GetMenuOptionBool("GBDeclicking", &gopts.gb_declick);
     // note that setting declick may reset gb sound engine
     gbSoundSetDeclicking(gopts.gb_declick);
     update_opts();
@@ -3042,28 +3044,28 @@ EVT_HANDLER(GBDeclicking, "GB sound declicking")
 
 EVT_HANDLER(GBEnhanceSound, "Enable GB sound effects")
 {
-    GetMenuOptionBool("GBEnhanceSound", gopts.gb_effects_config_enabled);
+    GetMenuOptionBool("GBEnhanceSound", &gopts.gb_effects_config_enabled);
     gb_effects_config.enabled = gopts.gb_effects_config_enabled;
     update_opts();
 }
 
 EVT_HANDLER(GBSurround, "GB surround sound effect (%)")
 {
-    GetMenuOptionBool("GBSurround", gopts.gb_effects_config_surround);
+    GetMenuOptionBool("GBSurround",&gopts.gb_effects_config_surround);
     gb_effects_config.surround = gopts.gb_effects_config_surround;
     update_opts();
 }
 
 EVT_HANDLER(AGBPrinter, "Enable AGB printer")
 {
-    GetMenuOptionInt("AGBPrinter", agbPrint, 1);
+    GetMenuOptionInt("AGBPrinter", &agbPrint, 1);
     update_opts();
 }
 
 EVT_HANDLER_MASK(GBALcdFilter, "Enable LCD filter", CMDEN_GBA)
 {
-    bool menuPress;
-    GetMenuOptionBool("GBALcdFilter", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("GBALcdFilter", &menuPress);
     toggleBooleanVar(&menuPress, &gbaLcdFilter);
     SetMenuOption("GBALcdFilter", gbaLcdFilter ? 1 : 0);
     utilUpdateSystemColorMaps(gbaLcdFilter);
@@ -3072,8 +3074,8 @@ EVT_HANDLER_MASK(GBALcdFilter, "Enable LCD filter", CMDEN_GBA)
 
 EVT_HANDLER_MASK(GBLcdFilter, "Enable LCD filter", CMDEN_GB)
 {
-    bool menuPress;
-    GetMenuOptionBool("GBLcdFilter", menuPress);
+    bool menuPress = false;
+    GetMenuOptionBool("GBLcdFilter", &menuPress);
     toggleBooleanVar(&menuPress, &gbLcdFilter);
     SetMenuOption("GBLcdFilter", gbLcdFilter ? 1 : 0);
     utilUpdateSystemColorMaps(gbLcdFilter);
@@ -3082,9 +3084,9 @@ EVT_HANDLER_MASK(GBLcdFilter, "Enable LCD filter", CMDEN_GB)
 
 EVT_HANDLER(GBColorOption, "Enable GB color option")
 {
-    bool menuPress;
+    bool menuPress = false;
     bool intVar = gbColorOption ? true : false;
-    GetMenuOptionBool("GBColorOption", menuPress);
+    GetMenuOptionBool("GBColorOption", &menuPress);
     toggleBooleanVar(&menuPress, &intVar);
     SetMenuOption("GBColorOption", intVar ? 1 : 0);
     gbColorOption = intVar ? 1 : 0;
@@ -3093,21 +3095,21 @@ EVT_HANDLER(GBColorOption, "Enable GB color option")
 
 EVT_HANDLER(ApplyPatches, "Apply IPS/UPS/IPF patches if found")
 {
-    GetMenuOptionInt("ApplyPatches", autoPatch, 1);
+    GetMenuOptionInt("ApplyPatches", &autoPatch, 1);
     update_opts();
 }
 
 EVT_HANDLER(MMX, "Enable MMX")
 {
 #ifdef MMX
-    GetMenuOptionInt("MMX", enableMMX, 1);
+    GetMenuOptionInt("MMX", &enableMMX, 1);
     update_opts();
 #endif
 }
 
 EVT_HANDLER(KeepOnTop, "Keep window on top")
 {
-    GetMenuOptionBool("KeepOnTop", gopts.keep_on_top);
+    GetMenuOptionBool("KeepOnTop", &gopts.keep_on_top);
     MainFrame* mf = wxGetApp().frame;
 
     if (gopts.keep_on_top)
@@ -3120,7 +3122,7 @@ EVT_HANDLER(KeepOnTop, "Keep window on top")
 
 EVT_HANDLER(StatusBar, "Enable status bar")
 {
-    GetMenuOptionInt("StatusBar", gopts.statusbar, 1);
+    GetMenuOptionInt("StatusBar", &gopts.statusbar, 1);
     update_opts();
     MainFrame* mf = wxGetApp().frame;
 
@@ -3136,56 +3138,56 @@ EVT_HANDLER(StatusBar, "Enable status bar")
 
 EVT_HANDLER(NoStatusMsg, "Disable on-screen status messages")
 {
-    GetMenuOptionInt("NoStatusMsg", disableStatusMessages, 1);
+    GetMenuOptionInt("NoStatusMsg", &disableStatusMessages, 1);
     update_opts();
 }
 
 EVT_HANDLER(FrameSkipAuto, "Auto Skip frames.")
 {
-    GetMenuOptionInt("FrameSkipAuto", autoFrameSkip, 1);
+    GetMenuOptionInt("FrameSkipAuto", &autoFrameSkip, 1);
     update_opts();
 }
 
 EVT_HANDLER(Fullscreen, "Enter fullscreen mode at startup")
 {
-    GetMenuOptionInt("Fullscreen", fullScreen, 1);
+    GetMenuOptionInt("Fullscreen", &fullScreen, 1);
     update_opts();
 }
 
 EVT_HANDLER(PauseWhenInactive, "Pause game when main window loses focus")
 {
-    GetMenuOptionInt("PauseWhenInactive", pauseWhenInactive, 1);
+    GetMenuOptionInt("PauseWhenInactive", &pauseWhenInactive, 1);
     update_opts();
 }
 
 EVT_HANDLER(RTC, "Enable RTC (vba-over.ini override is rtcEnabled")
 {
-    GetMenuOptionInt("RTC", rtcEnabled, 1);
+    GetMenuOptionInt("RTC", &rtcEnabled, 1);
     update_opts();
 }
 
 EVT_HANDLER(Transparent, "Draw on-screen messages transparently")
 {
-    GetMenuOptionInt("Transparent", showSpeedTransparent, 1);
+    GetMenuOptionInt("Transparent", &showSpeedTransparent, 1);
     update_opts();
 }
 
 EVT_HANDLER(SkipIntro, "Skip BIOS initialization")
 {
-    GetMenuOptionInt("SkipIntro", skipBios, 1);
+    GetMenuOptionInt("SkipIntro", &skipBios, 1);
     update_opts();
 }
 
 EVT_HANDLER(BootRomEn, "Use the specified BIOS file for GBA")
 {
-    GetMenuOptionInt("BootRomEn", useBiosFileGBA, 1);
+    GetMenuOptionInt("BootRomEn", &useBiosFileGBA, 1);
     update_opts();
 }
 
 EVT_HANDLER(BootRomGB, "Use the specified BIOS file for GB")
 {
     int val = 0;
-    GetMenuOptionInt("BootRomGB", val, 1);
+    GetMenuOptionInt("BootRomGB", &val, 1);
 
     if (val == 1 && colorizerHack == 1) {
         wxLogError(_("Cannot use GB BIOS when Colorizer Hack is enabled."));
@@ -3200,13 +3202,13 @@ EVT_HANDLER(BootRomGB, "Use the specified BIOS file for GB")
 
 EVT_HANDLER(BootRomGBC, "Use the specified BIOS file for GBC")
 {
-    GetMenuOptionInt("BootRomGBC", useBiosFileGBC, 1);
+    GetMenuOptionInt("BootRomGBC", &useBiosFileGBC, 1);
     update_opts();
 }
 
 EVT_HANDLER(VSync, "Wait for vertical sync")
 {
-    GetMenuOptionInt("VSync", vsync, 1);
+    GetMenuOptionInt("VSync", &vsync, 1);
     update_opts();
 }
 
@@ -3291,19 +3293,19 @@ EVT_HANDLER(LinkType4Gameboy, "Link Gameboy")
 
 EVT_HANDLER(LinkAuto, "Enable link at boot")
 {
-    GetMenuOptionBool("LinkAuto", gopts.link_auto);
+    GetMenuOptionBool("LinkAuto", &gopts.link_auto);
     update_opts();
 }
 
 EVT_HANDLER(SpeedOn, "Enable faster network protocol by default")
 {
-    GetMenuOptionInt("SpeedOn", linkHacks, 1);
+    GetMenuOptionInt("SpeedOn", &linkHacks, 1);
     update_opts();
 }
 
 EVT_HANDLER(LinkProto, "Local host IPC")
 {
-    GetMenuOptionInt("LinkProto", gopts.link_proto, 1);
+    GetMenuOptionInt("LinkProto", &gopts.link_proto, 1);
     update_opts();
     enable_menus();
     EnableNetworkMenu();

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -31,10 +31,10 @@ bool cmditem_lt(const struct cmditem& cmd1, const struct cmditem& cmd2)
     return wxStrcmp(cmd1.cmd, cmd2.cmd) < 0;
 }
 
-void MainFrame::GetMenuOptionBool(const char* menuName, bool& field)
+void MainFrame::GetMenuOptionBool(const wxString& menuName, bool field)
 {
     field = !field;
-    int id = wxXmlResource::GetXRCID(wxString(menuName, wxConvUTF8));
+    int id = wxXmlResource::GetXRCID(menuName);
 
     for (size_t i = 0; i < checkable_mi.size(); i++) {
         if (checkable_mi[i].cmd != id)
@@ -45,11 +45,11 @@ void MainFrame::GetMenuOptionBool(const char* menuName, bool& field)
     }
 }
 
-void MainFrame::GetMenuOptionInt(const char* menuName, int& field, int mask)
+void MainFrame::GetMenuOptionInt(const wxString& menuName, int field, int mask)
 {
     int value = mask;
     bool is_checked = ((field) & (mask)) != (value);
-    int id = wxXmlResource::GetXRCID(wxString(menuName, wxConvUTF8));
+    int id = wxXmlResource::GetXRCID(menuName);
 
     for (size_t i = 0; i < checkable_mi.size(); i++) {
         if (checkable_mi[i].cmd != id)
@@ -62,9 +62,9 @@ void MainFrame::GetMenuOptionInt(const char* menuName, int& field, int mask)
     field = ((field) & ~(mask)) | (is_checked ? (value) : 0);
 }
 
-void MainFrame::SetMenuOption(const char* menuName, int value)
+void MainFrame::SetMenuOption(const wxString& menuName, int value)
 {
-    int id = wxXmlResource::GetXRCID(wxString(menuName, wxConvUTF8));
+    int id = wxXmlResource::GetXRCID(menuName);
 
     for (size_t i = 0; i < checkable_mi.size(); i++) {
         if (checkable_mi[i].cmd != id)

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2978,10 +2978,14 @@ bool MainFrame::BindControls()
                     checkable_mi.push_back(cmi);
 
                     for (const VbamOption& option : VbamOption::AllOptions()) {
-                        if (option.is_int()) {
-                            MenuOptionIntMask(option.command(), option.GetInt(), (1 << 0));
-                        } else if (option.is_bool()) {
-                            MenuOptionBool(option.command(), option.GetBool());
+                        if (cmdtab[i].cmd == option.command()) {
+                            if (option.is_int()) {
+                                MenuOptionIntMask(
+                                    option.command(), option.GetInt(), (1 << 0));
+                            } else if (option.is_bool()) {
+                                MenuOptionBool(
+                                    option.command(), option.GetBool());
+                            }
                         }
                     }
                 }
@@ -3692,8 +3696,11 @@ bool MainFrame::BindControls()
             getsc("MaxScale", maxScale);
             /// Basic
             getrbi("OutputSimple", gopts.render_method, RND_SIMPLE);
+
+#if defined(__WXMAC__)
             getrbi("OutputQuartz2D", gopts.render_method, RND_QUARTZ2D);
-#if !defined(__WXMAC__)
+#else
+            rb = SafeXRCCTRL<wxRadioButton>(d, "OutputQuartz2D");
             rb->Hide();
 #endif
             getrbi("OutputOpenGL", gopts.render_method, RND_OPENGL);
@@ -3706,10 +3713,11 @@ bool MainFrame::BindControls()
                 rb->Hide();
             }
 #endif
-            getrbi("OutputDirect3D", gopts.render_method, RND_DIRECT3D);
-#if !defined(__WXMSW__) || defined(NO_D3D) || 1 // not implemented
+
+            // Direct3D is not implemented so hide the option on every platform.
+            rb = SafeXRCCTRL<wxRadioButton>(d, "OutputDirect3D");
             rb->Hide();
-#endif
+
             ch = GetValidatedChild<wxChoice, wxGenericValidator>(d, "Filter", wxGenericValidator(&gopts.filter));
 
             // Save the Filters choice control to extract the names from the XRC.

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -98,34 +98,6 @@ extern struct opts_t {
     // wxWidgets-generated options (opaque)
 } gopts;
 
-extern struct opt_desc {
-    wxString opt;
-    const char* cmd;
-    wxString desc;
-    wxString* stropt;
-    int* intopt;
-    wxString enumvals;
-    double min, max;
-    bool* boolopt;
-    double* doubleopt;
-    uint32_t* uintopt;
-    // current configured value
-    wxString curstr;
-    int curint;
-    double curdouble;
-    uint32_t curuint;
-#define curbool curint
-} opts[];
-
-// Initializer for struct opt_desc
-opt_desc new_opt_desc(wxString opt = wxT(""), const char* cmd = NULL, wxString desc = wxT(""),
-                      wxString* stropt = NULL, int* intopt = NULL, wxString enumvals = wxT(""),
-                      double min = 0, double max = 0, bool* boolopt = NULL,
-                      double* doubleopt = NULL, uint32_t* uintopt = NULL, wxString curstr = wxT(""),
-                      int curint = 0, double curdouble = 0, uint32_t curuint = 0);
-
-extern const int num_opts;
-
 extern const wxAcceleratorEntryUnicode default_accels[];
 extern const int num_def_accels;
 
@@ -137,6 +109,6 @@ void load_opts();
 // will detect changes and write config if necessary
 void update_opts();
 // returns true if option name correct; prints error if val invalid
-bool opt_set(const wxString& name, const wxString& val);
+void opt_set(const wxString& name, const wxString& val);
 
 #endif /* WX_OPTS_H */

--- a/src/wx/vbam-options-internal.h
+++ b/src/wx/vbam-options-internal.h
@@ -18,7 +18,7 @@ struct VbamOptionData {
     const VbamOption::Type type;
 };
 
-// Static data to initialize global values.;
+// Static data to initialize global values.
 extern const std::array<VbamOptionData, kNbOptions + 1> kAllOptionsData;
 
 // Conversion utilities.

--- a/src/wx/vbam-options-internal.h
+++ b/src/wx/vbam-options-internal.h
@@ -1,0 +1,42 @@
+#ifndef VBAM_OPTIONS_INTERNAL_INCLUDE
+#error "Do not include "vbam-options-internal.h" outside of the implementation."
+#endif
+
+#include <array>
+#include <string>
+#include <wx/string.h>
+
+#include "nonstd/optional.hpp"
+#include "vbam-options.h"
+
+namespace internal {
+
+struct VbamOptionData {
+    const wxString config_name;
+    const wxString command;
+    const wxString ux_helper;
+    const VbamOption::Type type;
+};
+
+// Static data to initialize global values.;
+extern const std::array<VbamOptionData, kNbOptions + 1> kAllOptionsData;
+
+// Conversion utilities.
+nonstd::optional<VbamOptionID> StringToOptionId(const wxString& input);
+wxString FilterToString(int value);
+wxString InterframeToString(int value);
+wxString RenderMethodToString(int value);
+wxString AudioApiToString(int value);
+wxString SoundQualityToString(int value);
+int StringToFilter(const wxString& config_name, const wxString& input);
+int StringToInterframe(const wxString& config_name, const wxString& input);
+int StringToRenderMethod(const wxString& config_name, const wxString& input);
+int StringToAudioApi(const wxString& config_name, const wxString& input);
+int StringToSoundQuality(const wxString& config_name, const wxString& input);
+
+wxString AllEnumValuesForType(VbamOption::Type type);
+
+// Max value for enum types.
+int MaxForType(VbamOption::Type type);
+
+}  // namespace internal

--- a/src/wx/vbam-options-static.cpp
+++ b/src/wx/vbam-options-static.cpp
@@ -1,0 +1,830 @@
+#include "vbam-options.h"
+
+// Helper implementation file to define and compile all of these huge constants
+// separately. These should not be updated very often, so this improves 
+
+#include <algorithm>
+#include <wx/log.h>
+
+#include "../common/ConfigManager.h"
+#include "../gb/gbGlobals.h"
+#include "opts.h"
+#include "wx/stringimpl.h"
+
+#define VBAM_OPTIONS_INTERNAL_INCLUDE
+#include "vbam-options-internal.h"
+#undef VBAM_OPTIONS_INTERNAL_INCLUDE
+
+namespace {
+
+// This enum must be kept in sync with the one in wxvbam.h
+enum class FilterFunction {
+    kNone,
+    k2xsai,
+    kSuper2xsai,
+    kSupereagle,
+    kPixelate,
+    kAdvmame,
+    kBilinear,
+    kBilinearplus,
+    kScanlines,
+    kTvmode,
+    kHQ2x,
+    kLQ2x,
+    kSimple2x,
+    kSimple3x,
+    kHQ3x,
+    kSimple4x,
+    kHQ4x,
+    kXbrz2x,
+    kXbrz3x,
+    kXbrz4x,
+    kXbrz5x,
+    kXbrz6x,
+    kPlugin, // This must always be last.
+
+    // Do not add anything under here.
+    kLast,
+};
+constexpr size_t kNbFilterFunctions = static_cast<size_t>(FilterFunction::kLast);
+
+// These MUST follow the same order as the definitions of the enum above.
+// Adding an option without adding to this array will result in a compiler
+// error since kNbFilterFunctions is automatically updated.
+static const std::array<wxString, kNbFilterFunctions> kFilterStrings = {
+    "none",
+    "2xsai",
+    "super2xsai",
+    "supereagle",
+    "pixelate",
+    "advmame",
+    "bilinear",
+    "bilinearplus",
+    "scanlines",
+    "tvmode",
+    "hq2x",
+    "lq2x",
+    "simple2x",
+    "simple3x",
+    "hq3x",
+    "simple4x",
+    "hq4x",
+    "xbrz2x",
+    "xbrz3x",
+    "xbrz4x",
+    "xbrz5x",
+    "xbrz6x",
+    "plugin",
+};
+
+// This enum must be kept in sync with the one in wxvbam.h
+enum class Interframe {
+    kNone = 0,
+    kSmart,
+    kMotionBlur,
+
+    // Do not add anything under here.
+    kLast,
+};
+constexpr size_t kNbInterframes = static_cast<size_t>(Interframe::kLast);
+
+// These MUST follow the same order as the definitions of the enum above.
+// Adding an option without adding to this array will result in a compiler
+// error since kNbInterframes is automatically updated.
+static const std::array<wxString, kNbInterframes> kInterframeStrings = {
+    "none",
+    "smart",
+    "motionblur",
+};
+
+// This enum must be kept in sync with the one in wxvbam.h
+enum class RenderMethod {
+    kSimple = 0,
+    kOpenGL,
+#ifdef __WXMSW__
+    kDirect3d,
+#elif defined(__WXMAC__)
+    kQuartz2d,
+#endif
+
+    // Do not add anything under here.
+    kLast,
+};
+constexpr size_t kNbRenderMethods = static_cast<size_t>(RenderMethod::kLast);
+
+// These MUST follow the same order as the definitions of the enum above.
+// Adding an option without adding to this array will result in a compiler
+// error since kNbRenderMethods is automatically updated.
+static const std::array<wxString, kNbRenderMethods> kRenderMethodStrings = {
+    "simple",
+    "opengl",
+#ifdef __WXMSW__
+    "direct3d",
+#elif defined(__WXMAC__)
+    "quartz2d",
+#endif
+};
+
+// This enum must be kept in sync with the one in wxvbam.h
+enum class AudioApi {
+    kSdl = 0,
+    kOpenAL,
+    kDirectSound,
+    kXAudio2,
+    kFaudio,
+
+    // Do not add anything under here.
+    kLast,
+};
+constexpr size_t kNbAudioApis = static_cast<size_t>(AudioApi::kLast);
+
+// These MUST follow the same order as the definitions of the enum above.
+// Adding an option without adding to this array will result in a compiler
+// error since kNbAudioApis is automatically updated.
+static const std::array<wxString, kNbAudioApis> kAudioApiStrings = {
+    "sdl",
+    "openal",
+    "directsound",
+    "xaudio2",
+    "faudio",
+};
+
+enum class SoundQuality {
+    k48kHz = 0,
+    k44kHz,
+    k22kHz,
+    k11kHz,
+
+    // Do not add anything under here.
+    kLast,
+};
+constexpr size_t kNbSoundQualities = static_cast<size_t>(SoundQuality::kLast);
+
+// These MUST follow the same order as the definitions of the enum above.
+// Adding an option without adding to this array will result in a compiler
+// error since kNbSoundQualities is automatically updated.
+static const std::array<wxString, kNbSoundQualities> kSoundQualityStrings = {
+    "48",
+    "44",
+    "22",
+    "11",
+};
+
+// Builds the "all enum values" string for a given array defined above.
+template<std::size_t SIZE>
+wxString AllEnumValuesForArray(const std::array<wxString, SIZE>& input) {
+    // 15 characters per option is a reasonable higher bound. Probably.
+    static constexpr size_t kMaxOptionLength = 15u;
+
+    wxString all_options;
+    all_options.reserve(kMaxOptionLength * SIZE);
+
+    std::for_each(input.cbegin(), input.cend(), [&all_options](const auto& elt) {
+        all_options.append(elt);
+        all_options.append('|');
+    });
+    // Remove last value
+    all_options.RemoveLast(1u);
+    return all_options;
+}
+
+}  // namespace
+
+// static
+std::array<VbamOption, kNbOptions>& VbamOption::AllOptions() {
+    // These MUST follow the same order as the definitions in VbamOptionID.
+    // Adding an option without adding to this array will result in a compiler
+    // error since kNbOptions is automatically updated.
+    // This will be initialized on the first call, in load_opts(), ensuring the
+    // translation initialization has already happened.
+    static std::array<VbamOption, kNbOptions> g_all_opts = {
+        /// Display
+        VbamOption(VbamOptionID::kDisplayBilinear, &gopts.bilinear),
+        VbamOption(VbamOptionID::kDisplayFilter, &gopts.filter),
+        VbamOption(VbamOptionID::kDisplayFilterPlugin, &gopts.filter_plugin),
+        VbamOption(VbamOptionID::kDisplayIFB, &gopts.ifb),
+        VbamOption(VbamOptionID::kDisplayKeepOnTop, &gopts.keep_on_top),
+        VbamOption(VbamOptionID::kDisplayMaxThreads, &gopts.max_threads, 1, 256),
+        VbamOption(VbamOptionID::kDisplayRenderMethod, &gopts.render_method),
+        VbamOption(VbamOptionID::kDisplayScale, &gopts.video_scale, 1, 6),
+        VbamOption(VbamOptionID::kDisplayStretch, &gopts.retain_aspect),
+
+        /// GB
+        VbamOption(VbamOptionID::kGBBiosFile, &gopts.gb_bios),
+        VbamOption(VbamOptionID::kGBColorOption, &gbColorOption, 0, 1),
+        VbamOption(VbamOptionID::kGBColorizerHack, &colorizerHack, 0, 1),
+        VbamOption(VbamOptionID::kGBLCDFilter, &gbLcdFilter),
+        VbamOption(VbamOptionID::kGBGBCBiosFile, &gopts.gbc_bios),
+        VbamOption(VbamOptionID::kGBPalette0, systemGbPalette),
+        VbamOption(VbamOptionID::kGBPalette1, systemGbPalette + 8),
+        VbamOption(VbamOptionID::kGBPalette2, systemGbPalette + 16),
+        VbamOption(VbamOptionID::kGBPrintAutoPage, &gopts.print_auto_page),
+        VbamOption(VbamOptionID::kGBPrintScreenCap, &gopts.print_screen_cap),
+        VbamOption(VbamOptionID::kGBROMDir, &gopts.gb_rom_dir),
+        VbamOption(VbamOptionID::kGBGBCROMDir, &gopts.gbc_rom_dir),
+
+        /// GBA
+        VbamOption(VbamOptionID::kGBABiosFile, &gopts.gba_bios),
+        VbamOption(VbamOptionID::kGBALCDFilter, &gbaLcdFilter),
+    #ifndef NO_LINK
+        VbamOption(VbamOptionID::kGBALinkAuto, &gopts.link_auto),
+        VbamOption(VbamOptionID::kGBALinkFast, &linkHacks, 0, 1),
+        VbamOption(VbamOptionID::kGBALinkHost, &gopts.link_host),
+        VbamOption(VbamOptionID::kGBAServerIP, &gopts.server_ip),
+        VbamOption(VbamOptionID::kGBALinkPort, &gopts.link_port, 0, 65535),
+        VbamOption(VbamOptionID::kGBALinkProto, &gopts.link_proto, 0, 1),
+        VbamOption(VbamOptionID::kGBALinkTimeout, &linkTimeout, 0, 9999999),
+        VbamOption(VbamOptionID::kGBALinkType, &gopts.gba_link_type, 0, 5),
+    #endif
+        VbamOption(VbamOptionID::kGBAROMDir, &gopts.gba_rom_dir),
+
+        /// General
+        VbamOption(VbamOptionID::kGeneralAutoLoadLastState, &gopts.autoload_state),
+        VbamOption(VbamOptionID::kGeneralBatteryDir, &gopts.battery_dir),
+        VbamOption(VbamOptionID::kGeneralFreezeRecent, &gopts.recent_freeze),
+        VbamOption(VbamOptionID::kGeneralRecordingDir, &gopts.recording_dir),
+        VbamOption(VbamOptionID::kGeneralRewindInterval, &gopts.rewind_interval, 0, 600),
+        VbamOption(VbamOptionID::kGeneralScreenshotDir, &gopts.scrshot_dir),
+        VbamOption(VbamOptionID::kGeneralStateDir, &gopts.state_dir),
+        VbamOption(VbamOptionID::kGeneralStatusBar, &gopts.statusbar, 0, 1),
+
+        /// Joypad
+        VbamOption(VbamOptionID::kJoypad),
+        VbamOption(VbamOptionID::kJoypadAutofireThrottle, &gopts.autofire_rate, 1, 1000),
+        VbamOption(VbamOptionID::kJoypadDefault, &gopts.default_stick, 1, 4),
+
+        /// Keyboard
+        VbamOption(VbamOptionID::kKeyboard),
+
+        // Core
+        VbamOption(VbamOptionID::kpreferencesagbPrint, &agbPrint, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesautoFrameSkip, &autoFrameSkip, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesautoPatch, &autoPatch, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesautoSaveLoadCheatList, &gopts.autoload_cheats),
+        VbamOption(VbamOptionID::kpreferencesborderAutomatic, &gbBorderAutomatic, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesborderOn, &gbBorderOn, 0, 1),
+        VbamOption(VbamOptionID::kpreferencescaptureFormat, &captureFormat, 0, 1),
+        VbamOption(VbamOptionID::kpreferencescheatsEnabled, &cheatsEnabled, 0, 1),
+    #ifdef MMX
+        VbamOption(VbamOptionID::kpreferencesenableMMX, &enableMMX, 0, 1),
+    #endif
+        VbamOption(VbamOptionID::kpreferencesdisableStatus, &disableStatusMessages, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesemulatorType, &gbEmulatorType, 0, 5),
+        VbamOption(VbamOptionID::kpreferencesflashSize, &optFlashSize, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesframeSkip, &frameSkip, -1, 9),
+        VbamOption(VbamOptionID::kpreferencesfsColorDepth, &fsColorDepth, 0, 999),
+        VbamOption(VbamOptionID::kpreferencesfsFrequency, &fsFrequency, 0, 999),
+        VbamOption(VbamOptionID::kpreferencesfsHeight, &fsHeight, 0, 99999),
+        VbamOption(VbamOptionID::kpreferencesfsWidth, &fsWidth, 0, 99999),
+        VbamOption(VbamOptionID::kpreferencesgbPaletteOption, &gbPaletteOption, 0, 2),
+        VbamOption(VbamOptionID::kpreferencesgbPrinter, &winGbPrinterEnabled, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesgdbBreakOnLoad, &gdbBreakOnLoad, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesgdbPort, &gdbPort, 0, 65535),
+    #ifndef NO_LINK
+        VbamOption(VbamOptionID::kpreferencesLinkNumPlayers, &linkNumPlayers, 2, 4),
+    #endif
+        VbamOption(VbamOptionID::kpreferencesmaxScale, &maxScale, 0, 100),
+        VbamOption(VbamOptionID::kpreferencespauseWhenInactive, &pauseWhenInactive, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesrtcEnabled, &rtcEnabled, 0, 1),
+        VbamOption(VbamOptionID::kpreferencessaveType, &cpuSaveType, 0, 5),
+        VbamOption(VbamOptionID::kpreferencesshowSpeed, &showSpeed, 0, 2),
+        VbamOption(VbamOptionID::kpreferencesshowSpeedTransparent, &showSpeedTransparent, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesskipBios, &skipBios, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesskipSaveGameCheats, &skipSaveGameCheats, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesskipSaveGameBattery, &skipSaveGameBattery, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesthrottle, &throttle, 0, 450),
+        VbamOption(VbamOptionID::kpreferencesspeedupThrottle, &speedup_throttle, 0, 3000),
+        VbamOption(VbamOptionID::kpreferencesspeedupFrameSkip, &speedup_frame_skip, 0, 300),
+        VbamOption(VbamOptionID::kpreferencesspeedupThrottleFrameSkip, &speedup_throttle_frame_skip),
+        VbamOption(VbamOptionID::kpreferencesuseBiosGB, &useBiosFileGB, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesuseBiosGBA, &useBiosFileGBA, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesuseBiosGBC, &useBiosFileGBC, 0, 1),
+        VbamOption(VbamOptionID::kpreferencesvsync, &vsync, 0, 1),
+
+        /// Geometry
+        VbamOption(VbamOptionID::kgeometryfullScreen, &fullScreen, 0, 1),
+        VbamOption(VbamOptionID::kgeometryisMaximized, &windowMaximized, 0, 1),
+        VbamOption(VbamOptionID::kgeometrywindowHeight, &windowHeight, 0, 99999),
+        VbamOption(VbamOptionID::kgeometrywindowWidth, &windowWidth, 0, 99999),
+        VbamOption(VbamOptionID::kgeometrywindowX, &windowPositionX, -1, 99999),
+        VbamOption(VbamOptionID::kgeometrywindowY, &windowPositionY, -1, 99999),
+
+        /// UI
+        VbamOption(VbamOptionID::kuiallowKeyboardBackgroundInput, &allowKeyboardBackgroundInput),
+        VbamOption(VbamOptionID::kuiallowJoystickBackgroundInput, &allowJoystickBackgroundInput),
+        VbamOption(VbamOptionID::kuihideMenuBar, &gopts.hide_menu_bar),
+
+        /// Sound
+        VbamOption(VbamOptionID::kSoundAudioAPI, &gopts.audio_api),
+        VbamOption(VbamOptionID::kSoundAudioDevice, &gopts.audio_dev),
+        VbamOption(VbamOptionID::kSoundBuffers, &gopts.audio_buffers, 2, 10),
+        VbamOption(VbamOptionID::kSoundEnable, &gopts.sound_en, 0, 0x30f),
+        VbamOption(VbamOptionID::kSoundGBAFiltering, &gopts.gba_sound_filter, 0, 100),
+        VbamOption(VbamOptionID::kSoundGBAInterpolation, &gopts.soundInterpolation),
+        VbamOption(VbamOptionID::kSoundGBDeclicking, &gopts.gb_declick),
+        VbamOption(VbamOptionID::kSoundGBEcho, &gopts.gb_echo, 0, 100),
+        VbamOption(VbamOptionID::kSoundGBEnableEffects, &gopts.gb_effects_config_enabled),
+        VbamOption(VbamOptionID::kSoundGBStereo, &gopts.gb_stereo, 0, 100),
+        VbamOption(VbamOptionID::kSoundGBSurround, &gopts.gb_effects_config_surround),
+        VbamOption(VbamOptionID::kSoundQuality, &gopts.sound_qual),
+        VbamOption(VbamOptionID::kSoundVolume, &gopts.sound_vol, 0, 200),
+    };
+    return g_all_opts;
+}
+
+namespace internal {
+
+// These MUST follow the same order as the definitions in VbamOptionID.
+// Adding an option without adding to this array will result in a compiler
+// error since kNbOptions is automatically updated.
+const std::array<VbamOptionData, kNbOptions + 1> kAllOptionsData = {
+    /// Display
+    VbamOptionData { "Display/Bilinear", "Bilinear", _("Use bilinear filter with 3d renderer"), VbamOption::Type::kBool },
+    VbamOptionData { "Display/Filter", "", _("Full-screen filter to apply"), VbamOption::Type::kFilter },
+    VbamOptionData { "Display/FilterPlugin", "", _("Filter plugin library"), VbamOption::Type::kString },
+    VbamOptionData { "Display/IFB", "", _("Interframe blending function"), VbamOption::Type::kInterframe },
+    VbamOptionData { "Display/KeepOnTop", "KeepOnTop", _("Keep window on top"), VbamOption::Type::kBool },
+    VbamOptionData { "Display/MaxThreads", "Multithread", _("Maximum number of threads to run filters in"), VbamOption::Type::kInt },
+    VbamOptionData { "Display/RenderMethod", "", _("Render method; if unsupported, simple method will be used"), VbamOption::Type::kRenderMethod },
+    VbamOptionData { "Display/Scale", "", _("Default scale factor"), VbamOption::Type::kDouble },
+    VbamOptionData { "Display/Stretch", "RetainAspect", _("Retain aspect ratio when resizing"), VbamOption::Type::kBool },
+
+    /// GB
+    VbamOptionData { "GB/BiosFile", "", _("BIOS file to use for GB, if enabled"), VbamOption::Type::kString },
+    VbamOptionData { "GB/ColorOption", "GBColorOption", _("GB color enhancement, if enabled"), VbamOption::Type::kInt },
+    VbamOptionData { "GB/ColorizerHack", "ColorizerHack", _("Enable DX Colorization Hacks"), VbamOption::Type::kInt },
+    VbamOptionData { "GB/LCDFilter", "GBLcdFilter", _("Apply LCD filter, if enabled"), VbamOption::Type::kBool },
+    VbamOptionData { "GB/GBCBiosFile", "", _("BIOS file to use for GBC, if enabled"), VbamOption::Type::kString },
+    VbamOptionData { "GB/Palette0", "", _("The default palette, as 8 comma-separated 4-digit hex integers (rgb555)."), VbamOption::Type::kGbPalette },
+    VbamOptionData { "GB/Palette1", "", _("The first user palette, as 8 comma-separated 4-digit hex integers (rgb555)."), VbamOption::Type::kGbPalette },
+    VbamOptionData { "GB/Palette2", "", _("The second user palette, as 8 comma-separated 4-digit hex integers (rgb555)."), VbamOption::Type::kGbPalette },
+    VbamOptionData { "GB/PrintAutoPage", "PrintGather", _("Automatically gather a full page before printing"), VbamOption::Type::kBool },
+    VbamOptionData { "GB/PrintScreenCap", "PrintSnap", _("Automatically save printouts as screen captures with -print suffix"), VbamOption::Type::kBool },
+    VbamOptionData { "GB/ROMDir", "", _("Directory to look for ROM files"), VbamOption::Type::kString },
+    VbamOptionData { "GB/GBCROMDir", "", _("Directory to look for GBC ROM files"), VbamOption::Type::kString },
+
+    /// GBA
+    VbamOptionData { "GBA/BiosFile", "", _("BIOS file to use, if enabled"), VbamOption::Type::kString },
+    VbamOptionData { "GBA/LCDFilter", "GBALcdFilter", _("Apply LCD filter, if enabled"), VbamOption::Type::kBool },
+#ifndef NO_LINK
+    VbamOptionData { "GBA/LinkAuto", "LinkAuto", _("Enable link at boot"), VbamOption::Type::kBool },
+    VbamOptionData { "GBA/LinkFast", "SpeedOn", _("Enable faster network protocol by default"), VbamOption::Type::kInt },
+    VbamOptionData { "GBA/LinkHost", "", _("Default network link client host"), VbamOption::Type::kString },
+    VbamOptionData { "GBA/ServerIP", "", _("Default network link server IP to bind"), VbamOption::Type::kString },
+    VbamOptionData { "GBA/LinkPort", "", _("Default network link port (server and client)"), VbamOption::Type::kUnsigned },
+    VbamOptionData { "GBA/LinkProto", "LinkProto", _("Default network protocol"), VbamOption::Type::kInt },
+    VbamOptionData { "GBA/LinkTimeout", "LinkTimeout", _("Link timeout (ms)"), VbamOption::Type::kInt },
+    VbamOptionData { "GBA/LinkType", "LinkType", _("Link cable type"), VbamOption::Type::kInt },
+#endif
+    VbamOptionData { "GBA/ROMDir", "", _("Directory to look for ROM files"), VbamOption::Type::kString },
+
+    /// General
+    VbamOptionData { "General/AutoLoadLastState", "", _("Automatically load last saved state"), VbamOption::Type::kBool },
+    VbamOptionData { "General/BatteryDir", "", _("Directory to store game save files (relative paths are relative to ROM; blank is config dir)"), VbamOption::Type::kString },
+    VbamOptionData { "General/FreezeRecent", "", _("Freeze recent load list"), VbamOption::Type::kBool },
+    VbamOptionData { "General/RecordingDir", "", _("Directory to store A/V and game recordings (relative paths are relative to ROM)"), VbamOption::Type::kString },
+    VbamOptionData { "General/RewindInterval", "", _("Number of seconds between rewind snapshots (0 to disable)"), VbamOption::Type::kInt },
+    VbamOptionData { "General/ScreenshotDir", "", _("Directory to store screenshots (relative paths are relative to ROM)"), VbamOption::Type::kString },
+    VbamOptionData { "General/StateDir", "", _("Directory to store saved state files (relative paths are relative to BatteryDir)"), VbamOption::Type::kString },
+    VbamOptionData { "General/StatusBar", "StatusBar", _("Enable status bar"), VbamOption::Type::kInt },
+
+    /// Joypad
+    VbamOptionData { "Joypad/*/*", "", _("The parameter Joypad/<n>/<button> contains a comma-separated list of key names which map to joypad #<n> button <button>.  Button is one of Up, Down, Left, Right, A, B, L, R, Select, Start, MotionUp, MotionDown, MotionLeft, MotionRight, AutoA, AutoB, Speed, Capture, GS"), VbamOption::Type::kNone },
+    VbamOptionData { "Joypad/AutofireThrottle", "", _("The autofire toggle period, in frames (1/60 s)"), VbamOption::Type::kInt },
+    VbamOptionData { "Joypad/Default", "", _("The number of the stick to use in single-player mode"), VbamOption::Type::kInt },
+
+    /// Keyboard
+    VbamOptionData { "Keyboard/*", "", _("The parameter Keyboard/<cmd> contains a comma-separated list of key names (e.g. Alt-Shift-F1).  When the named key is pressed, the command <cmd> is executed."), VbamOption::Type::kNone },
+
+    // Core
+    VbamOptionData { "preferences/agbPrint", "AGBPrinter", _("Enable AGB debug print"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/autoFrameSkip", "FrameSkipAuto", _("Auto skip frames."), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/autoPatch", "ApplyPatches", _("Apply IPS/UPS/IPF patches if found"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/autoSaveLoadCheatList", "", _("Automatically save and load cheat list"), VbamOption::Type::kBool },
+    VbamOptionData { "preferences/borderAutomatic", "", _("Automatically enable border for Super GameBoy games"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/borderOn", "", _("Always enable border"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/captureFormat", "", _("Screen capture file format"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/cheatsEnabled", "", _("Enable cheats"), VbamOption::Type::kInt },
+#ifdef MMX
+    VbamOptionData { "preferences/enableMMX", "MMX", _("Enable MMX"), VbamOption::Type::kInt },
+#endif
+    VbamOptionData { "preferences/disableStatus", "NoStatusMsg", _("Disable on-screen status messages"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/emulatorType", "", _("Type of system to emulate"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/flashSize", "", _("Flash size 0 = 64KB 1 = 128KB"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/frameSkip", "FrameSkip", _("Skip frames.  Values are 0-9 or -1 to skip automatically based on time."), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/fsColorDepth", "", _("Fullscreen mode color depth (0 = any)"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/fsFrequency", "", _("Fullscreen mode frequency (0 = any)"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/fsHeight", "", _("Fullscreen mode height (0 = desktop)"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/fsWidth", "", _("Fullscreen mode width (0 = desktop)"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/gbPaletteOption", "", _("The palette to use"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/gbPrinter", "Printer", _("Enable printer emulation"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/gdbBreakOnLoad", "DebugGDBBreakOnLoad", _("Break into GDB after loading the game."), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/gdbPort", "DebugGDBPort", _("Port to connect GDB to."), VbamOption::Type::kInt },
+#ifndef NO_LINK
+    VbamOptionData { "preferences/LinkNumPlayers", "", _("Number of players in network"), VbamOption::Type::kInt },
+#endif
+    VbamOptionData { "preferences/maxScale", "", _("Maximum scale factor (0 = no limit)"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/pauseWhenInactive", "PauseWhenInactive", _("Pause game when main window loses focus"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/rtcEnabled", "RTC", _("Enable RTC (vba-over.ini override is rtcEnabled"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/saveType", "", _("Native save (\"battery\") hardware type"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/showSpeed", "", _("Show speed indicator"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/showSpeedTransparent", "Transparent", _("Draw on-screen messages transparently"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/skipBios", "SkipIntro", _("Skip BIOS initialization"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/skipSaveGameCheats", "", _("Do not overwrite cheat list when loading state"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/skipSaveGameBattery", "", _("Do not overwrite native (battery) save when loading state"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/throttle", "", _("Throttle game speed, even when accelerated (0-450%, 0 = no throttle)"), VbamOption::Type::kUnsigned },
+    VbamOptionData { "preferences/speedupThrottle", "", _("Set throttle for speedup key (0-3000%, 0 = no throttle)"), VbamOption::Type::kUnsigned },
+    VbamOptionData { "preferences/speedupFrameSkip", "", _("Number of frames to skip with speedup (instead of speedup throttle)"), VbamOption::Type::kUnsigned },
+    VbamOptionData { "preferences/speedupThrottleFrameSkip", "", _("Use frame skip for speedup throttle"), VbamOption::Type::kBool },
+    VbamOptionData { "preferences/useBiosGB", "BootRomGB", _("Use the specified BIOS file for GB"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/useBiosGBA", "BootRomEn", _("Use the specified BIOS file"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/useBiosGBC", "BootRomGBC", _("Use the specified BIOS file for GBC"), VbamOption::Type::kInt },
+    VbamOptionData { "preferences/vsync", "VSync", _("Wait for vertical sync"), VbamOption::Type::kInt },
+
+    /// Geometry
+    VbamOptionData { "geometry/fullScreen", "Fullscreen", _("Enter fullscreen mode at startup"), VbamOption::Type::kInt },
+    VbamOptionData { "geometry/isMaximized", "Maximized", _("Window maximized"), VbamOption::Type::kInt },
+    VbamOptionData { "geometry/windowHeight", "Height", _("Window height at startup"), VbamOption::Type::kUnsigned },
+    VbamOptionData { "geometry/windowWidth", "Width", _("Window width at startup"), VbamOption::Type::kUnsigned },
+    VbamOptionData { "geometry/windowX", "X", _("Window axis X position at startup"), VbamOption::Type::kInt },
+    VbamOptionData { "geometry/windowY", "Y", _("Window axis Y position at startup"), VbamOption::Type::kInt },
+
+    /// UI
+    VbamOptionData { "ui/allowKeyboardBackgroundInput", "AllowKeyboardBackgroundInput", _("Capture key events while on background"), VbamOption::Type::kBool },
+    VbamOptionData { "ui/allowJoystickBackgroundInput", "AllowJoystickBackgroundInput", _("Capture joy events while on background"), VbamOption::Type::kBool },
+    VbamOptionData { "ui/hideMenuBar", "", _("Hide menu bar when mouse is inactive"), VbamOption::Type::kBool },
+
+    /// Sound
+    VbamOptionData { "Sound/AudioAPI", "", _("Sound API; if unsupported, default API will be used"), VbamOption::Type::kAudioApi },
+    VbamOptionData { "Sound/AudioDevice", "", _("Device ID of chosen audio device for chosen driver"), VbamOption::Type::kString },
+    VbamOptionData { "Sound/Buffers", "", _("Number of sound buffers"), VbamOption::Type::kInt },
+    VbamOptionData { "Sound/Enable", "", _("Bit mask of sound channels to enable"), VbamOption::Type::kInt },
+    VbamOptionData { "Sound/GBAFiltering", "", _("GBA sound filtering (%)"), VbamOption::Type::kInt },
+    VbamOptionData { "Sound/GBAInterpolation", "GBASoundInterpolation", _("GBA sound interpolation"), VbamOption::Type::kBool },
+    VbamOptionData { "Sound/GBDeclicking", "GBDeclicking", _("GB sound declicking"), VbamOption::Type::kBool },
+    VbamOptionData { "Sound/GBEcho", "", _("GB echo effect (%)"), VbamOption::Type::kInt },
+    VbamOptionData { "Sound/GBEnableEffects", "GBEnhanceSound", _("Enable GB sound effects"), VbamOption::Type::kBool },
+    VbamOptionData { "Sound/GBStereo", "", _("GB stereo effect (%)"), VbamOption::Type::kInt },
+    VbamOptionData { "Sound/GBSurround", "GBSurround", _("GB surround sound effect (%)"), VbamOption::Type::kBool },
+    VbamOptionData { "Sound/Quality", "", _("Sound sample rate (kHz)"), VbamOption::Type::kSoundQuality },
+    VbamOptionData { "Sound/Volume", "", _("Sound volume (%)"), VbamOption::Type::kInt },
+
+    // Last
+    VbamOptionData { "", "", "", VbamOption::Type::kNone },
+};
+
+nonstd::optional<VbamOptionID> StringToOptionId(const wxString& input) {
+    // Note: This map does not include "Joystick" and "Keyboard". This is on
+    // purpose, as these are handled separately.
+    static const std::map<wxString, VbamOptionID> kStringToOptionId = {
+        { "Display/Bilinear", VbamOptionID::kDisplayBilinear },
+        { "Display/Filter", VbamOptionID::kDisplayFilter },
+        { "Display/FilterPlugin", VbamOptionID::kDisplayFilterPlugin },
+        { "Display/IFB", VbamOptionID::kDisplayIFB },
+        { "Display/KeepOnTop", VbamOptionID::kDisplayKeepOnTop },
+        { "Display/MaxThreads", VbamOptionID::kDisplayMaxThreads },
+        { "Display/RenderMethod", VbamOptionID::kDisplayRenderMethod },
+        { "Display/Scale", VbamOptionID::kDisplayScale },
+        { "Display/Stretch", VbamOptionID::kDisplayStretch },
+
+        /// GB
+        { "GB/BiosFile", VbamOptionID::kGBBiosFile },
+        { "GB/ColorOption", VbamOptionID::kGBColorOption },
+        { "GB/ColorizerHack", VbamOptionID::kGBColorizerHack },
+        { "GB/LCDFilter", VbamOptionID::kGBLCDFilter },
+        { "GB/GBCBiosFile", VbamOptionID::kGBGBCBiosFile },
+        { "GB/Palette0", VbamOptionID::kGBPalette0 },
+        { "GB/Palette1", VbamOptionID::kGBPalette1 },
+        { "GB/Palette2", VbamOptionID::kGBPalette2 },
+        { "GB/PrintAutoPage", VbamOptionID::kGBPrintAutoPage },
+        { "GB/PrintScreenCap", VbamOptionID::kGBPrintScreenCap },
+        { "GB/ROMDir", VbamOptionID::kGBROMDir },
+        { "GB/GBCROMDir", VbamOptionID::kGBGBCROMDir },
+
+        /// GBA
+        { "GBA/BiosFile", VbamOptionID::kGBABiosFile },
+        { "GBA/LCDFilter", VbamOptionID::kGBALCDFilter },
+#ifndef NO_LINK
+        { "GBA/LinkAuto", VbamOptionID::kGBALinkAuto },
+        { "GBA/LinkFast", VbamOptionID::kGBALinkFast },
+        { "GBA/LinkHost", VbamOptionID::kGBALinkHost },
+        { "GBA/ServerIP", VbamOptionID::kGBAServerIP },
+        { "GBA/LinkPort", VbamOptionID::kGBALinkPort },
+        { "GBA/LinkProto", VbamOptionID::kGBALinkProto },
+        { "GBA/LinkTimeout", VbamOptionID::kGBALinkTimeout },
+        { "GBA/LinkType", VbamOptionID::kGBALinkType },
+#endif
+        { "GBA/ROMDir", VbamOptionID::kGBAROMDir },
+
+        /// General
+        { "General/AutoLoadLastState", VbamOptionID::kGeneralAutoLoadLastState },
+        { "General/BatteryDir", VbamOptionID::kGeneralBatteryDir },
+        { "General/FreezeRecent", VbamOptionID::kGeneralFreezeRecent },
+        { "General/RecordingDir", VbamOptionID::kGeneralRecordingDir },
+        { "General/RewindInterval", VbamOptionID::kGeneralRewindInterval },
+        { "General/ScreenshotDir", VbamOptionID::kGeneralScreenshotDir },
+        { "General/StateDir", VbamOptionID::kGeneralStateDir },
+        { "General/StatusBar", VbamOptionID::kGeneralStatusBar },
+
+        /// Joypad
+        { "Joypad/AutofireThrottle", VbamOptionID::kJoypadAutofireThrottle },
+        { "Joypad/Default", VbamOptionID::kJoypadDefault },
+
+        // Core
+        { "preferences/agbPrint", VbamOptionID::kpreferencesagbPrint },
+        { "preferences/autoFrameSkip", VbamOptionID::kpreferencesautoFrameSkip },
+        { "preferences/autoPatch", VbamOptionID::kpreferencesautoPatch },
+        { "preferences/autoSaveLoadCheatList", VbamOptionID::kpreferencesautoSaveLoadCheatList },
+        { "preferences/borderAutomatic", VbamOptionID::kpreferencesborderAutomatic },
+        { "preferences/borderOn", VbamOptionID::kpreferencesborderOn },
+        { "preferences/captureFormat", VbamOptionID::kpreferencescaptureFormat },
+        { "preferences/cheatsEnabled", VbamOptionID::kpreferencescheatsEnabled },
+#ifdef MMX
+        { "preferences/enableMMX", VbamOptionID::kpreferencesenableMMX },
+#endif
+        { "preferences/disableStatus", VbamOptionID::kpreferencesdisableStatus },
+        { "preferences/emulatorType", VbamOptionID::kpreferencesemulatorType },
+        { "preferences/flashSize", VbamOptionID::kpreferencesflashSize },
+        { "preferences/frameSkip", VbamOptionID::kpreferencesframeSkip },
+        { "preferences/fsColorDepth", VbamOptionID::kpreferencesfsColorDepth },
+        { "preferences/fsFrequency", VbamOptionID::kpreferencesfsFrequency },
+        { "preferences/fsHeight", VbamOptionID::kpreferencesfsHeight },
+        { "preferences/fsWidth", VbamOptionID::kpreferencesfsWidth },
+        { "preferences/gbPaletteOption", VbamOptionID::kpreferencesgbPaletteOption },
+        { "preferences/gbPrinter", VbamOptionID::kpreferencesgbPrinter },
+        { "preferences/gdbBreakOnLoad", VbamOptionID::kpreferencesgdbBreakOnLoad },
+        { "preferences/gdbPort", VbamOptionID::kpreferencesgdbPort },
+#ifndef NO_LINK
+        { "preferences/LinkNumPlayers", VbamOptionID::kpreferencesLinkNumPlayers },
+#endif
+        { "preferences/maxScale", VbamOptionID::kpreferencesmaxScale },
+        { "preferences/pauseWhenInactive", VbamOptionID::kpreferencespauseWhenInactive },
+        { "preferences/rtcEnabled", VbamOptionID::kpreferencesrtcEnabled },
+        { "preferences/saveType", VbamOptionID::kpreferencessaveType },
+        { "preferences/showSpeed", VbamOptionID::kpreferencesshowSpeed },
+        { "preferences/showSpeedTransparent", VbamOptionID::kpreferencesshowSpeedTransparent },
+        { "preferences/skipBios", VbamOptionID::kpreferencesskipBios },
+        { "preferences/skipSaveGameCheats", VbamOptionID::kpreferencesskipSaveGameCheats },
+        { "preferences/skipSaveGameBattery", VbamOptionID::kpreferencesskipSaveGameBattery },
+        { "preferences/throttle", VbamOptionID::kpreferencesthrottle },
+        { "preferences/speedupThrottle", VbamOptionID::kpreferencesspeedupThrottle },
+        { "preferences/speedupFrameSkip", VbamOptionID::kpreferencesspeedupFrameSkip },
+        { "preferences/speedupThrottleFrameSkip", VbamOptionID::kpreferencesspeedupThrottleFrameSkip },
+        { "preferences/useBiosGB", VbamOptionID::kpreferencesuseBiosGB },
+        { "preferences/useBiosGBA", VbamOptionID::kpreferencesuseBiosGBA },
+        { "preferences/useBiosGBC", VbamOptionID::kpreferencesuseBiosGBC },
+        { "preferences/vsync", VbamOptionID::kpreferencesvsync },
+
+        /// Geometry
+        { "geometry/fullScreen", VbamOptionID::kgeometryfullScreen },
+        { "geometry/isMaximized", VbamOptionID::kgeometryisMaximized },
+        { "geometry/windowHeight", VbamOptionID::kgeometrywindowHeight },
+        { "geometry/windowWidth", VbamOptionID::kgeometrywindowWidth },
+        { "geometry/windowX", VbamOptionID::kgeometrywindowX },
+        { "geometry/windowY", VbamOptionID::kgeometrywindowY },
+
+        /// UI
+        { "ui/allowKeyboardBackgroundInput", VbamOptionID::kuiallowKeyboardBackgroundInput },
+        { "ui/allowJoystickBackgroundInput", VbamOptionID::kuiallowJoystickBackgroundInput },
+        { "ui/hideMenuBar", VbamOptionID::kuihideMenuBar },
+
+        /// Sound
+        { "Sound/AudioAPI", VbamOptionID::kSoundAudioAPI },
+        { "Sound/AudioDevice", VbamOptionID::kSoundAudioDevice },
+        { "Sound/Buffers", VbamOptionID::kSoundBuffers },
+        { "Sound/Enable", VbamOptionID::kSoundEnable },
+        { "Sound/GBAFiltering", VbamOptionID::kSoundGBAFiltering },
+        { "Sound/GBAInterpolation", VbamOptionID::kSoundGBAInterpolation },
+        { "Sound/GBDeclicking", VbamOptionID::kSoundGBDeclicking },
+        { "Sound/GBEcho", VbamOptionID::kSoundGBEcho },
+        { "Sound/GBEnableEffects", VbamOptionID::kSoundGBEnableEffects },
+        { "Sound/GBStereo", VbamOptionID::kSoundGBStereo },
+        { "Sound/GBSurround", VbamOptionID::kSoundGBSurround },
+        { "Sound/Quality", VbamOptionID::kSoundQuality },
+        { "Sound/Volume", VbamOptionID::kSoundVolume },
+    };
+
+    const auto iter = kStringToOptionId.find(input);
+    if (iter == kStringToOptionId.end()) {
+        return nonstd::nullopt;
+    }
+    return iter->second;
+}
+
+wxString FilterToString(int value) {
+    assert(value >= 0 && static_cast<size_t>(value) < kNbFilterFunctions);
+    return kFilterStrings[value];
+}
+
+wxString InterframeToString(int value) {
+    assert(value >= 0 && static_cast<size_t>(value) < kNbInterframes);
+    return kInterframeStrings[value];
+}
+
+wxString RenderMethodToString(int value) {
+    assert(value >= 0 && static_cast<size_t>(value) < kNbRenderMethods);
+    return kRenderMethodStrings[value];
+}
+
+wxString AudioApiToString(int value) {
+    assert(value >= 0 && static_cast<size_t>(value) < kNbAudioApis);
+    return kAudioApiStrings[value];
+}
+
+wxString SoundQualityToString(int value) {
+    assert(value >= 0 && static_cast<size_t>(value) < kNbSoundQualities);
+    return kSoundQualityStrings[value];
+}
+
+int StringToFilter(const wxString& config_name, const wxString& input) {
+    static const std::map<wxString, FilterFunction> kStringToFilter = {
+        { kFilterStrings[0], FilterFunction::kNone },
+        { kFilterStrings[1], FilterFunction::k2xsai },
+        { kFilterStrings[2], FilterFunction::kSuper2xsai }, 
+        { kFilterStrings[3], FilterFunction::kSupereagle }, 
+        { kFilterStrings[4], FilterFunction::kPixelate }, 
+        { kFilterStrings[5], FilterFunction::kAdvmame }, 
+        { kFilterStrings[6], FilterFunction::kBilinear }, 
+        { kFilterStrings[7], FilterFunction::kBilinearplus }, 
+        { kFilterStrings[8], FilterFunction::kScanlines }, 
+        { kFilterStrings[9], FilterFunction::kTvmode }, 
+        { kFilterStrings[10], FilterFunction::kHQ2x }, 
+        { kFilterStrings[11], FilterFunction::kLQ2x }, 
+        { kFilterStrings[12], FilterFunction::kSimple2x }, 
+        { kFilterStrings[13], FilterFunction::kSimple3x }, 
+        { kFilterStrings[14], FilterFunction::kHQ3x }, 
+        { kFilterStrings[15], FilterFunction::kSimple4x }, 
+        { kFilterStrings[16], FilterFunction::kHQ4x }, 
+        { kFilterStrings[17], FilterFunction::kXbrz2x }, 
+        { kFilterStrings[18], FilterFunction::kXbrz3x }, 
+        { kFilterStrings[19], FilterFunction::kXbrz4x }, 
+        { kFilterStrings[20], FilterFunction::kXbrz5x }, 
+        { kFilterStrings[21], FilterFunction::kXbrz6x }, 
+        { kFilterStrings[22], FilterFunction::kPlugin }, 
+    };
+    assert(kFilterStrings.size() == kNbFilterFunctions);
+
+    const auto iter = kStringToFilter.find(input);
+    if (iter == kStringToFilter.end()) {
+        wxLogWarning(_("Invalid value %s for option %s; valid values are %s"),
+             input,
+             config_name,
+             AllEnumValuesForType(VbamOption::Type::kFilter));
+        return 0;
+    }
+    return static_cast<int>(iter->second);
+}
+
+int StringToInterframe(const wxString& config_name, const wxString& input) {
+    static const std::map<wxString, Interframe> kStringToInterframe = {
+        { kInterframeStrings[0], Interframe::kNone },
+        { kInterframeStrings[1], Interframe::kSmart },
+        { kInterframeStrings[2], Interframe::kMotionBlur },
+    };
+    assert(kStringToInterframe.size() == kNbInterframes);
+
+    const auto iter = kStringToInterframe.find(input);
+    if (iter == kStringToInterframe.end()) {
+        wxLogWarning(_("Invalid value %s for option %s; valid values are %s"),
+             input,
+             config_name,
+             AllEnumValuesForType(VbamOption::Type::kInterframe));
+        return 0;
+    }
+    return static_cast<int>(iter->second);
+}
+
+int StringToRenderMethod(const wxString& config_name, const wxString& input) {
+    static const std::map<wxString, RenderMethod> kStringToRenderMethod = {
+        { kRenderMethodStrings[0], RenderMethod::kSimple },
+        { kRenderMethodStrings[1], RenderMethod::kOpenGL },
+#ifdef __WXMSW__
+        { kRenderMethodStrings[2], RenderMethod::kDirect3d },
+#elif defined(__WXMAC__)
+        { kRenderMethodStrings[2], RenderMethod::kQuartz2d },
+#endif
+    };
+    assert(kStringToRenderMethod.size() == kNbRenderMethods);
+
+    const auto iter = kStringToRenderMethod.find(input);
+    if (iter == kStringToRenderMethod.end()) {
+        wxLogWarning(_("Invalid value %s for option %s; valid values are %s"),
+             input,
+             config_name,
+             AllEnumValuesForType(VbamOption::Type::kRenderMethod));
+        return 0;
+    }
+    return static_cast<int>(iter->second);
+}
+
+int StringToAudioApi(const wxString& config_name, const wxString& input) {
+    static const std::map<wxString, AudioApi> kStringToAudioApi = {
+        { kAudioApiStrings[0], AudioApi::kSdl },
+        { kAudioApiStrings[1], AudioApi::kOpenAL },
+        { kAudioApiStrings[2], AudioApi::kDirectSound }, 
+        { kAudioApiStrings[3], AudioApi::kXAudio2 }, 
+        { kAudioApiStrings[4], AudioApi::kFaudio }, 
+    };
+    assert(kStringToAudioApi.size() == kNbAudioApis);
+
+    const auto iter = kStringToAudioApi.find(input);
+    if (iter == kStringToAudioApi.end()) {
+        wxLogWarning(_("Invalid value %s for option %s; valid values are %s"),
+             input,
+             config_name,
+             AllEnumValuesForType(VbamOption::Type::kAudioApi));
+        return 0;
+    }
+    return static_cast<int>(iter->second);
+}
+
+int StringToSoundQuality(const wxString& config_name, const wxString& input) {
+    static const std::map<wxString, SoundQuality> kStringToSoundQuality = {
+        { kSoundQualityStrings[0], SoundQuality::k48kHz },
+        { kSoundQualityStrings[1], SoundQuality::k44kHz },
+        { kSoundQualityStrings[2], SoundQuality::k22kHz },
+        { kSoundQualityStrings[3], SoundQuality::k11kHz },
+    };
+    assert(kStringToSoundQuality.size() == kNbSoundQualities);
+
+    const auto iter = kStringToSoundQuality.find(input);
+    if (iter == kStringToSoundQuality.end()) {
+        wxLogWarning(_("Invalid value %s for option %s; valid values are %s"),
+             input,
+             config_name,
+             AllEnumValuesForType(VbamOption::Type::kSoundQuality));
+        return 0;
+    }
+    return static_cast<int>(iter->second);
+
+}
+
+wxString AllEnumValuesForType(VbamOption::Type type) {
+    switch (type) {
+    case VbamOption::Type::kFilter: {
+        static const wxString kAllFilterValues = AllEnumValuesForArray(kFilterStrings);
+        return kAllFilterValues;
+    }
+    case VbamOption::Type::kInterframe: {
+        static const wxString kAllInterframeValues = AllEnumValuesForArray(kInterframeStrings);
+        return kAllInterframeValues;
+    }
+    case VbamOption::Type::kRenderMethod: {
+        static const wxString kAllRenderValues = AllEnumValuesForArray(kRenderMethodStrings);
+        return kAllRenderValues;
+    }
+    case VbamOption::Type::kAudioApi: {
+        static const wxString kAllAudioApiValues = AllEnumValuesForArray(kAudioApiStrings);
+        return kAllAudioApiValues;
+    }
+    case VbamOption::Type::kSoundQuality: {
+        static const wxString kAllSoundQualityValues = AllEnumValuesForArray(kSoundQualityStrings);
+        return kAllSoundQualityValues;
+    }
+
+    // We don't use default here to explicitly trigger a compiler warning when
+    // adding a new value.
+    case VbamOption::Type::kNone:
+    case VbamOption::Type::kBool:
+    case VbamOption::Type::kDouble:
+    case VbamOption::Type::kInt:
+    case VbamOption::Type::kUnsigned:
+    case VbamOption::Type::kString:
+    case VbamOption::Type::kGbPalette:
+        assert(false);
+        return wxEmptyString;
+    }
+    assert(false);
+    return wxEmptyString;
+}
+
+int MaxForType(VbamOption::Type type) {
+    switch (type) {
+    case VbamOption::Type::kFilter:
+        return kNbFilterFunctions;
+    case VbamOption::Type::kInterframe:
+        return kNbInterframes;
+    case VbamOption::Type::kRenderMethod:
+        return kNbRenderMethods;
+    case VbamOption::Type::kAudioApi:
+        return kNbAudioApis;
+    case VbamOption::Type::kSoundQuality:
+        return kNbSoundQualities;
+
+    // We don't use default here to explicitly trigger a compiler warning when
+    // adding a new value.
+    case VbamOption::Type::kNone:
+    case VbamOption::Type::kBool:
+    case VbamOption::Type::kDouble:
+    case VbamOption::Type::kInt:
+    case VbamOption::Type::kUnsigned:
+    case VbamOption::Type::kString:
+    case VbamOption::Type::kGbPalette:
+        assert(false);
+        return 0;
+    }
+    assert(false);
+    return 0;
+}
+
+}  // namespace internal

--- a/src/wx/vbam-options.cpp
+++ b/src/wx/vbam-options.cpp
@@ -1,0 +1,368 @@
+#include "vbam-options.h"
+
+#include <variant>
+#include <wx/log.h>
+#include <wx/translation.h>
+
+#define VBAM_OPTIONS_INTERNAL_INCLUDE
+#include "vbam-options-internal.h"
+#undef VBAM_OPTIONS_INTERNAL_INCLUDE
+
+// static
+VbamOption const* VbamOption::FindOptionByName(const wxString &config_name) {
+    nonstd::optional<VbamOptionID> option_id = internal::StringToOptionId(config_name);
+    if (!option_id) {
+        return nullptr;
+    }
+    return &FindOptionByID(option_id.value());
+}
+
+// static
+VbamOption& VbamOption::FindOptionByID(VbamOptionID id) {
+    assert (id != VbamOptionID::Last);
+    return AllOptions()[static_cast<size_t>(id)];
+}
+
+VbamOption::~VbamOption() = default;
+
+VbamOption::VbamOption(VbamOptionID id) :
+    id_(id),
+    config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+    command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
+    ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+    type_(internal::kAllOptionsData[static_cast<size_t>(id)].type),
+    value_(),
+    min_(),
+    max_() {
+    assert(id != VbamOptionID::Last);
+    assert(is_none());
+}
+
+VbamOption::VbamOption(VbamOptionID id, bool* option) :
+    id_(id),
+    config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+    command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
+    ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+    type_(internal::kAllOptionsData[static_cast<size_t>(id)].type),
+    value_(option),
+    min_(),
+    max_() {
+    assert(id != VbamOptionID::Last);
+    assert(is_bool());
+}
+
+VbamOption::VbamOption(VbamOptionID id, double* option, double min, double max) :
+    id_(id),
+    config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+    command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
+    ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+    type_(internal::kAllOptionsData[static_cast<size_t>(id)].type),
+    value_(option),
+    min_(min),
+    max_(max) {
+    assert(id != VbamOptionID::Last);
+    assert(is_double());
+
+    // Validate the initial value.
+    SetDouble(*option);
+}
+
+VbamOption::VbamOption(VbamOptionID id, int32_t* option, int32_t min, int32_t max) :
+    id_(id),
+    config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+    command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
+    ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+    type_(internal::kAllOptionsData[static_cast<size_t>(id)].type),
+    value_(option),
+    min_(min),
+    max_(max) {
+    assert(id != VbamOptionID::Last);
+    assert(is_int());
+
+    // Validate the initial value.
+    SetInt(*option);
+}
+
+VbamOption::VbamOption(VbamOptionID id, uint32_t* option, uint32_t min, uint32_t max) :
+    id_(id),
+    config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+    command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
+    ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+    type_(internal::kAllOptionsData[static_cast<size_t>(id)].type),
+    value_(option),
+    min_(min),
+    max_(max) {
+    assert(id != VbamOptionID::Last);
+    assert(is_unsigned());
+
+    // Validate the initial value.
+    SetUnsigned(*option);
+}
+
+VbamOption::VbamOption(VbamOptionID id, wxString* option) :
+    id_(id),
+    config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+    command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
+    ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+    type_(internal::kAllOptionsData[static_cast<size_t>(id)].type),
+    value_(option),
+    min_(),
+    max_() {
+    assert(id != VbamOptionID::Last);
+    assert(is_string());
+}
+
+VbamOption::VbamOption(VbamOptionID id, int* option) :
+    id_(id),
+    config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+    command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
+    ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+    type_(internal::kAllOptionsData[static_cast<size_t>(id)].type),
+    value_(option),
+    min_(0),
+    max_(internal::MaxForType(type_)) {
+    assert(id != VbamOptionID::Last);
+    assert(is_filter() || is_interframe() || is_render_method() || is_audio_api() || is_sound_quality());
+
+    // Validate the initial value.
+    SetEnumInt(*option);
+}
+
+VbamOption::VbamOption(VbamOptionID id, uint16_t* option) :
+    id_(id),
+    config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+    command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
+    ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+    type_(internal::kAllOptionsData[static_cast<size_t>(id)].type),
+    value_(option),
+    min_(),
+    max_() {
+    assert(id != VbamOptionID::Last);
+    assert(is_gb_palette());
+}
+
+bool VbamOption::GetBool() const {
+    assert(is_bool());
+    return *(std::get<bool*>(value_));
+}
+
+double VbamOption::GetDouble() const {
+    assert(is_double());
+    return *(std::get<double*>(value_));
+}
+
+int32_t VbamOption::GetInt() const {
+    assert(is_int());
+    return *(std::get<int32_t*>(value_));
+}
+
+uint32_t VbamOption::GetUnsigned() const {
+    assert(is_unsigned());
+    return *(std::get<uint32_t*>(value_));
+}
+
+const wxString VbamOption::GetString() const {
+    assert(is_string());
+    return *(std::get<wxString*>(value_));
+}
+
+wxString VbamOption::GetEnumString() const {
+    switch (type_) {
+    case VbamOption::Type::kFilter:
+        return internal::FilterToString(*(std::get<int32_t*>(value_)));
+    case VbamOption::Type::kInterframe:
+        return internal::InterframeToString(*(std::get<int32_t*>(value_)));
+    case VbamOption::Type::kRenderMethod:
+        return internal::RenderMethodToString(*(std::get<int32_t*>(value_)));
+    case VbamOption::Type::kAudioApi:
+        return internal::AudioApiToString(*(std::get<int32_t*>(value_)));
+    case VbamOption::Type::kSoundQuality:
+        return internal::SoundQualityToString(*(std::get<int32_t*>(value_)));
+
+    // We don't use default here to explicitly trigger a compiler warning when
+    // adding a new value.
+    case VbamOption::Type::kNone:
+    case VbamOption::Type::kBool:
+    case VbamOption::Type::kDouble:
+    case VbamOption::Type::kInt:
+    case VbamOption::Type::kUnsigned:
+    case VbamOption::Type::kString:
+    case VbamOption::Type::kGbPalette:
+        assert(false);
+        return wxEmptyString;
+    }
+    assert(false);
+    return wxEmptyString;
+}
+
+wxString VbamOption::GetGbPaletteString() const {
+    assert(is_gb_palette());
+
+    wxString palette_string;
+    uint16_t const* value = std::get<uint16_t*>(value_);
+    palette_string.Printf("%04X,%04X,%04X,%04X,%04X,%04X,%04X,%04X",
+        value[0], value[1], value[2], value[3],
+        value[4], value[5], value[6], value[7]);
+    return palette_string;
+}
+
+void VbamOption::SetBool(bool value) const {
+    assert(is_bool());
+    *std::get<bool*>(value_) = value;
+}
+
+void VbamOption::SetDouble(double value) const {
+    assert(is_double());
+    if (value < std::get<double>(min_) || value > std::get<double>(max_)) {
+        wxLogWarning(
+            _("Invalid value %f for option %s; valid values are %f - %f"),
+            value,
+            config_name_,
+            std::get<double>(min_),
+            std::get<double>(max_));
+        return;
+    }
+    *std::get<double*>(value_) = value;
+}
+
+void VbamOption::SetInt(int32_t value) const {
+    assert(is_int());
+    if (value < std::get<int32_t>(min_) || value > std::get<int32_t>(max_)) {
+        wxLogWarning(
+            _("Invalid value %d for option %s; valid values are %d - %d"),
+            value,
+            config_name_,
+            std::get<int32_t>(min_),
+            std::get<int32_t>(max_));
+        return;
+    }
+    *std::get<int32_t*>(value_) = value;
+}
+
+void VbamOption::SetUnsigned(uint32_t value) const {
+    assert(is_unsigned());
+    if (value < std::get<uint32_t>(min_) || value > std::get<uint32_t>(max_)) {
+        wxLogWarning(
+            _("Invalid value %d for option %s; valid values are %d - %d"),
+            value,
+            config_name_,
+            std::get<uint32_t>(min_),
+            std::get<uint32_t>(max_));
+        return;
+    }
+    *std::get<uint32_t*>(value_) = value;
+}
+
+void VbamOption::SetString(const wxString& value) const {
+    assert(is_string());
+    *std::get<wxString*>(value_) = value;
+}
+
+void VbamOption::SetEnumString(const wxString& value) const {
+    switch (type_) {
+    case VbamOption::Type::kFilter:
+        SetEnumInt(internal::StringToFilter(config_name_, value));
+        return;
+    case VbamOption::Type::kInterframe:
+        SetEnumInt(internal::StringToInterframe(config_name_, value));
+        return;
+    case VbamOption::Type::kRenderMethod:
+        SetEnumInt(internal::StringToRenderMethod(config_name_, value));
+        return;
+    case VbamOption::Type::kAudioApi:
+        SetEnumInt(internal::StringToAudioApi(config_name_, value));
+        return;
+    case VbamOption::Type::kSoundQuality:
+        SetEnumInt(internal::StringToSoundQuality(config_name_, value));
+        return;
+
+    // We don't use default here to explicitly trigger a compiler warning when
+    // adding a new value.
+    case VbamOption::Type::kNone:
+    case VbamOption::Type::kBool:
+    case VbamOption::Type::kDouble:
+    case VbamOption::Type::kInt:
+    case VbamOption::Type::kUnsigned:
+    case VbamOption::Type::kString:
+    case VbamOption::Type::kGbPalette:
+        assert(false);
+        return;
+    }
+}
+
+void VbamOption::SetEnumInt(int value) const {
+    assert(is_filter() || is_interframe() || is_render_method() || is_audio_api() || is_sound_quality());
+    if (value < std::get<int32_t>(min_) || value > std::get<int32_t>(max_)) {
+        wxLogWarning(
+            _("Invalid value %d for option %s; valid values are %s"),
+            value,
+            config_name_,
+            internal::AllEnumValuesForType(type_));
+        return;
+    }
+    *std::get<int32_t*>(value_) = value;
+}
+
+void VbamOption::SetGbPalette(const wxString& value) const {
+    assert(is_gb_palette());
+
+    // 8 values of 4 chars and 7 commas.
+    static constexpr size_t kPaletteStringSize = 8 * 4 + 7;
+
+    if (value.size() != kPaletteStringSize) {
+        wxLogWarning(_("Invalid value %s for option %s"),
+             value,
+             config_name_);
+        return;
+    }
+    uint16_t* dest = std::get<uint16_t*>(value_);
+
+    for (size_t i = 0; i < 8; i++) {
+        wxString number = value.substr(i * 4, 4);
+        long temp = 0;
+        if (number.ToLong(&temp, 16)) {
+            dest[i] = temp;
+        }
+    }
+}
+
+wxString VbamOption::ToHelperString() const {
+    wxString helper_string = config_name_;
+
+    switch (type_) {
+    case VbamOption::Type::kNone:
+        break;
+    case VbamOption::Type::kBool:
+        helper_string.Append(" (flag)");
+        break;
+    case VbamOption::Type::kDouble:
+        helper_string.Append(" (decimal)");
+        break;
+    case VbamOption::Type::kInt:
+        helper_string.Append(" (int)");
+        break;
+    case VbamOption::Type::kUnsigned:
+        helper_string.Append(" (unsigned)");
+        break;
+    case VbamOption::Type::kString:
+        helper_string.Append(" (string)");
+        break;
+    case VbamOption::Type::kFilter:
+    case VbamOption::Type::kInterframe:
+    case VbamOption::Type::kRenderMethod:
+    case VbamOption::Type::kAudioApi:
+    case VbamOption::Type::kSoundQuality:
+        helper_string.Append(" (");
+        helper_string.Append(internal::AllEnumValuesForType(type_));
+        helper_string.Append(")");
+        break;
+    case VbamOption::Type::kGbPalette:
+        helper_string.Append(" (XXXX,XXXX,XXXX,XXXX,XXXX,XXXX,XXXX,XXXX)");
+        break;
+    }
+    helper_string.Append("\n\t");
+    helper_string.Append(ux_helper_);
+    helper_string.Append("\n");
+
+    return helper_string;
+}

--- a/src/wx/vbam-options.cpp
+++ b/src/wx/vbam-options.cpp
@@ -318,7 +318,7 @@ void VbamOption::SetGbPalette(const wxString& value) const {
     uint16_t* dest = std::get<uint16_t*>(value_);
 
     for (size_t i = 0; i < 8; i++) {
-        wxString number = value.substr(i * 4, 4);
+        wxString number = value.substr(i * 5, 4);
         long temp = 0;
         if (number.ToLong(&temp, 16)) {
             dest[i] = temp;

--- a/src/wx/vbam-options.h
+++ b/src/wx/vbam-options.h
@@ -60,8 +60,6 @@ enum class VbamOptionID {
     /// Joypad
     kJoypad,
     kJoypadAutofireThrottle,
-
-    /// Keyboard
     kJoypadDefault,
 
     /// Keyboard

--- a/src/wx/vbam-options.h
+++ b/src/wx/vbam-options.h
@@ -1,0 +1,272 @@
+#ifndef VBAM_OPTIONS_H
+#define VBAM_OPTIONS_H
+
+#include <array>
+#include <variant>
+
+#include <wx/string.h>
+
+enum class VbamOptionID {
+    // Display
+    kDisplayBilinear = 0,
+    kDisplayFilter,
+    kDisplayFilterPlugin,
+    kDisplayIFB,
+    kDisplayKeepOnTop,
+    kDisplayMaxThreads,
+    kDisplayRenderMethod,
+    kDisplayScale,
+    kDisplayStretch,
+
+    /// GB
+    kGBBiosFile,
+    kGBColorOption,
+    kGBColorizerHack,
+    kGBLCDFilter,
+    kGBGBCBiosFile,
+    kGBPalette0,
+    kGBPalette1,
+    kGBPalette2,
+    kGBPrintAutoPage,
+    kGBPrintScreenCap,
+    kGBROMDir,
+    kGBGBCROMDir,
+
+    /// GBA
+    kGBABiosFile,
+    kGBALCDFilter,
+#ifndef NO_LINK
+    kGBALinkAuto,
+    kGBALinkFast,
+    kGBALinkHost,
+    kGBAServerIP,
+    kGBALinkPort,
+    kGBALinkProto,
+    kGBALinkTimeout,
+    kGBALinkType,
+#endif
+    kGBAROMDir,
+
+    /// General
+    kGeneralAutoLoadLastState,
+    kGeneralBatteryDir,
+    kGeneralFreezeRecent,
+    kGeneralRecordingDir,
+    kGeneralRewindInterval,
+    kGeneralScreenshotDir,
+    kGeneralStateDir,
+    kGeneralStatusBar,
+
+    /// Joypad
+    kJoypad,
+    kJoypadAutofireThrottle,
+
+    /// Keyboard
+    kJoypadDefault,
+
+    /// Keyboard
+    kKeyboard,
+
+    // Core
+    kpreferencesagbPrint,
+    kpreferencesautoFrameSkip,
+    kpreferencesautoPatch,
+    kpreferencesautoSaveLoadCheatList,
+    kpreferencesborderAutomatic,
+    kpreferencesborderOn,
+    kpreferencescaptureFormat,
+    kpreferencescheatsEnabled,
+
+#ifdef MMX
+    kpreferencesenableMMX,
+#endif
+    kpreferencesdisableStatus,
+    kpreferencesemulatorType,
+    kpreferencesflashSize,
+    kpreferencesframeSkip,
+    kpreferencesfsColorDepth,
+    kpreferencesfsFrequency,
+    kpreferencesfsHeight,
+    kpreferencesfsWidth,
+    kpreferencesgbPaletteOption,
+    kpreferencesgbPrinter,
+    kpreferencesgdbBreakOnLoad,
+    kpreferencesgdbPort,
+#ifndef NO_LINK
+    kpreferencesLinkNumPlayers,
+#endif
+    kpreferencesmaxScale,
+    kpreferencespauseWhenInactive,
+    kpreferencesrtcEnabled,
+    kpreferencessaveType,
+    kpreferencesshowSpeed,
+    kpreferencesshowSpeedTransparent,
+    kpreferencesskipBios,
+    kpreferencesskipSaveGameCheats,
+    kpreferencesskipSaveGameBattery,
+    kpreferencesthrottle,
+    kpreferencesspeedupThrottle,
+    kpreferencesspeedupFrameSkip,
+    kpreferencesspeedupThrottleFrameSkip,
+    kpreferencesuseBiosGB,
+    kpreferencesuseBiosGBA,
+    kpreferencesuseBiosGBC,
+    kpreferencesvsync,
+
+    /// Geometry
+    kgeometryfullScreen,
+    kgeometryisMaximized,
+    kgeometrywindowHeight,
+    kgeometrywindowWidth,
+    kgeometrywindowX,
+    kgeometrywindowY,
+
+    /// UI
+    kuiallowKeyboardBackgroundInput,
+    kuiallowJoystickBackgroundInput,
+    kuihideMenuBar,
+
+    /// Sound
+    kSoundAudioAPI,
+    kSoundAudioDevice,
+    kSoundBuffers,
+    kSoundEnable,
+    kSoundGBAFiltering,
+    kSoundGBAInterpolation,
+    kSoundGBDeclicking,
+    kSoundGBEcho,
+    kSoundGBEnableEffects,
+    kSoundGBStereo,
+    kSoundGBSurround,
+    kSoundQuality,
+    kSoundVolume,
+
+    // Do not add anything under here.
+    Last,
+};
+
+constexpr size_t kNbOptions = static_cast<size_t>(VbamOptionID::Last);
+
+// Represents a single option saved in the INI file. VbamOption does not own the
+// individual option, but keeps a pointer to where the data is actually saved.
+//
+// Ideally, options in the UI code should only be accessed and set via this
+// class, which should also take care of updating the INI file when
+// VbamOption::Set*() is called. This should also handle keyboard and joystick
+// configuration so option parsing can be done in a uniform manner. If we ever
+// get to that point, we would be able to remove most update_opts() calls and
+// have individual UI elements access the option via
+// VbamOption::FindOptionByID().
+//
+// The implementation for this class is largely inspired by base::Value in
+// Chromium.
+// https://source.chromium.org/chromium/chromium/src/+/main:base/values.h
+class VbamOption {
+public:
+    enum class Type {
+        kNone = 0,
+        kBool,
+        kDouble,
+        kInt,
+        kUnsigned,
+        kString,
+        kFilter,
+        kInterframe,
+        kRenderMethod,
+        kAudioApi,
+        kSoundQuality,
+        kGbPalette,
+    };
+
+    static std::array<VbamOption, kNbOptions>& AllOptions();
+
+    // O(log(kNbOptions))
+    static VbamOption const* FindOptionByName(const wxString& config_name);
+
+    // O(1)
+    static VbamOption& FindOptionByID(VbamOptionID id);
+
+    ~VbamOption();
+
+    // Accessors.
+    const wxString& config_name() const { return config_name_; }
+    const wxString& command() const { return command_; }
+    const wxString& ux_helper() const { return ux_helper_; }
+
+    // Returns the type of the value stored by the current object.
+    Type type() const { return type_; }
+
+    // Returns true if the current object represents a given type.
+    bool is_none() const { return type() == Type::kNone; }
+    bool is_bool() const { return type() == Type::kBool; }
+    bool is_double() const { return type() == Type::kDouble; }
+    bool is_int() const { return type() == Type::kInt; }
+    bool is_unsigned() const { return type() == Type::kUnsigned; }
+    bool is_string() const { return type() == Type::kString; }
+    bool is_filter() const { return type() == Type::kFilter; }
+    bool is_interframe() const { return type() == Type::kInterframe; }
+    bool is_render_method() const { return type() == Type::kRenderMethod; }
+    bool is_audio_api() const { return type() == Type::kAudioApi; }
+    bool is_sound_quality() const { return type() == Type::kSoundQuality; }
+    bool is_gb_palette() const { return type() == Type::kGbPalette; }
+
+    // Returns a reference to the stored data. Will assert on type mismatch.
+    // All enum types go through GetEnumString().
+    bool GetBool() const;
+    double GetDouble() const;
+    int32_t GetInt() const;
+    uint32_t GetUnsigned() const;
+    const wxString GetString() const;
+    wxString GetEnumString() const;
+    wxString GetGbPaletteString() const;
+
+    // Sets the value. Will assert on type mismatch.
+    // All enum types go through SetEnumString() and SetEnumInt().
+    void SetBool(bool value) const;
+    void SetDouble(double value) const;
+    void SetInt(int32_t value) const;
+    void SetUnsigned(uint32_t value) const;
+    void SetString(const wxString& value) const;
+    void SetEnumString(const wxString& value) const;
+    void SetEnumInt(int value) const;
+    void SetGbPalette(const wxString& value) const;
+
+    // Command-line helper string.
+    wxString ToHelperString() const;
+
+private:
+    // Disable copy and assignment. Every individual option is unique.
+    VbamOption(const VbamOption&) = delete;
+    VbamOption& operator=(const VbamOption&) = delete;
+
+    VbamOption(VbamOptionID id);
+    VbamOption(VbamOptionID id, bool* option);
+    VbamOption(VbamOptionID id, double* option, double min, double max);
+    VbamOption(VbamOptionID id, int32_t* option, int32_t min, int32_t max);
+    VbamOption(VbamOptionID id, uint32_t* option, uint32_t min, uint32_t max);
+    VbamOption(VbamOptionID id, wxString* option);
+    VbamOption(VbamOptionID id, int* option);
+    VbamOption(VbamOptionID id, uint16_t* option);
+
+    const VbamOptionID id_;
+
+    const wxString config_name_;
+    const wxString command_;
+    const wxString ux_helper_;
+
+    const Type type_;
+    const std::variant<
+            std::monostate,
+            bool*,
+            double*,
+            int32_t*,
+            uint32_t*,
+            wxString*,
+            uint16_t*>
+        value_;
+
+    const std::variant<std::monostate, double, int32_t, uint32_t> min_;
+    const std::variant<std::monostate, double, int32_t, uint32_t> max_;
+};
+
+#endif /* VBAM_OPTIONS_H */

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -4,6 +4,7 @@
 //   create & display main frame
 
 #include "wxvbam.h"
+
 #include <stdio.h>
 #include <wx/cmdline.h>
 #include <wx/file.h>
@@ -19,14 +20,15 @@
 #include <wx/url.h>
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
-#include "wayland.h"
-#include "strutils.h"
 
 // The built-in xrc file
 #include "builtin-xrc.h"
 
 // The built-in vba-over.ini
 #include "builtin-over.h"
+#include "strutils.h"
+#include "vbam-options.h"
+#include "wayland.h"
 #include "wx/gamecontrol.h"
 #include "wx/userinput.h"
 
@@ -627,29 +629,19 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
     }
 
     if (cl.Found(wxT("o"))) {
+        // This was most likely done on a command line, so use
+        // stderr instead of gui for messages
+        wxLog::SetActiveTarget(new wxLogStderr);
+
         wxPrintf(_("Options set from the command line are saved if any"
                    " configuration changes are made in the user interface.\n\n"
                    "For flag options, true and false are specified as 1 and 0, respectively.\n\n"));
 
-        for (int i = 0; i < num_opts; i++) {
-            wxPrintf(wxT("%s (%s"), opts[i].opt.c_str(),
-                opts[i].boolopt ? wxT("flag") : opts[i].stropt ? wxT("string") : !opts[i].enumvals.empty() ? opts[i].enumvals.c_str() : (opts[i].intopt ? wxT("int") : opts[i].doubleopt ? wxT("decimal") : wxT("string")));
-
-            if (!opts[i].enumvals.empty()) {
-                const wxString evx = wxGetTranslation(opts[i].enumvals);
-
-                if (wxStrcmp(evx, opts[i].enumvals))
-                    wxPrintf(wxT(" = %s"), evx.c_str());
-            }
-
-            wxPrintf(wxT(")\n\t%s\n\n"), opts[i].desc.c_str());
-
-            if (!opts[i].enumvals.empty())
-                opts[i].enumvals = wxGetTranslation(opts[i].enumvals);
+        for (const VbamOption& opt : VbamOption::AllOptions()) {
+            wxPrintf("%s\n", opt.ToHelperString());
         }
 
         wxPrintf(_("The commands available for the Keyboard/* option are:\n\n"));
-
         for (int i = 0; i < ncmds; i++)
             wxPrintf(wxT("%s (%s)\n"), cmdtab[i].cmd.c_str(), cmdtab[i].name.c_str());
 

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -221,8 +221,8 @@ public:
     void MenuOptionIntMask(const wxString& menuName, int field, int mask);
     void MenuOptionIntRadioValue(const wxString& menuName, int field, int mask);
     void MenuOptionBool(const wxString& menuName, bool field);
-    void GetMenuOptionInt(const wxString& menuName, int field, int mask);
-    void GetMenuOptionBool(const wxString& menuName, bool field);
+    void GetMenuOptionInt(const wxString& menuName, int* field, int mask);
+    void GetMenuOptionBool(const wxString& menuName, bool* field);
     void SetMenuOption(const wxString& menuName, int value);
 
     void SetJoystick();
@@ -435,6 +435,7 @@ enum showspeed {
 };
 
 // This enum must be kept in sync with the one in vbam-options-static.cpp.
+// TODO: These 2 enums should be unified and a validator created for this enum.
 enum filtfunc {
     // this order must match order of option enum and selector widget
     FF_NONE,
@@ -471,6 +472,7 @@ enum filtfunc {
                         : x == FF_PLUGIN ? 0 : x == FF_NONE ? 1 : 2)
 
 // This enum must be kept in sync with the one in vbam-options-static.cpp.
+// TODO: These 2 enums should be unified and a validator created for this enum.
 enum ifbfunc {
     IFB_NONE,
     IFB_SMART,
@@ -478,19 +480,26 @@ enum ifbfunc {
 };
 
 // This enum must be kept in sync with the one in vbam-options-static.cpp.
+// TODO: These 2 enums should be unified and a validator created for this enum.
 enum renderer {
     RND_SIMPLE,
     RND_OPENGL,
+#if defined(__WXMSW__)
     RND_DIRECT3D,
+#elif defined(__WXMAC__)
     RND_QUARTZ2D,
+#endif
 };
 
 // This enum must be kept in sync with the one in vbam-options-static.cpp.
-enum audioapi { AUD_SDL,
+// TODO: These 2 enums should be unified and a validator created for this enum.
+enum audioapi {
+    AUD_SDL,
     AUD_OPENAL,
     AUD_DIRECTSOUND,
     AUD_XAUDIO2,
-    AUD_FAUDIO };
+    AUD_FAUDIO
+};
 
 // an unfortunate legacy default; should have a non-digit preceding %d
 // the only reason to keep it is that user can set slotdir to old dir

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -194,8 +194,8 @@ enum { CMDEN_GB = (1 << 0), // GB ROM loaded
 struct checkable_mi_t {
     int cmd;
     wxMenuItem* mi;
-    bool* boolopt;
-    int *intopt, mask, val;
+    int mask, val;
+    bool initialized = false;
 };
 
 // wxArray is only for small types
@@ -218,12 +218,12 @@ public:
     ~MainFrame();
 
     bool BindControls();
-    void MenuOptionIntMask(const char* menuName, int& field, int mask);
-    void MenuOptionIntRadioValue(const char* menuName, int& field, int mask);
-    void MenuOptionBool(const char* menuName, bool& field);
-    void GetMenuOptionInt(const char* menuName, int& field, int mask);
-    void GetMenuOptionBool(const char* menuName, bool& field);
-    void SetMenuOption(const char* menuName, int value);
+    void MenuOptionIntMask(const wxString& menuName, int field, int mask);
+    void MenuOptionIntRadioValue(const wxString& menuName, int field, int mask);
+    void MenuOptionBool(const wxString& menuName, bool field);
+    void GetMenuOptionInt(const wxString& menuName, int field, int mask);
+    void GetMenuOptionBool(const wxString& menuName, bool field);
+    void SetMenuOption(const wxString& menuName, int value);
 
     void SetJoystick();
 
@@ -434,6 +434,7 @@ enum showspeed {
     SS_DETAILED
 };
 
+// This enum must be kept in sync with the one in vbam-options-static.cpp.
 enum filtfunc {
     // this order must match order of option enum and selector widget
     FF_NONE,
@@ -469,14 +470,14 @@ enum filtfunc {
                         ? 3                                                \
                         : x == FF_PLUGIN ? 0 : x == FF_NONE ? 1 : 2)
 
+// This enum must be kept in sync with the one in vbam-options-static.cpp.
 enum ifbfunc {
-    // this order must match order of option enum and selector widget
     IFB_NONE,
     IFB_SMART,
     IFB_MOTION_BLUR
 };
 
-// make sure and keep this in sync with opts.cpp!
+// This enum must be kept in sync with the one in vbam-options-static.cpp.
 enum renderer {
     RND_SIMPLE,
     RND_OPENGL,
@@ -484,7 +485,7 @@ enum renderer {
     RND_QUARTZ2D,
 };
 
-// likewise
+// This enum must be kept in sync with the one in vbam-options-static.cpp.
 enum audioapi { AUD_SDL,
     AUD_OPENAL,
     AUD_DIRECTSOUND,


### PR DESCRIPTION
This change introduces a new class to handle all of the INI options data, VbamOption. A VbamOption represents a single option in the INI file. It is not constructible outside of its implementation, which prevents the initialization of incorrectly formatted options.

Internally, a VbamOption points to a global variable in memory, which holds the value used at runtime. This is because various parts of the codebase edit the global variable rather than going through a central registry. This also means we need to separately update the INI values.

In the future, we may be able to convert all existing reads and writes to the global variable to go through VbamOption. Individual UX elements could link directly to getters/setters for a specific VbamOption rather than have duplicate data.

VbamOption replaces the opt_desc struct and the global opts array. All users of opt_desc and the global opts array have been updated.

This is a necessary preliminary change to better support a refactor of accelerators, through wxUserInput.

Issue: #745, #158