### PR TITLE
Interframe blending changer OSD improvement

### DIFF
--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-18 14:29+0000\n"
+"POT-Creation-Date: 2022-09-21 17:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -187,7 +187,7 @@ msgstr ""
 msgid "GameShark"
 msgstr ""
 
-#: guiinit.cpp:757 cmdevents.cpp:675
+#: guiinit.cpp:757 cmdevents.cpp:678
 msgid "GameGenie"
 msgstr ""
 
@@ -262,7 +262,7 @@ msgstr ""
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: guiinit.cpp:1846 cmdevents.cpp:745 xrc/DisplayConfig.xrc:85
+#: guiinit.cpp:1846 cmdevents.cpp:748 xrc/DisplayConfig.xrc:85
 #: xrc/DisplayConfig.xrc:135 xrc/DisplayConfig.xrc:221
 #: xrc/GameBoyAdvanceConfig.xrc:32 xrc/GameBoyAdvanceConfig.xrc:204
 #: xrc/SoundConfig.xrc:219 xrc/SoundConfig.xrc:309
@@ -306,50 +306,50 @@ msgstr ""
 msgid "Main display panel not found"
 msgstr ""
 
-#: guiinit.cpp:2929
+#: guiinit.cpp:2941
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: guiinit.cpp:2943
+#: guiinit.cpp:2955
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: guiinit.cpp:3082
+#: guiinit.cpp:3094
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: guiinit.cpp:3290
+#: guiinit.cpp:3302
 msgid "Code"
 msgstr ""
 
-#: guiinit.cpp:3299
+#: guiinit.cpp:3311
 msgid "Description"
 msgstr ""
 
-#: guiinit.cpp:3373 xrc/CheatAdd.xrc:31
+#: guiinit.cpp:3385 xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: guiinit.cpp:3374
+#: guiinit.cpp:3386
 msgid "Old Value"
 msgstr ""
 
-#: guiinit.cpp:3375
+#: guiinit.cpp:3387
 msgid "New Value"
 msgstr ""
 
-#: guiinit.cpp:3902
+#: guiinit.cpp:3918
 msgid "Menu commands"
 msgstr ""
 
-#: guiinit.cpp:3925
+#: guiinit.cpp:3941
 msgid "Other commands"
 msgstr ""
 
-#: guiinit.cpp:4036
+#: guiinit.cpp:4052
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid "Text files (*.txt;*.log)|*.txt;*.log|"
 msgstr ""
 
 #: viewers.cpp:562 viewers.cpp:772 gfxviewers.cpp:1600 gfxviewers.cpp:1742
-#: cmdevents.cpp:1157 cmdevents.cpp:1235 cmdevents.cpp:1305 cmdevents.cpp:1374
+#: cmdevents.cpp:1160 cmdevents.cpp:1238 cmdevents.cpp:1308 cmdevents.cpp:1377
 #: viewsupt.cpp:1180
 msgid "Select output file"
 msgstr ""
@@ -445,11 +445,11 @@ msgid ""
 "Table (*.act)|*.act"
 msgstr ""
 
-#: gfxviewers.cpp:1601 gfxviewers.cpp:1743 cmdevents.cpp:1158 viewsupt.cpp:1181
+#: gfxviewers.cpp:1601 gfxviewers.cpp:1743 cmdevents.cpp:1161 viewsupt.cpp:1181
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: cmdevents.cpp:104
+#: cmdevents.cpp:107
 msgid ""
 "GameBoy Advance Files (*.agb;*.gba;*.bin;*.elf;*.mb;*.zip;*.7z;*.rar)|*.agb;"
 "*.gba;*.bin;*.elf;*.mb;*.agb.gz;*.gba.gz;*.bin.gz;*.elf.gz;*.mb.gz;*.agb.z;*."
@@ -459,371 +459,371 @@ msgid ""
 "*.7z;*.rar|"
 msgstr ""
 
-#: cmdevents.cpp:116
+#: cmdevents.cpp:119
 msgid "Open ROM file"
 msgstr ""
 
-#: cmdevents.cpp:133
+#: cmdevents.cpp:136
 msgid ""
 "GameBoy Files (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg;*.gb;*."
 "gbc;*.cgb;*.sgb;*.dmg.gz;*.gb.gz;*.gbc.gz;*.cgb.gz;*.sgb.gz;*.dmg.z;*.gb.z;*."
 "gbc.z;*.cgb.z;*.sgb.z;*.zip;*.7z;*.rar|"
 msgstr ""
 
