### PR TITLE
Fix prototype for main

### DIFF
--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -76,7 +76,7 @@ int WinMain(HINSTANCE hInstance,
 
 #else  // __WXMSW__
 
-int main(int argc, char* argv) {
+int main(int argc, char** argv) {
     // Set up logging.
 #ifdef DEBUG
     wxLog::SetLogLevel(wxLOG_Trace);


### PR DESCRIPTION
A typo in 297d7c06c47015c7da3f98baef11f302cc1206f7 meant main had the wrong prototype on non-Windows systems, breaking the build.