### PR TITLE
[build] Add basic clang-cl support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,12 @@ if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
+if(MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+    # TODO: We should update the XAudio headers to build with clang-cl. See
+    # https://github.com/visualboyadvance-m/visualboyadvance-m/issues/1021
+    add_definitions(-DNO_XAUDIO2)
+endif()
+
 option(ENABLE_GBA_LOGGING "Enable extended GBA logging" ON)
 if(ENABLE_GBA_LOGGING)
     add_definitions(-DGBA_LOGGING )
@@ -561,11 +567,12 @@ option(UPSTREAM_RELEASE "do some optimizations and release automation tasks" OFF
 
 include(SetCompilerLinkerFlags)
 
-if(CMAKE_C_COMPILER_ID STREQUAL Clang AND CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+if(CMAKE_C_COMPILER_ID STREQUAL Clang AND CMAKE_CXX_COMPILER_ID STREQUAL Clang AND NOT MSVC)
+    # TODO: This should also be done for clang-cl.
     include(LLVMToolchain)
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID STREQUAL Clang AND NOT MSVC)
     unset(LTO_FLAGS)
     if(ENABLE_LTO)
         if(CMAKE_COMPILER_IS_GNUCXX)

--- a/cmake/Set-Toolchain-vcpkg.cmake
+++ b/cmake/Set-Toolchain-vcpkg.cmake
@@ -290,7 +290,7 @@ function(vcpkg_set_toolchain)
         set(CMAKE_GENERATOR_PLATFORM x64 CACHE STRING "visual studio build architecture" FORCE)
     endif()
 
-    if(WIN32 AND NOT CMAKE_GENERATOR MATCHES "Visual Studio")
+    if(WIN32 AND NOT CMAKE_GENERATOR MATCHES "Visual Studio" AND NOT DEFINED CMAKE_CXX_COMPILER)
         if(VCPKG_TARGET_TRIPLET MATCHES "^x[68][46]-windows-")
             # set toolchain to VS for e.g. Ninja or jom
             set(CMAKE_C_COMPILER   cl CACHE STRING "Microsoft C/C++ Compiler" FORCE)

--- a/cmake/SetCompilerLinkerFlags.cmake
+++ b/cmake/SetCompilerLinkerFlags.cmake
@@ -27,7 +27,7 @@ endfunction()
 function(add_linker_flags)
     # Set linker flags if not already set.
     foreach(flag ${ARGV})
-        foreach(var EXE SHARED MODULE STATIC)
+        foreach(var EXE SHARED)
             set(var "CMAKE_${var}_LINKER_FLAGS")
 
             # Remove any duplicates first.

--- a/fex/7z_C/CpuArch.c
+++ b/fex/7z_C/CpuArch.c
@@ -5,7 +5,7 @@
 
 #ifdef MY_CPU_X86_OR_AMD64
 
-#if (defined(_MSC_VER) && !defined(MY_CPU_AMD64)) || defined(__GNUC__)
+#if (defined(_MSC_VER) && !defined(MY_CPU_AMD64)) || defined(__GNUC__) || defined(__clang__)
 #define USE_ASM
 #endif
 


### PR DESCRIPTION
XAudio2 is disabled because the included header needs to be updated to be parseable by clang.