-#: cmdevents.cpp:140
+#: cmdevents.cpp:143
 msgid "Open GB ROM file"
 msgstr ""
 
-#: cmdevents.cpp:157
+#: cmdevents.cpp:160
 msgid ""
 "GameBoy Color Files (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg;*."
 "gb;*.gbc;*.cgb;*.sgb;*.dmg.gz;*.gb.gz;*.gbc.gz;*.cgb.gz;*.sgb.gz;*.dmg.z;*."
 "gb.z;*.gbc.z;*.cgb.z;*.sgb.z;*.zip;*.7z;*.rar|"
 msgstr ""
 
-#: cmdevents.cpp:164
+#: cmdevents.cpp:167
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: cmdevents.cpp:583 cmdevents.cpp:699 cmdevents.cpp:738 cmdevents.cpp:811
+#: cmdevents.cpp:586 cmdevents.cpp:702 cmdevents.cpp:741 cmdevents.cpp:814
 msgid "Unknown"
 msgstr ""
 
-#: cmdevents.cpp:591
+#: cmdevents.cpp:594
 msgid "ROM"
 msgstr ""
 
-#: cmdevents.cpp:595
+#: cmdevents.cpp:598
 msgid "ROM+MBC1"
 msgstr ""
 
-#: cmdevents.cpp:599
+#: cmdevents.cpp:602
 msgid "ROM+MBC1+RAM"
 msgstr ""
 
-#: cmdevents.cpp:603
+#: cmdevents.cpp:606
 msgid "ROM+MBC1+RAM+BATT"
 msgstr ""
 
-#: cmdevents.cpp:607
+#: cmdevents.cpp:610
 msgid "ROM+MBC2"
 msgstr ""
 
-#: cmdevents.cpp:611
+#: cmdevents.cpp:614
 msgid "ROM+MBC2+BATT"
 msgstr ""
 
-#: cmdevents.cpp:615
+#: cmdevents.cpp:618
 msgid "ROM+MMM01"
 msgstr ""
 
-#: cmdevents.cpp:619
+#: cmdevents.cpp:622
 msgid "ROM+MMM01+RAM"
 msgstr ""
 
-#: cmdevents.cpp:623
+#: cmdevents.cpp:626
 msgid "ROM+MMM01+RAM+BATT"
 msgstr ""
 
-#: cmdevents.cpp:627
+#: cmdevents.cpp:630
 msgid "ROM+MBC3+TIMER+BATT"
 msgstr ""
 
-#: cmdevents.cpp:631
+#: cmdevents.cpp:634
 msgid "ROM+MBC3+TIMER+RAM+BATT"
 msgstr ""
 
-#: cmdevents.cpp:635
+#: cmdevents.cpp:638
 msgid "ROM+MBC3"
 msgstr ""
 
-#: cmdevents.cpp:639
+#: cmdevents.cpp:642
 msgid "ROM+MBC3+RAM"
 msgstr ""
 
-#: cmdevents.cpp:643
+#: cmdevents.cpp:646
 msgid "ROM+MBC3+RAM+BATT"
 msgstr ""
 
-#: cmdevents.cpp:647
+#: cmdevents.cpp:650
 msgid "ROM+MBC5"
 msgstr ""
 
-#: cmdevents.cpp:651
+#: cmdevents.cpp:654
 msgid "ROM+MBC5+RAM"
 msgstr ""
 
-#: cmdevents.cpp:655
+#: cmdevents.cpp:658
 msgid "ROM+MBC5+RAM+BATT"
 msgstr ""
 
-#: cmdevents.cpp:659
+#: cmdevents.cpp:662
 msgid "ROM+MBC5+RUMBLE"
 msgstr ""
 
-#: cmdevents.cpp:663
+#: cmdevents.cpp:666
 msgid "ROM+MBC5+RUMBLE+RAM"
 msgstr ""
 
-#: cmdevents.cpp:667
+#: cmdevents.cpp:670
 msgid "ROM+MBC5+RUMBLE+RAM+BATT"
 msgstr ""
 
-#: cmdevents.cpp:671
+#: cmdevents.cpp:674
 msgid "ROM+MBC7+BATT"
 msgstr ""
 
-#: cmdevents.cpp:679
+#: cmdevents.cpp:682
 msgid "GameShark V3.0"
 msgstr ""
 
-#: cmdevents.cpp:683
+#: cmdevents.cpp:686
 msgid "ROM+POCKET CAMERA"
 msgstr ""
 
-#: cmdevents.cpp:687
+#: cmdevents.cpp:690
 msgid "ROM+BANDAI TAMA5"
 msgstr ""
 
-#: cmdevents.cpp:691
+#: cmdevents.cpp:694
 msgid "ROM+HuC-3"
 msgstr ""
 
-#: cmdevents.cpp:695
+#: cmdevents.cpp:698
 msgid "ROM+HuC-1"
 msgstr ""
 
-#: cmdevents.cpp:847 cmdevents.cpp:869
+#: cmdevents.cpp:850 cmdevents.cpp:872
 msgid "Select Dot Code file"
 msgstr ""
 
-#: cmdevents.cpp:849 cmdevents.cpp:871
+#: cmdevents.cpp:852 cmdevents.cpp:874
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: cmdevents.cpp:890 cmdevents.cpp:1085
+#: cmdevents.cpp:893 cmdevents.cpp:1088
 msgid "Select battery file"
 msgstr ""
 
-#: cmdevents.cpp:891 cmdevents.cpp:1086
+#: cmdevents.cpp:894 cmdevents.cpp:1089
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: cmdevents.cpp:899
+#: cmdevents.cpp:902
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: cmdevents.cpp:900 cmdevents.cpp:928 cmdevents.cpp:1048
+#: cmdevents.cpp:903 cmdevents.cpp:931 cmdevents.cpp:1051
 msgid "Confirm import"
 msgstr ""
 
-#: cmdevents.cpp:906 panel.cpp:392
+#: cmdevents.cpp:909 panel.cpp:392
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: cmdevents.cpp:908
+#: cmdevents.cpp:911
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: cmdevents.cpp:917
+#: cmdevents.cpp:920
 msgid "Select code file"
 msgstr ""
 
-#: cmdevents.cpp:918
+#: cmdevents.cpp:921
 msgid "Gameshark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: cmdevents.cpp:918
+#: cmdevents.cpp:921
 msgid "Gameshark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: cmdevents.cpp:927
+#: cmdevents.cpp:930
 msgid ""
 "Importing a code file will replace any loaded cheats.  Do you want to "
 "continue?"
 msgstr ""
 
-#: cmdevents.cpp:944
+#: cmdevents.cpp:947
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: cmdevents.cpp:954
+#: cmdevents.cpp:957
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: cmdevents.cpp:1024
+#: cmdevents.cpp:1027
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: cmdevents.cpp:1026
+#: cmdevents.cpp:1029
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: cmdevents.cpp:1037 cmdevents.cpp:1113
+#: cmdevents.cpp:1040 cmdevents.cpp:1116
 msgid "Select snapshot file"
 msgstr ""
 
-#: cmdevents.cpp:1038
+#: cmdevents.cpp:1041
 msgid ""
 "GS & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|GameShark SP Snapshots (*.gsv)|"
 "*.gsv"
 msgstr ""
 
-#: cmdevents.cpp:1038
+#: cmdevents.cpp:1041
 msgid "Gameboy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: cmdevents.cpp:1047
+#: cmdevents.cpp:1050
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write).  Do you want to continue?"
 msgstr ""
 
-#: cmdevents.cpp:1072
+#: cmdevents.cpp:1075
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1074
+#: cmdevents.cpp:1077
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1097
+#: cmdevents.cpp:1100
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: cmdevents.cpp:1099 panel.cpp:701
+#: cmdevents.cpp:1102 panel.cpp:701
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: cmdevents.cpp:1107
+#: cmdevents.cpp:1110
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: cmdevents.cpp:1114
+#: cmdevents.cpp:1117
 msgid "Gameshark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: cmdevents.cpp:1128
+#: cmdevents.cpp:1131
 msgid "Exported from VisualBoyAdvance-M"
 msgstr ""
 
-#: cmdevents.cpp:1140
+#: cmdevents.cpp:1143
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1142
+#: cmdevents.cpp:1145
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1182 sys.cpp:557
+#: cmdevents.cpp:1185 sys.cpp:557
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: cmdevents.cpp:1203 cmdevents.cpp:1273 cmdevents.cpp:1344 cmdevents.cpp:1408
+#: cmdevents.cpp:1206 cmdevents.cpp:1276 cmdevents.cpp:1347 cmdevents.cpp:1411
 msgid " files ("
 msgstr ""
 
-#: cmdevents.cpp:1439
+#: cmdevents.cpp:1442
 msgid "Select file"
 msgstr ""
 
-#: cmdevents.cpp:1756 cmdevents.cpp:1849
+#: cmdevents.cpp:1759 cmdevents.cpp:1852
 msgid "Select state file"
 msgstr ""
 
-#: cmdevents.cpp:1757 cmdevents.cpp:1850
+#: cmdevents.cpp:1760 cmdevents.cpp:1853
 msgid "VisualBoyAdvance saved game files|*.sgm"
 msgstr ""
 
-#: cmdevents.cpp:1880 cmdevents.cpp:1890 cmdevents.cpp:1901
+#: cmdevents.cpp:1883 cmdevents.cpp:1893 cmdevents.cpp:1904
 #, c-format
 msgid "Current state slot #%d"
 msgstr ""
 
-#: cmdevents.cpp:1971
+#: cmdevents.cpp:1974
 msgid "Cannot use Colorizer Hack when GB BIOS File is enabled."
 msgstr ""
 
-#: cmdevents.cpp:2186
+#: cmdevents.cpp:2189
 msgid "Sound enabled"
 msgstr ""
 
-#: cmdevents.cpp:2186
+#: cmdevents.cpp:2189
 msgid "Sound disabled"
 msgstr ""
 
-#: cmdevents.cpp:2199 cmdevents.cpp:2213
+#: cmdevents.cpp:2202 cmdevents.cpp:2216
 #, c-format
 msgid "Volume: %d%%"
 msgstr ""
 
-#: cmdevents.cpp:2288
+#: cmdevents.cpp:2291
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: cmdevents.cpp:2290
+#: cmdevents.cpp:2293
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: cmdevents.cpp:2291
+#: cmdevents.cpp:2294
 msgid "GDB Connection"
 msgstr ""
 
-#: cmdevents.cpp:2344
+#: cmdevents.cpp:2347
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: cmdevents.cpp:2351
+#: cmdevents.cpp:2354
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: cmdevents.cpp:2354
+#: cmdevents.cpp:2357
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: cmdevents.cpp:2769
+#: cmdevents.cpp:2772
 #, c-format
-msgid "Using pixel filter %s"
+msgid "Using pixel filter: %s"
 msgstr ""
 
-#: cmdevents.cpp:2784
+#: cmdevents.cpp:2787
 #, c-format
-msgid "Using interframe blending #%d"
+msgid "Using interframe blending: %s"
 msgstr ""
 
-#: cmdevents.cpp:2823 panel.cpp:194 panel.cpp:308
+#: cmdevents.cpp:2826 panel.cpp:194 panel.cpp:308
 msgid "Could not initialize the sound driver!"
 msgstr ""
 
-#: cmdevents.cpp:2927
+#: cmdevents.cpp:2930
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: cmdevents.cpp:2928
+#: cmdevents.cpp:2931
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2020 VBA-M development team"
 msgstr ""
 
-#: cmdevents.cpp:2929
+#: cmdevents.cpp:2932
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -839,15 +839,15 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: cmdevents.cpp:3189
+#: cmdevents.cpp:3192
 msgid "Cannot use GB BIOS when Colorizer Hack is enabled."
 msgstr ""
 
-#: cmdevents.cpp:3249
+#: cmdevents.cpp:3252
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: cmdevents.cpp:3255
+#: cmdevents.cpp:3258
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -1749,11 +1749,11 @@ msgid "Interframe blending :"
 msgstr ""
 
 #: xrc/DisplayConfig.xrc:136
-msgid "Smart interframe blending"
+msgid "Smart"
 msgstr ""
 
 #: xrc/DisplayConfig.xrc:137
-msgid "Interframe motion blur"
+msgid "Motion Blur"
 msgstr ""
 
 #: xrc/DisplayConfig.xrc:151 xrc/SoundConfig.xrc:91

--- a/src/wx/autoupdater/wxmsw/autoupdater.cpp
+++ b/src/wx/autoupdater/wxmsw/autoupdater.cpp
@@ -7,7 +7,7 @@
 void initAutoupdater()
 {
     // even if we are a nightly, only check latest stable version
-    wxString version = str_split(vbam_version, '-')[0];
+    wxString version = strutils::split(vbam_version, '-')[0];
 #ifndef NO_HTTPS
     win_sparkle_set_appcast_url("https://data.vba-m.com/appcast.xml");
 #else

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -1,4 +1,5 @@
 #include "wxvbam.h"
+
 #include <algorithm>
 #include <wx/aboutdlg.h>
 #include <wx/ffile.h>
@@ -10,6 +11,7 @@
 #include <wx/wfstream.h>
 #include <wx/msgdlg.h>
 
+#include "strutils.h"
 #include "../common/version_cpp.h"
 #include "../gb/gbPrinter.h"
 #include "../gba/agbprint.h"
@@ -2766,7 +2768,7 @@ EVT_HANDLER_MASK(ChangeFilter, "Change Pixel Filter", CMDEN_NREC_ANY)
     }
 
     wxString msg;
-    msg.Printf(_("Using pixel filter %s"), pixel_filters->GetString(gopts.filter));
+    msg.Printf(_("Using pixel filter: %s"), pixel_filters_->GetString(gopts.filter));
     systemScreenMessage(msg);
 }
 
@@ -2781,7 +2783,7 @@ EVT_HANDLER_MASK(ChangeIFB, "Change Interframe Blending", CMDEN_NREC_ANY)
     }
 
     wxString msg;
-    msg.Printf(_("Using interframe blending #%d"), gopts.ifb);
+    msg.Printf(_("Using interframe blending: %s"), interframe_blenders_->GetString(gopts.ifb));
     systemScreenMessage(msg);
 }
 

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -3715,7 +3715,7 @@ bool MainFrame::BindControls()
             ch = GetValidatedChild<wxChoice, wxGenericValidator>(d, "Filter", wxGenericValidator(&gopts.filter));
 
             // Save the Filters choice control to extract the names from the XRC.
-            pixel_filters = ch;
+            pixel_filters_ = ch;
 
             // these two are filled and/or hidden at dialog load time
             wxControl* pll;
@@ -3731,6 +3731,10 @@ bool MainFrame::BindControls()
                 NULL, &PluginEnableHandler);
             ch = GetValidatedChild<wxChoice, wxGenericValidator>(d, "IFB", wxGenericValidator(&gopts.ifb));
             d->Fit();
+
+            // Save the interframe blender choice control to extract the names from the XRC.
+            interframe_blenders_ = ch;
+
         }
         d = LoadXRCropertySheetDialog("SoundConfig");
         wxSlider* sl;

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -631,12 +631,12 @@ void load_opts()
             cfg->Read(opt.opt, opt.stropt, *opt.stropt);
             opt.curstr = *opt.stropt;
         } else if (!opt.enumvals.empty()) {
-            auto enum_opts = str_split(opt.enumvals.MakeLower(), wxT("|"));
+            auto enum_opts = strutils::split(opt.enumvals.MakeLower(), wxT("|"));
             opt.curint     = *opt.intopt;
             bool gotit     = cfg->Read(opt.opt, &s); s.MakeLower();
 
             if (gotit && !s.empty()) {
-                const auto found_pos = vec_find(enum_opts, s);
+                const auto found_pos = enum_opts.Index(s);
                 const bool matched   = ((int)found_pos != wxNOT_FOUND);
 
                 if (!matched) {
@@ -795,7 +795,7 @@ void update_opts()
         } else if (!opt.enumvals.empty()) {
             if (*opt.intopt != opt.curint) {
                 opt.curint = *opt.intopt;
-                auto enum_opts = str_split(opt.enumvals.MakeLower(), wxT("|"));
+                auto enum_opts = strutils::split(opt.enumvals.MakeLower(), wxT("|"));
 
                 cfg->Write(opt.opt, enum_opts[opt.curint]);
             }
@@ -938,9 +938,9 @@ bool opt_set(const wxString& name, const wxString& val)
         } else if (!opt->enumvals.empty()) {
             wxString s     = val; s.MakeLower();
             wxString ev    = opt->enumvals; ev.MakeLower();
-            auto enum_opts = str_split(ev, wxT("|"));
+            auto enum_opts = strutils::split(ev, wxT("|"));
 
-            const std::size_t found_pos = vec_find(enum_opts, s);
+            const std::size_t found_pos = enum_opts.Index(s);
             const bool matched          = ((int)found_pos != wxNOT_FOUND);
 
             if (!matched) {
@@ -1016,7 +1016,7 @@ bool opt_set(const wxString& name, const wxString& val)
         if (name.Find(wxT('/')) == wxNOT_FOUND)
             return false;
 
-        auto parts = str_split(name, wxT("/"));
+        auto parts = strutils::split(name, wxT("/"));
 
         if (parts[0] != wxT("Keyboard")) {
             cmditem* cmd = std::lower_bound(&cmdtab[0], &cmdtab[ncmds], cmditem{parts[1],wxString(),0,0,NULL}, cmditem_lt);

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -129,6 +129,7 @@ const wxAcceleratorEntryUnicode default_accels[] = {
     wxAcceleratorEntryUnicode(wxMOD_CMD, WXK_F10, wxID_FILE10),
     wxAcceleratorEntryUnicode(wxMOD_CMD, wxT('0'), XRCID("VideoLayersReset")),
     wxAcceleratorEntryUnicode(wxMOD_CMD, wxT('G'), XRCID("ChangeFilter")),
+    wxAcceleratorEntryUnicode(wxMOD_CMD, wxT('I'), XRCID("ChangeIFB")),
     wxAcceleratorEntryUnicode(wxMOD_NONE, WXK_NUMPAD_ADD, XRCID("IncreaseVolume")),
     wxAcceleratorEntryUnicode(wxMOD_NONE, WXK_NUMPAD_SUBTRACT, XRCID("DecreaseVolume")),
     wxAcceleratorEntryUnicode(wxMOD_NONE, WXK_NUMPAD_ENTER, XRCID("ToggleSound"))

--- a/src/wx/strutils.cpp
+++ b/src/wx/strutils.cpp
@@ -1,10 +1,13 @@
 #include "strutils.h"
+
 #include <wx/tokenzr.h>
+
+namespace strutils {
 
 // From: https://stackoverflow.com/a/7408245/262458
 //
 // Modified to ignore empty tokens or return sep for them.
-wxArrayString str_split(const wxString& text, const wxString& sep, bool empty_token_is_sep) {
+wxArrayString split(const wxString& text, const wxString& sep, bool empty_token_is_sep) {
     wxArrayString tokens;
     size_t start = 0, end = 0;
 
@@ -29,11 +32,9 @@ wxArrayString str_split(const wxString& text, const wxString& sep, bool empty_to
     return tokens;
 }
 
-wxArrayString str_split_with_sep(const wxString& text, const wxString& sep)
+wxArrayString split_with_sep(const wxString& text, const wxString& sep)
 {
-    return str_split(text, sep, true);
+    return split(text, sep, true);
 }
 
-size_t vec_find(wxArrayString& opts, const wxString& val) {
-    return opts.Index(val);
-}
+} // namespace strutils

--- a/src/wx/strutils.h
+++ b/src/wx/strutils.h
@@ -7,15 +7,16 @@
 #include <wx/string.h>
 #include <wx/arrstr.h>
 
+namespace strutils {
+
 // From: https://stackoverflow.com/a/7408245/262458
-wxArrayString str_split(const wxString& text, const wxString& sep, bool empty_token_is_sep=false);
+wxArrayString split(const wxString& text, const wxString& sep, bool empty_token_is_sep=false);
 
 // Same as above, but it includes the sep dir.
 // If "A,,,B" is the text and "," is sep, then
 // 'A', ',' and 'B' will be in the output.
-wxArrayString str_split_with_sep(const wxString& text, const wxString& sep);
+wxArrayString split_with_sep(const wxString& text, const wxString& sep);
 
-// From: https://stackoverflow.com/a/15099743/262458
-size_t vec_find(wxArrayString& opts, const wxString& val);
+} // namespace strutils
 
 #endif

--- a/src/wx/tests/strutils.cpp
+++ b/src/wx/tests/strutils.cpp
@@ -2,96 +2,95 @@
 
 #include "tests.hpp"
 
-TEST_CASE("str_split() basic test") {
+TEST_CASE("strutils::split() basic test") {
     wxString foo = "foo|bar|baz";
 
-    auto vec = str_split(foo, '|');
+    auto vec = strutils::split(foo, '|');
 
-    REQUIRE(vec.size() == 3);
+    CHECK(vec.size() == 3);
 
-    REQUIRE(vec[0] == "foo");
-    REQUIRE(vec[1] == "bar");
-    REQUIRE(vec[2] == "baz");
+    CHECK(vec[0] == "foo");
+    CHECK(vec[1] == "bar");
+    CHECK(vec[2] == "baz");
 }
 
-TEST_CASE("str_split() multi-char separator") {
+TEST_CASE("strutils::split() multi-char separator") {
     wxString foo = "foo|-|bar|-|baz";
 
-    auto vec = str_split(foo, "|-|");
+    auto vec = strutils::split(foo, "|-|");
 
-    REQUIRE(vec.size() == 3);
+    CHECK(vec.size() == 3);
 
-    REQUIRE(vec[0] == "foo");
-    REQUIRE(vec[1] == "bar");
-    REQUIRE(vec[2] == "baz");
+    CHECK(vec[0] == "foo");
+    CHECK(vec[1] == "bar");
+    CHECK(vec[2] == "baz");
 }
 
-TEST_CASE("str_split() skips empty tokens") {
+TEST_CASE("strutils::split() skips empty tokens") {
     wxString foo = "|-|foo|-||-|bar|-|baz|-|";
 
-    auto vec = str_split(foo, "|-|");
+    auto vec = strutils::split(foo, "|-|");
 
-    REQUIRE(vec.size() == 3);
+    CHECK(vec.size() == 3);
 
-    REQUIRE(vec[0] == "foo");
-    REQUIRE(vec[1] == "bar");
-    REQUIRE(vec[2] == "baz");
+    CHECK(vec[0] == "foo");
+    CHECK(vec[1] == "bar");
+    CHECK(vec[2] == "baz");
 }
 
-TEST_CASE("str_split() empty input") {
+TEST_CASE("strutils::split() empty input") {
     wxString foo;
 
-    auto vec = str_split(foo, "|-|");
+    auto vec = strutils::split(foo, "|-|");
 
-    REQUIRE(vec.size() == 0);
+    CHECK(vec.size() == 0);
 }
 
-TEST_CASE("str_split() no tokens, just separators") {
+TEST_CASE("strutils::split() no tokens, just separators") {
     wxString foo = "|-||-||-||-||-|";
 
-    auto vec = str_split(foo, "|-|");
+    auto vec = strutils::split(foo, "|-|");
 
-    REQUIRE(vec.size() == 0);
+    CHECK(vec.size() == 0);
 }
 
-TEST_CASE("str_split_with_sep() basic test") {
+TEST_CASE("strutils::split_with_sep() basic test") {
     wxString foo = "foo|bar|baz|";
 
-    auto vec = str_split_with_sep(foo, '|');
+    auto vec = strutils::split_with_sep(foo, '|');
 
-    REQUIRE(vec.size() == 4);
+    CHECK(vec.size() == 4);
 
-    REQUIRE(vec[0] == "foo");
-    REQUIRE(vec[1] == "bar");
-    REQUIRE(vec[2] == "baz");
-    REQUIRE(vec[3] == "|");
+    CHECK(vec[0] == "foo");
+    CHECK(vec[1] == "bar");
+    CHECK(vec[2] == "baz");
+    CHECK(vec[3] == "|");
 }
 
-TEST_CASE("str_split_with_sep() multi-char sep") {
+TEST_CASE("strutils::split_with_sep() multi-char sep") {
     wxString foo = "foo|-|bar|-|baz|-|";
 
-    auto vec = str_split_with_sep(foo, "|-|");
+    auto vec = strutils::split_with_sep(foo, "|-|");
 
-    REQUIRE(vec.size() == 4);
+    CHECK(vec.size() == 4);
 
-    REQUIRE(vec[0] == "foo");
-    REQUIRE(vec[1] == "bar");
-    REQUIRE(vec[2] == "baz");
-    REQUIRE(vec[3] == "|-|");
+    CHECK(vec[0] == "foo");
+    CHECK(vec[1] == "bar");
+    CHECK(vec[2] == "baz");
+    CHECK(vec[3] == "|-|");
 }
 
-TEST_CASE("str_split_with_sep() multiple sep tokens") {
+TEST_CASE("strutils::split_with_sep() multiple sep tokens") {
     wxString foo = "|-|foo|-||-|bar|-|baz|-|";
 
-    auto vec = str_split_with_sep(foo, "|-|");
+    auto vec = strutils::split_with_sep(foo, "|-|");
 
-    REQUIRE(vec.size() == 6);
+    CHECK(vec.size() == 6);
 
-    REQUIRE(vec[0] == "|-|");
-    REQUIRE(vec[1] == "foo");
-    REQUIRE(vec[2] == "|-|");
-    REQUIRE(vec[3] == "bar");
-    REQUIRE(vec[4] == "baz");
-    REQUIRE(vec[5] == "|-|");
+    CHECK(vec[0] == "|-|");
+    CHECK(vec[1] == "foo");
+    CHECK(vec[2] == "|-|");
+    CHECK(vec[3] == "bar");
+    CHECK(vec[4] == "baz");
+    CHECK(vec[5] == "|-|");
 }
-

--- a/src/wx/widgets/gamecontrol.cpp
+++ b/src/wx/widgets/gamecontrol.cpp
@@ -135,7 +135,7 @@ nonstd::optional<wxGameControl> wxGameControl::FromString(const wxString &name) 
         return nonstd::nullopt;
     }
 
-    auto parts = str_split(name, wxT("/"));
+    auto parts = strutils::split(name, wxT("/"));
     if (parts.size() != 3) {
         wxLogDebug("Wrong split size: %d", parts.size());
         return nonstd::nullopt;

--- a/src/wx/widgets/joyedit.cpp
+++ b/src/wx/widgets/joyedit.cpp
@@ -229,7 +229,7 @@ wxAcceleratorEntry_v wxJoyKeyTextCtrl::ToAccelFromString(const wxString& s, wxCh
     if (s.size() == 0)
         return empty;
 
-    for (const auto& token : str_split_with_sep(s, sep)) {
+    for (const auto& token : strutils::split_with_sep(s, sep)) {
         if (!ParseString(token, token.size(), mod, key, joy))
             return empty;
         ret.insert(ret.begin(), wxAcceleratorEntryUnicode(token, joy, mod, key));

--- a/src/wx/widgets/keyedit.cpp
+++ b/src/wx/widgets/keyedit.cpp
@@ -204,7 +204,7 @@ static bool checkForPairKeyMod(const wxString& s, int& mod, int& key)
 {
     long ulkey, ulmod;
     // key:mod as pair
-    auto pair = str_split(s, ":");
+    auto pair = strutils::split(s, ":");
     if (pair.size() == 2 && pair[0].ToLong(&ulkey) && pair[1].ToLong(&ulmod))
     {
         key = (int)ulkey;
@@ -309,7 +309,7 @@ wxAcceleratorEntry_v wxKeyTextCtrl::FromString(const wxString& s, wxChar sep)
     wxAcceleratorEntry_v ret, empty;
     int mod, key;
 
-    for (const auto& token : str_split_with_sep(s, sep)) {
+    for (const auto& token : strutils::split_with_sep(s, sep)) {
         if (!ParseString(token, token.size(), mod, key))
             return empty;
         ret.insert(ret.begin(), wxAcceleratorEntryUnicode(mod, key));

--- a/src/wx/widgets/userinput.cpp
+++ b/src/wx/widgets/userinput.cpp
@@ -43,7 +43,7 @@ std::set<wxUserInput> wxUserInput::FromString(const wxString& string) {
         return user_inputs;
     }
 
-    for (const auto& token : str_split_with_sep(string, wxT(","))) {
+    for (const auto& token : strutils::split_with_sep(string, wxT(","))) {
         int mod, key, joy;
         if (!wxJoyKeyTextCtrl::ParseString(token, token.size(), mod, key, joy)) {
             user_inputs.clear();

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -331,7 +331,7 @@ bool wxvbamApp::OnInit()
 
     // process command-line options
     for (size_t i = 0; i < pending_optset.size(); i++) {
-        auto parts = str_split(pending_optset[i], wxT('='));
+        auto parts = strutils::split(pending_optset[i], wxT('='));
         opt_set(parts[0], parts[1]);
     }
 
@@ -680,7 +680,7 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
 
     for (int i = 0; i < nparm; i++) {
         auto p     = cl.GetParam(i);
-        auto parts = str_split(p, wxT('='));
+        auto parts = strutils::split(p, wxT('='));
 
         if (parts.size() > 1) {
             opt_set(parts[0], parts[1]);

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -382,7 +382,8 @@ private:
     // Load a named wxDialog from the XRC file
     wxDialog* LoadXRCropertySheetDialog(const char* name);
 
-    wxChoice* pixel_filters = nullptr;
+    wxChoice* pixel_filters_       = nullptr;
+    wxChoice* interframe_blenders_ = nullptr;
 
 #include "cmdhandlers.h"
 };

--- a/src/wx/xrc/DisplayConfig.xrc
+++ b/src/wx/xrc/DisplayConfig.xrc
@@ -133,8 +133,8 @@
                 <object class="wxChoice" name="IFB">
                   <content>
                     <item>None</item>
-                    <item>Smart interframe blending</item>
-                    <item>Interframe motion blur</item>
+                    <item>Smart</item>
+                    <item>Motion Blur</item>
                   </content>
                 </object>
                 <flag>wxALL|wxEXPAND</flag>


### PR DESCRIPTION
This puts the name of the interframe blending algorithm in the OSD instead of the index on activation of the `Change interframe blending` menu entry, as requested by @Squall-Leonhart.

This also sets the default accelerator for this menu entry `CTRL+I`.

I am also doing a minor refactor of my `strutils` library, @Steelskin sanity check please?