### PR TITLE
[config] Add Observers for Options

### DIFF
--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-21 19:17+0000\n"
+"POT-Creation-Date: 2022-10-21 17:50-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,241 +115,217 @@ msgstr ""
 msgid "Bad configuration option or multiple ROM files given:\n"
 msgstr ""
 
-#: guiinit.cpp:84
+#: guiinit.cpp:85
 msgid "Start!"
 msgstr ""
 
-#: guiinit.cpp:103 xrc/NetLink.xrc:99
+#: guiinit.cpp:104 xrc/NetLink.xrc:99
 msgid "Connect"
 msgstr ""
 
-#: guiinit.cpp:120
+#: guiinit.cpp:121
 msgid "You must enter a valid host name"
 msgstr ""
 
-#: guiinit.cpp:121
+#: guiinit.cpp:122
 msgid "Host name invalid"
 msgstr ""
 
-#: guiinit.cpp:139
+#: guiinit.cpp:140
 msgid "Waiting for clients..."
 msgstr ""
 
-#: guiinit.cpp:140
+#: guiinit.cpp:141
 #, c-format
 msgid "Server IP address is: %s\n"
 msgstr ""
 
-#: guiinit.cpp:142
+#: guiinit.cpp:143
 msgid "Waiting for connection..."
 msgstr ""
 
-#: guiinit.cpp:143
+#: guiinit.cpp:144
 #, c-format
 msgid "Connecting to %s\n"
 msgstr ""
 
-#: guiinit.cpp:176
+#: guiinit.cpp:177
 msgid ""
 "Error occurred.\n"
 "Please try again."
 msgstr ""
 
-#: guiinit.cpp:243 guiinit.cpp:296
+#: guiinit.cpp:244 guiinit.cpp:297
 msgid "Select cheat file"
 msgstr ""
 
-#: guiinit.cpp:244
+#: guiinit.cpp:245
 msgid "VBA cheat lists (*.clt)|*.clt|CHT cheat lists (*.cht)|*.cht"
 msgstr ""
 
-#: guiinit.cpp:263 panel.cpp:453
+#: guiinit.cpp:264 panel.cpp:510
 msgid "Loaded cheats"
 msgstr ""
 
-#: guiinit.cpp:297
+#: guiinit.cpp:298
 msgid "VBA cheat lists (*.clt)|*.clt"
 msgstr ""
 
-#: guiinit.cpp:315
+#: guiinit.cpp:316
 msgid "Saved cheats"
 msgstr ""
 
-#: guiinit.cpp:346 guiinit.cpp:365
+#: guiinit.cpp:347 guiinit.cpp:366
 msgid "Restore old values?"
 msgstr ""
 
-#: guiinit.cpp:347 guiinit.cpp:366
+#: guiinit.cpp:348 guiinit.cpp:367
 msgid "Removing cheats"
 msgstr ""
 
-#: guiinit.cpp:757 xrc/JoyPanel.xrc:364
+#: guiinit.cpp:758 xrc/JoyPanel.xrc:364
 msgid "GameShark"
 msgstr ""
 
-#: guiinit.cpp:758 cmdevents.cpp:679
+#: guiinit.cpp:759 cmdevents.cpp:679
 msgid "GameGenie"
 msgstr ""
 
-#: guiinit.cpp:760
+#: guiinit.cpp:761
 msgid "Generic Code"
 msgstr ""
 
-#: guiinit.cpp:761
+#: guiinit.cpp:762
 msgid "GameShark Advance"
 msgstr ""
 
-#: guiinit.cpp:762
+#: guiinit.cpp:763
 msgid "CodeBreaker Advance"
 msgstr ""
 
-#: guiinit.cpp:763
+#: guiinit.cpp:764
 msgid "Flashcart CHT"
 msgstr ""
 
-#: guiinit.cpp:831 guiinit.cpp:1086
+#: guiinit.cpp:832 guiinit.cpp:1087
 msgid "Number cannot be empty"
 msgstr ""
 
-#: guiinit.cpp:869
+#: guiinit.cpp:870
 #, c-format
 msgid "Search produced %d results.  Please refine better"
 msgstr ""
 
-#: guiinit.cpp:881
+#: guiinit.cpp:882
 msgid "Search produced no results"
 msgstr ""
 
-#: guiinit.cpp:1044
+#: guiinit.cpp:1045
 msgid "8-bit "
 msgstr ""
 
-#: guiinit.cpp:1048
+#: guiinit.cpp:1049
 msgid "16-bit "
 msgstr ""
 
-#: guiinit.cpp:1052
+#: guiinit.cpp:1053
 msgid "32-bit "
 msgstr ""
 
-#: guiinit.cpp:1058
+#: guiinit.cpp:1059
 msgid "signed decimal"
 msgstr ""
 
-#: guiinit.cpp:1062
+#: guiinit.cpp:1063
 msgid "unsigned decimal"
 msgstr ""
 
-#: guiinit.cpp:1066
+#: guiinit.cpp:1067
 msgid "unsigned hexadecimal"
 msgstr ""
 
-#: guiinit.cpp:1544
+#: guiinit.cpp:1545
 #, c-format
 msgid "%d frames = %.2f ms"
 msgstr ""
 
-#: guiinit.cpp:1556
+#: guiinit.cpp:1557
 msgid "Default device"
 msgstr ""
 
-#: guiinit.cpp:1726
+#: guiinit.cpp:1727
 msgid "Desktop mode"
 msgstr ""
 
-#: guiinit.cpp:1733
+#: guiinit.cpp:1734
 #, c-format
 msgid "%d x %d - %dbpp @ %dHz"
 msgstr ""
 
-#: guiinit.cpp:1846 cmdevents.cpp:749 xrc/DisplayConfig.xrc:85
-#: xrc/DisplayConfig.xrc:135 xrc/DisplayConfig.xrc:221
-#: xrc/GameBoyAdvanceConfig.xrc:32 xrc/GameBoyAdvanceConfig.xrc:204
-#: xrc/SoundConfig.xrc:219 xrc/SoundConfig.xrc:309
-msgid "None"
-msgstr ""
-
-#: guiinit.cpp:1887
-#, c-format
-msgid "No usable rpi plugins found in %s"
-msgstr ""
-
-#: guiinit.cpp:1907 xrc/DisplayConfig.xrc:107
-msgid "Plugin"
-msgstr ""
-
-#: guiinit.cpp:1935
-msgid "Please select a plugin or a different filter"
-msgstr ""
-
-#: guiinit.cpp:1936
-msgid "Plugin selection error"
-msgstr ""
-
-#: guiinit.cpp:2149
+#: guiinit.cpp:1976
 msgid "This will clear all user-defined accelerators.  Are you sure?"
 msgstr ""
 
-#: guiinit.cpp:2149
+#: guiinit.cpp:1976
 msgid "Confirm"
 msgstr ""
 
-#: guiinit.cpp:2740
+#: guiinit.cpp:2567
 msgid "Main icon not found"
 msgstr ""
 
-#: guiinit.cpp:2750
+#: guiinit.cpp:2577
 msgid "Browse"
 msgstr ""
 
-#: guiinit.cpp:2764
+#: guiinit.cpp:2591
 msgid "Main display panel not found"
 msgstr ""
 
-#: guiinit.cpp:2941
+#: guiinit.cpp:2768
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: guiinit.cpp:2955
+#: guiinit.cpp:2782
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s ; keeping menu"
 msgstr ""
 
-#: guiinit.cpp:3096
+#: guiinit.cpp:2922
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: guiinit.cpp:3304
+#: guiinit.cpp:3125
 msgid "Code"
 msgstr ""
 
-#: guiinit.cpp:3313
+#: guiinit.cpp:3134
 msgid "Description"
 msgstr ""
 
-#: guiinit.cpp:3387 xrc/CheatAdd.xrc:31
+#: guiinit.cpp:3208 xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: guiinit.cpp:3388
+#: guiinit.cpp:3209
 msgid "Old Value"
 msgstr ""
 
-#: guiinit.cpp:3389
+#: guiinit.cpp:3210
 msgid "New Value"
 msgstr ""
 
-#: guiinit.cpp:3925
+#: guiinit.cpp:3682
 msgid "Menu commands"
 msgstr ""
 
-#: guiinit.cpp:3948
+#: guiinit.cpp:3705
 msgid "Other commands"
 msgstr ""
 
-#: guiinit.cpp:4059
+#: guiinit.cpp:3816
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -593,6 +569,13 @@ msgstr ""
 msgid "ROM+HuC-1"
 msgstr ""
 
+#: cmdevents.cpp:749 dialogs/display-config.cpp:338 xrc/DisplayConfig.xrc:85
+#: xrc/DisplayConfig.xrc:135 xrc/DisplayConfig.xrc:221
+#: xrc/GameBoyAdvanceConfig.xrc:32 xrc/GameBoyAdvanceConfig.xrc:204
+#: xrc/SoundConfig.xrc:219 xrc/SoundConfig.xrc:309
+msgid "None"
+msgstr ""
+
 #: cmdevents.cpp:851 cmdevents.cpp:873
 msgid "Select Dot Code file"
 msgstr ""
@@ -619,7 +602,7 @@ msgstr ""
 msgid "Confirm import"
 msgstr ""
 
-#: cmdevents.cpp:910 panel.cpp:396
+#: cmdevents.cpp:910 panel.cpp:453
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
@@ -702,7 +685,7 @@ msgstr ""
 msgid "Wrote battery %s"
 msgstr ""
 
-#: cmdevents.cpp:1103 panel.cpp:705
+#: cmdevents.cpp:1103 panel.cpp:762
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
@@ -798,32 +781,22 @@ msgstr ""
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: cmdevents.cpp:2773
-#, c-format
-msgid "Using pixel filter: %s"
-msgstr ""
-
-#: cmdevents.cpp:2788
-#, c-format
-msgid "Using interframe blending: %s"
-msgstr ""
-
-#: cmdevents.cpp:2827 panel.cpp:198 panel.cpp:312
+#: cmdevents.cpp:2802 panel.cpp:255 panel.cpp:369
 msgid "Could not initialize the sound driver!"
 msgstr ""
 
-#: cmdevents.cpp:2931
+#: cmdevents.cpp:2906
 msgid "Nintendo GameBoy (+Color+Advance) emulator."
 msgstr ""
 
-#: cmdevents.cpp:2932
+#: cmdevents.cpp:2907
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2020 VBA-M development team"
 msgstr ""
 
-#: cmdevents.cpp:2933
+#: cmdevents.cpp:2908
 msgid ""
 "This program is free software: you can redistribute it and/or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -839,29 +812,29 @@ msgid ""
 "along with this program.  If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: cmdevents.cpp:3193
+#: cmdevents.cpp:3168
 msgid "Cannot use GB BIOS when Colorizer Hack is enabled."
 msgstr ""
 
-#: cmdevents.cpp:3253
+#: cmdevents.cpp:3233
 msgid "LAN link is already active.  Disable link mode to disconnect."
 msgstr ""
 
-#: cmdevents.cpp:3259
+#: cmdevents.cpp:3239
 msgid "Network is not supported in local mode."
 msgstr ""
 
-#: opts.cpp:494 opts.cpp:515 opts.cpp:747
+#: opts.cpp:542 opts.cpp:563 opts.cpp:768
 #, c-format
 msgid "Invalid key binding %s for %s"
 msgstr ""
 
-#: opts.cpp:670 opts.cpp:679 opts.cpp:688 opts.cpp:697 config/option.cpp:334
+#: opts.cpp:691 opts.cpp:700 opts.cpp:709 opts.cpp:718 config/option.cpp:477
 #, c-format
 msgid "Invalid value %s for option %s"
 msgstr ""
 
-#: opts.cpp:769
+#: opts.cpp:790
 #, c-format
 msgid "Unknown option %s with value %s"
 msgstr ""
@@ -941,177 +914,177 @@ msgstr ""
 msgid "Error setting up server socket (%d)"
 msgstr ""
 
-#: panel.cpp:112
+#: panel.cpp:169
 #, c-format
 msgid "%s is not a valid ROM file"
 msgstr ""
 
-#: panel.cpp:113 panel.cpp:174 panel.cpp:250
+#: panel.cpp:170 panel.cpp:231 panel.cpp:307
 msgid "Problem loading file"
 msgstr ""
 
-#: panel.cpp:173
+#: panel.cpp:230
 #, c-format
 msgid "Unable to load Game Boy ROM %s"
 msgstr ""
 
-#: panel.cpp:210
+#: panel.cpp:267
 msgid ""
 "Cannot use GB BIOS file when Colorizer Hack is enabled, disabling GB BIOS "
 "file."
 msgstr ""
 
-#: panel.cpp:226 panel.cpp:326
+#: panel.cpp:283 panel.cpp:383
 #, c-format
 msgid "Could not load BIOS %s"
 msgstr ""
 
-#: panel.cpp:249
+#: panel.cpp:306
 #, c-format
 msgid "Unable to load Game Boy Advance ROM %s"
 msgstr ""
 
-#: panel.cpp:485
+#: panel.cpp:542
 msgid " player "
 msgstr ""
 
-#: panel.cpp:653
+#: panel.cpp:710
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: panel.cpp:653
+#: panel.cpp:710
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: panel.cpp:677
+#: panel.cpp:734
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: panel.cpp:677
+#: panel.cpp:734
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: panel.cpp:882
+#: panel.cpp:944
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported; looking for another"
 msgstr ""
 
-#: panel.cpp:920
+#: panel.cpp:982
 #, c-format
 msgid "Fullscreen mode %dx%d-%d@%d not supported"
 msgstr ""
 
-#: panel.cpp:925
+#: panel.cpp:987
 #, c-format
 msgid "Valid mode: %dx%d-%d@%d"
 msgstr ""
 
-#: panel.cpp:933
+#: panel.cpp:995
 #, c-format
 msgid "Chose mode %dx%d-%d@%d"
 msgstr ""
 
-#: panel.cpp:937
+#: panel.cpp:999
 #, c-format
 msgid "Failed to change mode to %dx%d-%d@%d"
 msgstr ""
 
-#: panel.cpp:1025
+#: panel.cpp:1087
 msgid "Not a valid GBA cartridge"
 msgstr ""
 
-#: panel.cpp:1189
+#: panel.cpp:1255
 msgid "No memory for rewinding"
 msgstr ""
 
-#: panel.cpp:1199
+#: panel.cpp:1265
 msgid "Error writing rewind state"
 msgstr ""
 
-#: panel.cpp:2186
+#: panel.cpp:2285
 msgid "Enabling EGL VSync."
 msgstr ""
 
-#: panel.cpp:2188
+#: panel.cpp:2287
 msgid "Disabling EGL VSync."
 msgstr ""
 
-#: panel.cpp:2195
+#: panel.cpp:2294
 msgid "Enabling GLX VSync."
 msgstr ""
 
-#: panel.cpp:2197
+#: panel.cpp:2296
 msgid "Disabling GLX VSync."
 msgstr ""
 
-#: panel.cpp:2215
+#: panel.cpp:2314
 msgid "Failed to set glXSwapIntervalEXT"
 msgstr ""
 
-#: panel.cpp:2224
+#: panel.cpp:2323
 msgid "Failed to set glXSwapIntervalSGI"
 msgstr ""
 
-#: panel.cpp:2233
+#: panel.cpp:2332
 msgid "Failed to set glXSwapIntervalMESA"
 msgstr ""
 
-#: panel.cpp:2240
+#: panel.cpp:2339
 msgid "No support for wglGetExtensionsStringEXT"
 msgstr ""
 
-#: panel.cpp:2243
+#: panel.cpp:2342
 msgid "No support for WGL_EXT_swap_control"
 msgstr ""
 
-#: panel.cpp:2252
+#: panel.cpp:2351
 msgid "Failed to set wglSwapIntervalEXT"
 msgstr ""
 
-#: panel.cpp:2258
+#: panel.cpp:2357
 msgid "No VSYNC available on this platform"
 msgstr ""
 
-#: panel.cpp:2354
+#: panel.cpp:2453
 msgid "memory allocation error"
 msgstr ""
 
-#: panel.cpp:2357
+#: panel.cpp:2456
 msgid "error initializing codec"
 msgstr ""
 
-#: panel.cpp:2360
+#: panel.cpp:2459
 msgid "error writing to output file"
 msgstr ""
 
-#: panel.cpp:2363
+#: panel.cpp:2462
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: panel.cpp:2368
+#: panel.cpp:2467
 msgid "programming error; aborting!"
 msgstr ""
 
-#: panel.cpp:2380 panel.cpp:2409
+#: panel.cpp:2479 panel.cpp:2508
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: panel.cpp:2437
+#: panel.cpp:2536
 #, c-format
 msgid "Error in audio/video recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2443
+#: panel.cpp:2542
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2453
+#: panel.cpp:2552
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -1128,170 +1101,170 @@ msgstr ""
 msgid "B:"
 msgstr ""
 
-#: config/internal/option-internal.cpp:367
+#: config/internal/option-internal.cpp:320
 msgid "Use bilinear filter with 3d renderer"
 msgstr ""
 
-#: config/internal/option-internal.cpp:368
+#: config/internal/option-internal.cpp:321
 msgid "Full-screen filter to apply"
 msgstr ""
 
-#: config/internal/option-internal.cpp:370
+#: config/internal/option-internal.cpp:323
 msgid "Filter plugin library"
 msgstr ""
 
-#: config/internal/option-internal.cpp:372
+#: config/internal/option-internal.cpp:325
 msgid "Interframe blending function"
 msgstr ""
 
-#: config/internal/option-internal.cpp:374
+#: config/internal/option-internal.cpp:327
 msgid "Keep window on top"
 msgstr ""
 
-#: config/internal/option-internal.cpp:377
+#: config/internal/option-internal.cpp:330
 msgid "Maximum number of threads to run filters in"
 msgstr ""
 
-#: config/internal/option-internal.cpp:380
+#: config/internal/option-internal.cpp:333
 msgid "Render method; if unsupported, simple method will be used"
 msgstr ""
 
-#: config/internal/option-internal.cpp:382
+#: config/internal/option-internal.cpp:335
 msgid "Default scale factor"
 msgstr ""
 
-#: config/internal/option-internal.cpp:385
+#: config/internal/option-internal.cpp:338
 msgid "Retain aspect ratio when resizing"
 msgstr ""
 
-#: config/internal/option-internal.cpp:388
+#: config/internal/option-internal.cpp:341
 msgid "BIOS file to use for GB, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:391
+#: config/internal/option-internal.cpp:344
 msgid "GB color enhancement, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:393
+#: config/internal/option-internal.cpp:346
 msgid "Enable DX Colorization Hacks"
 msgstr ""
 
-#: config/internal/option-internal.cpp:394
-#: config/internal/option-internal.cpp:426
+#: config/internal/option-internal.cpp:347
+#: config/internal/option-internal.cpp:379
 msgid "Apply LCD filter, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:396
+#: config/internal/option-internal.cpp:349
 msgid "BIOS file to use for GBC, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:399
+#: config/internal/option-internal.cpp:352
 msgid ""
 "The default palette, as 8 comma-separated 4-digit hex integers (rgb555)."
 msgstr ""
 
-#: config/internal/option-internal.cpp:403
+#: config/internal/option-internal.cpp:356
 msgid ""
 "The first user palette, as 8 comma-separated 4-digit hex integers (rgb555)."
 msgstr ""
 
-#: config/internal/option-internal.cpp:407
+#: config/internal/option-internal.cpp:360
 msgid ""
 "The second user palette, as 8 comma-separated 4-digit hex integers (rgb555)."
 msgstr ""
 
-#: config/internal/option-internal.cpp:411
+#: config/internal/option-internal.cpp:364
 msgid "Automatically gather a full page before printing"
 msgstr ""
 
-#: config/internal/option-internal.cpp:415
+#: config/internal/option-internal.cpp:368
 msgid "Automatically save printouts as screen captures with -print suffix"
 msgstr ""
 
-#: config/internal/option-internal.cpp:417
-#: config/internal/option-internal.cpp:447
+#: config/internal/option-internal.cpp:370
+#: config/internal/option-internal.cpp:400
 msgid "Directory to look for ROM files"
 msgstr ""
 
-#: config/internal/option-internal.cpp:419
+#: config/internal/option-internal.cpp:372
 msgid "Directory to look for GBC ROM files"
 msgstr ""
 
-#: config/internal/option-internal.cpp:423
+#: config/internal/option-internal.cpp:376
 msgid "BIOS file to use, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:428
+#: config/internal/option-internal.cpp:381
 msgid "Enable link at boot"
 msgstr ""
 
-#: config/internal/option-internal.cpp:431
+#: config/internal/option-internal.cpp:384
 msgid "Enable faster network protocol by default"
 msgstr ""
 
-#: config/internal/option-internal.cpp:433
+#: config/internal/option-internal.cpp:386
 msgid "Default network link client host"
 msgstr ""
 
-#: config/internal/option-internal.cpp:435
+#: config/internal/option-internal.cpp:388
 msgid "Default network link server IP to bind"
 msgstr ""
 
-#: config/internal/option-internal.cpp:438
+#: config/internal/option-internal.cpp:391
 msgid "Default network link port (server and client)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:440
+#: config/internal/option-internal.cpp:393
 msgid "Default network protocol"
 msgstr ""
 
-#: config/internal/option-internal.cpp:442
+#: config/internal/option-internal.cpp:395
 msgid "Link timeout (ms)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:444
+#: config/internal/option-internal.cpp:397
 msgid "Link cable type"
 msgstr ""
 
-#: config/internal/option-internal.cpp:452
+#: config/internal/option-internal.cpp:405
 msgid "Automatically load last saved state"
 msgstr ""
 
-#: config/internal/option-internal.cpp:454
+#: config/internal/option-internal.cpp:407
 msgid ""
 "Directory to store game save files (relative paths are relative to ROM; "
 "blank is config dir)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:457
+#: config/internal/option-internal.cpp:410
 msgid "Freeze recent load list"
 msgstr ""
 
-#: config/internal/option-internal.cpp:460
+#: config/internal/option-internal.cpp:413
 msgid ""
 "Directory to store A/V and game recordings (relative paths are relative to "
 "ROM)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:464
+#: config/internal/option-internal.cpp:417
 msgid "Number of seconds between rewind snapshots (0 to disable)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:467
+#: config/internal/option-internal.cpp:420
 msgid "Directory to store screenshots (relative paths are relative to ROM)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:471
+#: config/internal/option-internal.cpp:424
 msgid ""
 "Directory to store saved state files (relative paths are relative to "
 "BatteryDir)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:474
+#: config/internal/option-internal.cpp:427
 msgid "Enable status bar"
 msgstr ""
 
-#: config/internal/option-internal.cpp:479
+#: config/internal/option-internal.cpp:432
 msgid ""
 "The parameter Joypad/<n>/<button> contains a comma-separated list of key "
 "names which map to joypad #<n> button <button>.  Button is one of Up, Down, "
@@ -1299,287 +1272,306 @@ msgid ""
 "MotionRight, AutoA, AutoB, Speed, Capture, GS"
 msgstr ""
 
-#: config/internal/option-internal.cpp:486
+#: config/internal/option-internal.cpp:439
 msgid "The autofire toggle period, in frames (1/60 s)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:489
+#: config/internal/option-internal.cpp:442
 msgid "The number of the stick to use in single-player mode"
 msgstr ""
 
-#: config/internal/option-internal.cpp:494
+#: config/internal/option-internal.cpp:447
 msgid ""
 "The parameter Keyboard/<cmd> contains a comma-separated list of key names (e."
 "g. Alt-Shift-F1).  When the named key is pressed, the command <cmd> is "
 "executed."
 msgstr ""
 
-#: config/internal/option-internal.cpp:501
+#: config/internal/option-internal.cpp:454
 msgid "Enable AGB debug print"
 msgstr ""
 
-#: config/internal/option-internal.cpp:503
+#: config/internal/option-internal.cpp:456
 msgid "Auto skip frames."
 msgstr ""
 
-#: config/internal/option-internal.cpp:505
+#: config/internal/option-internal.cpp:458
 msgid "Apply IPS/UPS/IPF patches if found"
 msgstr ""
 
-#: config/internal/option-internal.cpp:507
+#: config/internal/option-internal.cpp:460
 msgid "Automatically save and load cheat list"
 msgstr ""
 
-#: config/internal/option-internal.cpp:510
+#: config/internal/option-internal.cpp:463
 msgid "Automatically enable border for Super GameBoy games"
 msgstr ""
 
-#: config/internal/option-internal.cpp:512
+#: config/internal/option-internal.cpp:465
 msgid "Always enable border"
 msgstr ""
 
-#: config/internal/option-internal.cpp:514
+#: config/internal/option-internal.cpp:467
 msgid "Screen capture file format"
 msgstr ""
 
-#: config/internal/option-internal.cpp:516
+#: config/internal/option-internal.cpp:469
 msgid "Enable cheats"
 msgstr ""
 
-#: config/internal/option-internal.cpp:519 xrc/MainMenu.xrc:355
+#: config/internal/option-internal.cpp:472 xrc/MainMenu.xrc:355
 msgid "Enable MMX"
 msgstr ""
 
-#: config/internal/option-internal.cpp:523
+#: config/internal/option-internal.cpp:476
 msgid "Disable on-screen status messages"
 msgstr ""
 
-#: config/internal/option-internal.cpp:524
+#: config/internal/option-internal.cpp:477
 msgid "Type of system to emulate"
 msgstr ""
 
-#: config/internal/option-internal.cpp:526
+#: config/internal/option-internal.cpp:479
 msgid "Flash size 0 = 64KB 1 = 128KB"
 msgstr ""
 
-#: config/internal/option-internal.cpp:529
+#: config/internal/option-internal.cpp:482
 msgid "Skip frames.  Values are 0-9 or -1 to skip automatically based on time."
 msgstr ""
 
-#: config/internal/option-internal.cpp:533
+#: config/internal/option-internal.cpp:486
 msgid "Fullscreen mode color depth (0 = any)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:535
+#: config/internal/option-internal.cpp:488
 msgid "Fullscreen mode frequency (0 = any)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:537
+#: config/internal/option-internal.cpp:490
 msgid "Fullscreen mode height (0 = desktop)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:539
+#: config/internal/option-internal.cpp:492
 msgid "Fullscreen mode width (0 = desktop)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:540
+#: config/internal/option-internal.cpp:493
 msgid "The palette to use"
 msgstr ""
 
-#: config/internal/option-internal.cpp:543
+#: config/internal/option-internal.cpp:496
 msgid "Enable printer emulation"
 msgstr ""
 
-#: config/internal/option-internal.cpp:545
+#: config/internal/option-internal.cpp:498
 msgid "Break into GDB after loading the game."
 msgstr ""
 
-#: config/internal/option-internal.cpp:547
+#: config/internal/option-internal.cpp:500
 msgid "Port to connect GDB to."
 msgstr ""
 
-#: config/internal/option-internal.cpp:550
+#: config/internal/option-internal.cpp:503
 msgid "Number of players in network"
 msgstr ""
 
-#: config/internal/option-internal.cpp:553
+#: config/internal/option-internal.cpp:506
 msgid "Maximum scale factor (0 = no limit)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:555
+#: config/internal/option-internal.cpp:508
 msgid "Pause game when main window loses focus"
 msgstr ""
 
-#: config/internal/option-internal.cpp:558
+#: config/internal/option-internal.cpp:511
 msgid "Enable RTC (vba-over.ini override is rtcEnabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:561
+#: config/internal/option-internal.cpp:514
 msgid "Native save (\"battery\") hardware type"
 msgstr ""
 
-#: config/internal/option-internal.cpp:563
+#: config/internal/option-internal.cpp:516
 msgid "Show speed indicator"
 msgstr ""
 
-#: config/internal/option-internal.cpp:566
+#: config/internal/option-internal.cpp:519
 msgid "Draw on-screen messages transparently"
 msgstr ""
 
-#: config/internal/option-internal.cpp:568
+#: config/internal/option-internal.cpp:521
 msgid "Skip BIOS initialization"
 msgstr ""
 
-#: config/internal/option-internal.cpp:570
+#: config/internal/option-internal.cpp:523
 msgid "Do not overwrite cheat list when loading state"
 msgstr ""
 
-#: config/internal/option-internal.cpp:573
+#: config/internal/option-internal.cpp:526
 msgid "Do not overwrite native (battery) save when loading state"
 msgstr ""
 
-#: config/internal/option-internal.cpp:576
+#: config/internal/option-internal.cpp:529
 msgid "Throttle game speed, even when accelerated (0-450%, 0 = no throttle)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:580
+#: config/internal/option-internal.cpp:533
 msgid "Set throttle for speedup key (0-3000%, 0 = no throttle)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:583
+#: config/internal/option-internal.cpp:536
 msgid "Number of frames to skip with speedup (instead of speedup throttle)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:587
+#: config/internal/option-internal.cpp:540
 msgid "Use frame skip for speedup throttle"
 msgstr ""
 
-#: config/internal/option-internal.cpp:589
+#: config/internal/option-internal.cpp:542
 msgid "Use the specified BIOS file for GB"
 msgstr ""
 
-#: config/internal/option-internal.cpp:591
+#: config/internal/option-internal.cpp:544
 msgid "Use the specified BIOS file"
 msgstr ""
 
-#: config/internal/option-internal.cpp:593
+#: config/internal/option-internal.cpp:546
 msgid "Use the specified BIOS file for GBC"
 msgstr ""
 
-#: config/internal/option-internal.cpp:594
+#: config/internal/option-internal.cpp:547
 msgid "Wait for vertical sync"
 msgstr ""
 
-#: config/internal/option-internal.cpp:599
+#: config/internal/option-internal.cpp:552
 msgid "Enter fullscreen mode at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:600
+#: config/internal/option-internal.cpp:553
 msgid "Window maximized"
 msgstr ""
 
-#: config/internal/option-internal.cpp:602
+#: config/internal/option-internal.cpp:555
 msgid "Window height at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:604
+#: config/internal/option-internal.cpp:557
 msgid "Window width at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:606
+#: config/internal/option-internal.cpp:559
 msgid "Window axis X position at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:608
+#: config/internal/option-internal.cpp:561
 msgid "Window axis Y position at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:614
+#: config/internal/option-internal.cpp:567
 msgid "Capture key events while on background"
 msgstr ""
 
-#: config/internal/option-internal.cpp:617
+#: config/internal/option-internal.cpp:570
 msgid "Capture joy events while on background"
 msgstr ""
 
-#: config/internal/option-internal.cpp:618
+#: config/internal/option-internal.cpp:571
 msgid "Hide menu bar when mouse is inactive"
 msgstr ""
 
-#: config/internal/option-internal.cpp:623
+#: config/internal/option-internal.cpp:576
 msgid "Sound API; if unsupported, default API will be used"
 msgstr ""
 
-#: config/internal/option-internal.cpp:626
+#: config/internal/option-internal.cpp:579
 msgid "Device ID of chosen audio device for chosen driver"
 msgstr ""
 
-#: config/internal/option-internal.cpp:628
+#: config/internal/option-internal.cpp:581
 msgid "Number of sound buffers"
 msgstr ""
 
-#: config/internal/option-internal.cpp:630
+#: config/internal/option-internal.cpp:583
 msgid "Bit mask of sound channels to enable"
 msgstr ""
 
-#: config/internal/option-internal.cpp:632
+#: config/internal/option-internal.cpp:585
 msgid "GBA sound filtering (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:635
+#: config/internal/option-internal.cpp:588
 msgid "GBA sound interpolation"
 msgstr ""
 
-#: config/internal/option-internal.cpp:636
+#: config/internal/option-internal.cpp:589
 msgid "GB sound declicking"
 msgstr ""
 
-#: config/internal/option-internal.cpp:638
+#: config/internal/option-internal.cpp:591
 msgid "GB echo effect (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:640
+#: config/internal/option-internal.cpp:593
 msgid "Enable GB sound effects"
 msgstr ""
 
-#: config/internal/option-internal.cpp:641
+#: config/internal/option-internal.cpp:594
 msgid "GB stereo effect (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:644
+#: config/internal/option-internal.cpp:597
 msgid "GB surround sound effect (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:645
+#: config/internal/option-internal.cpp:598
 msgid "Sound sample rate (kHz)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:647
+#: config/internal/option-internal.cpp:600
 msgid "Sound volume (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:711
-#: config/internal/option-internal.cpp:731
-#: config/internal/option-internal.cpp:751
-#: config/internal/option-internal.cpp:771
-#: config/internal/option-internal.cpp:791
+#: config/internal/option-internal.cpp:667
+#: config/internal/option-internal.cpp:687
+#: config/internal/option-internal.cpp:708
+#: config/internal/option-internal.cpp:728
+#: config/internal/option-internal.cpp:748
 #, c-format
 msgid "Invalid value %s for option %s; valid values are %s"
 msgstr ""
 
-#: config/option.cpp:243
+#: config/option.cpp:330
 #, c-format
 msgid "Invalid value %f for option %s; valid values are %f - %f"
 msgstr ""
 
-#: config/option.cpp:256 config/option.cpp:269
+#: config/option.cpp:348 config/option.cpp:366
 #, c-format
 msgid "Invalid value %d for option %s; valid values are %d - %d"
 msgstr ""
 
-#: config/option.cpp:319
+#: config/option.cpp:458
 #, c-format
 msgid "Invalid value %d for option %s; valid values are %s"
+msgstr ""
+
+#: dialogs/display-config.cpp:370
+#, c-format
+msgid "No usable rpi plugins found in %s"
+msgstr ""
+
+#: dialogs/display-config.cpp:400
+#, c-format
+msgid "Using pixel filter: %s"
+msgstr ""
+
+#: dialogs/display-config.cpp:408
+#, c-format
+msgid "Using interframe blending: %s"
+msgstr ""
+
+#: dialogs/display-config.cpp:438 xrc/DisplayConfig.xrc:107
+msgid "Plugin"
 msgstr ""
 
 #: widgets/keyedit.cpp:122 widgets/keyedit.cpp:280

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -751,8 +751,11 @@ set(
     config/internal/option-internal.cpp
     config/option.cpp
     config/user-input.cpp
+    dialogs/display-config.cpp
     widgets/keyedit.cpp
     widgets/joyedit.cpp
+    widgets/option-validator.cpp
+    widgets/render-plugin.cpp
     widgets/sdljoy.cpp
     widgets/wxmisc.cpp
     # probably ought to be in common
@@ -792,7 +795,10 @@ set(
     config/internal/option-internal.h
     config/option.h
     config/user-input.h
+    dialogs/display-config.h
     widgets/dpi-support.h
+    widgets/option-validator.h
+    widgets/render-plugin.h
     widgets/wx/keyedit.h
     widgets/wx/joyedit.h
     widgets/wx/sdljoy.h

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -11,10 +11,10 @@
 #include <wx/wfstream.h>
 #include <wx/msgdlg.h>
 
-#include "strutils.h"
 #include "../common/version_cpp.h"
 #include "../gb/gbPrinter.h"
 #include "../gba/agbprint.h"
+#include "config/option.h"
 
 #if (wxMAJOR_VERSION < 3)
 #define GetXRCDialog(n) \
@@ -2529,40 +2529,35 @@ EVT_HANDLER(GameBoyConfigure, "Game Boy options...")
     update_opts();
 }
 
+// FIXME: These should be changed so AdjustSize() is called somewhere else.
 EVT_HANDLER(SetSize1x, "1x")
 {
-    gopts.video_scale = 1;
-    panel->AdjustSize(true);
+    config::Option::ByID(config::OptionID::kDisplayScale)->SetDouble(1);
 }
 
 EVT_HANDLER(SetSize2x, "2x")
 {
-    gopts.video_scale = 2;
-    panel->AdjustSize(true);
+    config::Option::ByID(config::OptionID::kDisplayScale)->SetDouble(2);
 }
 
 EVT_HANDLER(SetSize3x, "3x")
 {
-    gopts.video_scale = 3;
-    panel->AdjustSize(true);
+    config::Option::ByID(config::OptionID::kDisplayScale)->SetDouble(3);
 }
 
 EVT_HANDLER(SetSize4x, "4x")
 {
-    gopts.video_scale = 4;
-    panel->AdjustSize(true);
+    config::Option::ByID(config::OptionID::kDisplayScale)->SetDouble(4);
 }
 
 EVT_HANDLER(SetSize5x, "5x")
 {
-    gopts.video_scale = 5;
-    panel->AdjustSize(true);
+    config::Option::ByID(config::OptionID::kDisplayScale)->SetDouble(5);
 }
 
 EVT_HANDLER(SetSize6x, "6x")
 {
-    gopts.video_scale = 6;
-    panel->AdjustSize(true);
+    config::Option::ByID(config::OptionID::kDisplayScale)->SetDouble(6);
 }
 
 EVT_HANDLER(GameBoyAdvanceConfigure, "Game Boy Advance options...")
@@ -2756,37 +2751,17 @@ EVT_HANDLER_MASK(DisplayConfigure, "Display options...", CMDEN_NREC_ANY)
 
 EVT_HANDLER_MASK(ChangeFilter, "Change Pixel Filter", CMDEN_NREC_ANY)
 {
-    int filt = gopts.filter;
-
-    if ((filt == FF_PLUGIN || ++gopts.filter == FF_PLUGIN) && gopts.filter_plugin.empty()) {
-        gopts.filter = 0;
-    }
-
-    update_opts();
-
-    if (panel->panel) {
-        panel->panel->Destroy();
-        panel->panel = nullptr;
-    }
-
-    wxString msg;
-    msg.Printf(_("Using pixel filter: %s"), pixel_filters_->GetString(gopts.filter));
-    systemScreenMessage(msg);
+    const wxString& filter_plugin =
+        config::Option::ByID(config::OptionID::kDisplayFilterPlugin)
+            ->GetString();
+    // Skip the filter plugin if it is not set.
+    config::Option::ByID(config::OptionID::kDisplayFilter)
+        ->NextFilter(filter_plugin == wxEmptyString);
 }
 
 EVT_HANDLER_MASK(ChangeIFB, "Change Interframe Blending", CMDEN_NREC_ANY)
 {
-    gopts.ifb = (gopts.ifb + 1) % 3;
-    update_opts();
-
-    if (panel->panel) {
-        panel->panel->Destroy();
-        panel->panel = nullptr;
-    }
-
-    wxString msg;
-    msg.Printf(_("Using interframe blending: %s"), interframe_blenders_->GetString(gopts.ifb));
-    systemScreenMessage(msg);
+    config::Option::ByID(config::OptionID::kDisplayIFB)->NextInterframe();
 }
 
 EVT_HANDLER_MASK(SoundConfigure, "Sound options...", CMDEN_NREC_ANY)

--- a/src/wx/config/internal/option-internal.h
+++ b/src/wx/config/internal/option-internal.h
@@ -24,14 +24,14 @@ extern const std::array<OptionData, kNbOptions + 1> kAllOptionsData;
 
 // Conversion utilities.
 nonstd::optional<OptionID> StringToOptionId(const wxString& input);
-wxString FilterToString(int value);
-wxString InterframeToString(int value);
-wxString RenderMethodToString(int value);
+wxString FilterToString(const Filter& value);
+wxString InterframeToString(const Interframe& value);
+wxString RenderMethodToString(const RenderMethod& value);
 wxString AudioApiToString(int value);
 wxString SoundQualityToString(int value);
-int StringToFilter(const wxString& config_name, const wxString& input);
-int StringToInterframe(const wxString& config_name, const wxString& input);
-int StringToRenderMethod(const wxString& config_name, const wxString& input);
+Filter StringToFilter(const wxString& config_name, const wxString& input);
+Interframe StringToInterframe(const wxString& config_name, const wxString& input);
+RenderMethod StringToRenderMethod(const wxString& config_name, const wxString& input);
 int StringToAudioApi(const wxString& config_name, const wxString& input);
 int StringToSoundQuality(const wxString& config_name, const wxString& input);
 

--- a/src/wx/config/option.h
+++ b/src/wx/config/option.h
@@ -4,6 +4,8 @@
 #include "nonstd/variant.hpp"
 
 #include <array>
+#include <functional>
+#include <unordered_set>
 
 #include <wx/string.h>
 
@@ -145,8 +147,65 @@ enum class OptionID {
     // Do not add anything under here.
     Last,
 };
+static constexpr size_t kNbOptions = static_cast<size_t>(OptionID::Last);
 
-constexpr size_t kNbOptions = static_cast<size_t>(OptionID::Last);
+// Values for kDisplayFilter.
+enum class Filter {
+    kNone,
+    k2xsai,
+    kSuper2xsai,
+    kSupereagle,
+    kPixelate,
+    kAdvmame,
+    kBilinear,
+    kBilinearplus,
+    kScanlines,
+    kTvmode,
+    kHQ2x,
+    kLQ2x,
+    kSimple2x,
+    kSimple3x,
+    kHQ3x,
+    kSimple4x,
+    kHQ4x,
+    kXbrz2x,
+    kXbrz3x,
+    kXbrz4x,
+    kXbrz5x,
+    kXbrz6x,
+    kPlugin,  // This must always be last.
+
+    // Do not add anything under here.
+    kLast,
+};
+static constexpr size_t kNbFilters = static_cast<size_t>(Filter::kLast);
+
+// Values for kDisplayIFB.
+enum class Interframe {
+    kNone = 0,
+    kSmart,
+    kMotionBlur,
+
+    // Do not add anything under here.
+    kLast,
+};
+static constexpr size_t kNbInterframes = static_cast<size_t>(Interframe::kLast);
+
+// Values for kDisplayRenderMethod.
+enum class RenderMethod {
+    kSimple = 0,
+    kOpenGL,
+#if defined(__WXMSW__) && !defined(NO_D3D)
+    kDirect3d,
+#elif defined(__WXMAC__)
+    kQuartz2d,
+#endif
+
+    // Do not add anything under here.
+    kLast,
+};
+static constexpr size_t kNbRenderMethods =
+    static_cast<size_t>(RenderMethod::kLast);
 
 // Represents a single option saved in the INI file. Option does not own the
 // individual option, but keeps a pointer to where the data is actually saved.
@@ -156,8 +215,7 @@ constexpr size_t kNbOptions = static_cast<size_t>(OptionID::Last);
 // Option::Set*() is called. This should also handle keyboard and joystick
 // configuration so option parsing can be done in a uniform manner. If we ever
 // get to that point, we would be able to remove most update_opts() calls and
-// have individual UI elements access the option via
-// Option::FindByID().
+// have individual UI elements access the option via Option::ByID().
 //
 // The implementation for this class is largely inspired by base::Value in
 // Chromium.
@@ -179,13 +237,41 @@ public:
         kGbPalette,
     };
 
-    static std::array<Option, kNbOptions>& AllOptions();
+    // Observer for an option. OnValueChanged() will be called when the value
+    // has changed. Implementers should take care of not modifying option()
+    // in the OnValueChanged() handler.
+    class Observer {
+    public:
+        explicit Observer(config::OptionID option_id);
+        virtual ~Observer();
+
+        // Class is move-only.
+        Observer(const Observer&) = delete;
+        Observer& operator=(const Observer&) = delete;
+        Observer(Observer&& other) = default;
+        Observer& operator=(Observer&& other) = default;
+
+        virtual void OnValueChanged() = 0;
+
+    protected:
+        Option* option() const { return option_; }
+
+    private:
+        Option* option_;
+    };
+
+    static std::array<Option, kNbOptions>& All();
 
     // O(log(kNbOptions))
-    static Option const* FindByName(const wxString& config_name);
+    static Option* ByName(const wxString& config_name);
 
     // O(1)
-    static Option& FindByID(OptionID id);
+    static Option* ByID(OptionID id);
+
+    // Convenience direct accessors for some enum options.
+    static Filter GetFilterValue();
+    static Interframe GetInterframeValue();
+    static RenderMethod GetRenderMethodValue();
 
     ~Option();
 
@@ -193,6 +279,7 @@ public:
     const wxString& config_name() const { return config_name_; }
     const wxString& command() const { return command_; }
     const wxString& ux_helper() const { return ux_helper_; }
+    const OptionID& id() const { return id_; }
 
     // Returns the type of the value stored by the current object.
     Type type() const { return type_; }
@@ -212,25 +299,35 @@ public:
     bool is_gb_palette() const { return type() == Type::kGbPalette; }
 
     // Returns a reference to the stored data. Will assert on type mismatch.
-    // All enum types go through GetEnumString().
+    // Only enum types can use through GetEnumString().
     bool GetBool() const;
     double GetDouble() const;
     int32_t GetInt() const;
     uint32_t GetUnsigned() const;
-    const wxString GetString() const;
+    const wxString& GetString() const;
+    Filter GetFilter() const;
+    Interframe GetInterframe() const;
+    RenderMethod GetRenderMethod() const;
     wxString GetEnumString() const;
     wxString GetGbPaletteString() const;
 
     // Sets the value. Will assert on type mismatch.
-    // All enum types go through SetEnumString() and SetEnumInt().
-    void SetBool(bool value) const;
-    void SetDouble(double value) const;
-    void SetInt(int32_t value) const;
-    void SetUnsigned(uint32_t value) const;
-    void SetString(const wxString& value) const;
-    void SetEnumString(const wxString& value) const;
-    void SetEnumInt(int value) const;
-    void SetGbPalette(const wxString& value) const;
+    // Only enum types can use SetEnumString().
+    // Returns true on success. On failure, the value will not be modified.
+    bool SetBool(bool value);
+    bool SetDouble(double value);
+    bool SetInt(int32_t value);
+    bool SetUnsigned(uint32_t value);
+    bool SetString(const wxString& value);
+    bool SetFilter(const Filter& value);
+    bool SetInterframe(const Interframe& value);
+    bool SetRenderMethod(const RenderMethod& value);
+    bool SetEnumString(const wxString& value);
+    bool SetGbPalette(const wxString& value);
+
+    // Special convenience modifiers.
+    void NextFilter(bool skip_filter_plugin);
+    void NextInterframe();
 
     // Command-line helper string.
     wxString ToHelperString() const;
@@ -240,14 +337,31 @@ private:
     Option(const Option&) = delete;
     Option& operator=(const Option&) = delete;
 
-    Option(OptionID id);
+    explicit Option(OptionID id);
     Option(OptionID id, bool* option);
     Option(OptionID id, double* option, double min, double max);
     Option(OptionID id, int32_t* option, int32_t min, int32_t max);
     Option(OptionID id, uint32_t* option, uint32_t min, uint32_t max);
     Option(OptionID id, wxString* option);
+    Option(OptionID id, Filter* option);
+    Option(OptionID id, Interframe* option);
+    Option(OptionID id, RenderMethod* option);
     Option(OptionID id, int* option);
     Option(OptionID id, uint16_t* option);
+
+    // Helper method for enums not fully converted yet.
+    bool SetEnumInt(int value);
+
+    // Observer.
+    void AddObserver(Observer* observer);
+    void RemoveObserver(Observer* observer);
+    void CallObservers();
+    std::unordered_set<Observer*> observers_;
+
+    // Set to true when the observers are being called. This will fire an assert
+    // to prevent modifying the object again, which would trigger an infinite
+    // call stack.
+    bool calling_observers_ = false;
 
     const OptionID id_;
 
@@ -262,11 +376,28 @@ private:
                           int32_t*,
                           uint32_t*,
                           wxString*,
+                          Filter*,
+                          Interframe*,
+                          RenderMethod*,
                           uint16_t*>
         value_;
 
     const nonstd::variant<nonstd::monostate, double, int32_t, uint32_t> min_;
     const nonstd::variant<nonstd::monostate, double, int32_t, uint32_t> max_;
+};
+
+// A simple Option::Observer that calls a callback when the value has changed.
+class BasicOptionObserver : public Option::Observer {
+public:
+    BasicOptionObserver(config::OptionID option_id,
+                        std::function<void(config::Option*)> callback);
+    ~BasicOptionObserver() override;
+
+private:
+    // Option::Observer implementation.
+    void OnValueChanged() override;
+
+    std::function<void(config::Option*)> callback_;
 };
 
 }  // namespace config

--- a/src/wx/dialogs/display-config.cpp
+++ b/src/wx/dialogs/display-config.cpp
@@ -1,0 +1,445 @@
+#include "dialogs/display-config.h"
+
+#include <wx/arrstr.h>
+#include <wx/choice.h>
+#include <wx/clntdata.h>
+#include <wx/dir.h>
+#include <wx/dynlib.h>
+#include <wx/log.h>
+#include <wx/object.h>
+#include <wx/radiobut.h>
+#include <wx/spinctrl.h>
+#include <wx/stdpaths.h>
+#include <wx/textctrl.h>
+#include <wx/xrc/xmlres.h>
+
+#include "../../System.h"
+#include "../../common/ConfigManager.h"
+#include "config/option.h"
+#include "rpi.h"
+#include "wayland.h"
+#include "widgets/option-validator.h"
+#include "widgets/render-plugin.h"
+#include "widgets/wx/wxmisc.h"
+#include "wxvbam.h"
+
+namespace dialogs {
+
+namespace {
+
+// Validator for a wxTextCtrl with a double value.
+class ScaleValidator : public widgets::OptionValidator {
+public:
+    ScaleValidator()
+        : widgets::OptionValidator(config::OptionID::kDisplayScale) {}
+    ~ScaleValidator() override = default;
+
+private:
+    // OptionValidator implementation.
+    wxObject* Clone() const override { return new ScaleValidator(); }
+
+    bool IsWindowValueValid() override {
+        double value;
+        if (!wxDynamicCast(GetWindow(), wxTextCtrl)
+                 ->GetValue()
+                 .ToDouble(&value)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    bool WriteToWindow() override {
+        wxDynamicCast(GetWindow(), wxTextCtrl)
+            ->SetValue(wxString::Format("%.1f", option()->GetDouble()));
+        return true;
+    }
+
+    bool WriteToOption() override {
+        double value;
+        if (!wxDynamicCast(GetWindow(), wxTextCtrl)
+                 ->GetValue()
+                 .ToDouble(&value)) {
+            return false;
+        }
+
+        return option()->SetDouble(value);
+    }
+};
+
+// Validator for a wxChoice with a Filter value.
+class FilterValidator : public widgets::OptionValidator {
+public:
+    FilterValidator() : OptionValidator(config::OptionID::kDisplayFilter) {
+        Bind(wxEVT_CHOICE, &FilterValidator::OnChoice, this);
+    }
+    ~FilterValidator() override = default;
+
+private:
+    // wxChoice event handler.
+    void OnChoice(wxCommandEvent&) { WriteToOption(); }
+
+    // OptionValidator implementation.
+    wxObject* Clone() const override { return new FilterValidator(); }
+
+    bool IsWindowValueValid() override { return true; }
+
+    bool WriteToWindow() override {
+        wxDynamicCast(GetWindow(), wxChoice)
+            ->SetSelection(static_cast<int>(option()->GetFilter()));
+        return true;
+    }
+
+    bool WriteToOption() override {
+        const int selection =
+            wxDynamicCast(GetWindow(), wxChoice)->GetSelection();
+        if (selection == wxNOT_FOUND) {
+            return false;
+        }
+
+        if (static_cast<size_t>(selection) > config::kNbFilters) {
+            return false;
+        }
+
+        return option()->SetFilter(static_cast<config::Filter>(selection));
+    }
+};
+
+// Validator for a wxChoice with an Interframe value.
+class InterframeValidator : public widgets::OptionValidator {
+public:
+    InterframeValidator() : OptionValidator(config::OptionID::kDisplayIFB) {
+        Bind(wxEVT_CHOICE, &InterframeValidator::OnChoice, this);
+    }
+    ~InterframeValidator() override = default;
+
+private:
+    // wxChoice event handler.
+    void OnChoice(wxCommandEvent&) { WriteToOption(); }
+
+    // OptionValidator implementation.
+    wxObject* Clone() const override { return new InterframeValidator(); }
+
+    bool IsWindowValueValid() override { return true; }
+
+    bool WriteToWindow() override {
+        wxDynamicCast(GetWindow(), wxChoice)
+            ->SetSelection(static_cast<int>(option()->GetInterframe()));
+        return true;
+    }
+
+    bool WriteToOption() override {
+        const int selection =
+            wxDynamicCast(GetWindow(), wxChoice)->GetSelection();
+        if (selection == wxNOT_FOUND) {
+            return false;
+        }
+
+        if (static_cast<size_t>(selection) > config::kNbInterframes) {
+            return false;
+        }
+
+        return option()->SetInterframe(
+            static_cast<config::Interframe>(selection));
+    }
+};
+
+// Validator for a wxRadioButton with a RenderMethod value.
+class RenderValidator : public widgets::OptionValidator {
+public:
+    explicit RenderValidator(config::RenderMethod render_method)
+        : OptionValidator(config::OptionID::kDisplayRenderMethod),
+          render_method_(render_method) {
+        assert(render_method != config::RenderMethod::kLast);
+        Bind(wxEVT_RADIOBUTTON, &RenderValidator::OnRadioButton, this);
+    }
+    ~RenderValidator() override = default;
+
+private:
+    // wxRadioButton event handler.
+    void OnRadioButton(wxCommandEvent&) { WriteToOption(); }
+
+    // OptionValidator implementation.
+    wxObject* Clone() const override {
+        return new RenderValidator(render_method_);
+    }
+
+    bool IsWindowValueValid() override { return true; }
+
+    bool WriteToWindow() override {
+        wxDynamicCast(GetWindow(), wxRadioButton)
+            ->SetValue(option()->GetRenderMethod() == render_method_);
+        return true;
+    }
+
+    bool WriteToOption() override {
+        if (wxDynamicCast(GetWindow(), wxRadioButton)->GetValue()) {
+            return option()->SetRenderMethod(render_method_);
+        }
+
+        return true;
+    }
+
+    const config::RenderMethod render_method_;
+};
+
+class PluginSelectorValidator : public widgets::OptionValidator {
+public:
+    PluginSelectorValidator()
+        : widgets::OptionValidator(config::OptionID::kDisplayFilterPlugin) {}
+    ~PluginSelectorValidator() override = default;
+
+private:
+    // widgets::OptionValidator implementation.
+    wxObject* Clone() const override { return new PluginSelectorValidator(); }
+
+    bool IsWindowValueValid() override { return true; }
+
+    bool WriteToWindow() override {
+        wxChoice* plugin_selector = wxDynamicCast(GetWindow(), wxChoice);
+        assert(plugin_selector);
+        const wxString selected_plugin = option()->GetString();
+        for (size_t i = 0; i < plugin_selector->GetCount(); i++) {
+            const wxString& plugin_data =
+                dynamic_cast<wxStringClientData*>(
+                    plugin_selector->GetClientObject(i))
+                    ->GetData();
+            if (plugin_data == selected_plugin) {
+                plugin_selector->SetSelection(i);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool WriteToOption() override {
+        wxChoice* plugin_selector = wxDynamicCast(GetWindow(), wxChoice);
+        assert(plugin_selector);
+        const wxString& selected_window_plugin =
+            dynamic_cast<wxStringClientData*>(
+                plugin_selector->GetClientObject(
+                    plugin_selector->GetSelection()))
+                ->GetData();
+        return option()->SetString(selected_window_plugin);
+    }
+};
+
+// Helper functions to assert on the returned value.
+wxWindow* GetValidatedChild(const wxWindow* parent, const wxString& name) {
+    wxWindow* window = parent->FindWindow(name);
+    assert(window);
+    return window;
+}
+
+template <class T>
+T* GetValidatedChild(const wxWindow* parent, const wxString& name) {
+    T* child = wxDynamicCast(GetValidatedChild(parent, name), T);
+    assert(child);
+    return child;
+}
+
+}  // namespace
+
+// static
+DisplayConfig* DisplayConfig::NewInstance(wxWindow* parent) {
+    assert(parent);
+    return new DisplayConfig(parent);
+}
+
+DisplayConfig::DisplayConfig(wxWindow* parent)
+    : wxDialog(),
+      filter_observer_(config::OptionID::kDisplayFilter,
+                       std::bind(&DisplayConfig::OnFilterChanged,
+                                 this,
+                                 std::placeholders::_1)),
+      interframe_observer_(config::OptionID::kDisplayIFB,
+                           std::bind(&DisplayConfig::OnInterframeChanged,
+                                     this,
+                                     std::placeholders::_1)) {
+    wxXmlResource::Get()->LoadDialog(this, parent, "DisplayConfig");
+
+    // Speed
+    // AutoSkip/FrameSkip are 2 controls for 1 value.  Needs post-process
+    // to ensure checkbox not ignored
+    GetValidatedChild(this, "FrameSkip")
+        ->SetValidator(wxGenericValidator(&frameSkip));
+    if (frameSkip >= 0) {
+        systemFrameSkip = frameSkip;
+    }
+
+    // On-Screen Display
+    GetValidatedChild(this, "SpeedIndicator")
+        ->SetValidator(wxGenericValidator(&showSpeed));
+
+    // Zoom
+    GetValidatedChild(this, "DefaultScale")->SetValidator(ScaleValidator());
+
+    // this was a choice, but I'd rather not have to make an off-by-one
+    // validator just for this, and spinctrl is good enough.
+    GetValidatedChild(this, "MaxScale")
+        ->SetValidator(wxGenericValidator(&maxScale));
+
+    // Basic
+    GetValidatedChild(this, "OutputSimple")
+        ->SetValidator(RenderValidator(config::RenderMethod::kSimple));
+
+#if defined(__WXMAC__)
+    GetValidatedChild(this, "OutputQuartz2D")
+        ->SetValidator(RenderValidator(config::RenderMethod::kQuartz2d));
+#else
+    GetValidatedChild(this, "OutputQuartz2D")->Hide();
+#endif
+
+#ifdef NO_OGL
+    GetValidatedChild(this, "OutputOpenGL")->Hide();
+#elif defined(__WXGTK__) && !wxCHECK_VERSION(3, 2, 0)
+    // wxGLCanvas segfaults on Wayland before wx 3.2.
+    if (IsItWayland()) {
+        GetValidatedChild(this, "OutputOpenGL")->Hide();
+    } else {
+        GetValidatedChild(this, "OutputOpenGL")
+            ->SetValidator(RenderValidator(config::RenderMethod::kOpenGL));
+    }
+#else
+    GetValidatedChild(this, "OutputOpenGL")
+        ->SetValidator(RenderValidator(config::RenderMethod::kOpenGL));
+#endif  // NO_OGL
+
+    // Direct3D is not implemented so hide the option on every platform.
+    GetValidatedChild(this, "OutputDirect3D")->Hide();
+
+    filter_selector_ = GetValidatedChild<wxChoice>(this, "Filter");
+    filter_selector_->SetValidator(FilterValidator());
+
+    // These are filled and/or hidden at dialog load time.
+    plugin_label_ = GetValidatedChild<wxControl>(this, "PluginLab");
+    plugin_selector_ = GetValidatedChild<wxChoice>(this, "Plugin");
+
+    interframe_selector_ = GetValidatedChild<wxChoice>(this, "IFB");
+    interframe_selector_->SetValidator(InterframeValidator());
+
+    Bind(wxEVT_SHOW, &DisplayConfig::OnDialogShown, this, GetId());
+    Bind(wxEVT_CLOSE_WINDOW, &DisplayConfig::OnDialogClosed, this, GetId());
+
+    // Finally, fit everything nicely.
+    Fit();
+}
+
+void DisplayConfig::OnDialogShown(wxShowEvent&) {
+    // Populate the plugin values, if any.
+    wxArrayString plugins;
+    const wxString plugin_path = wxGetApp().GetPluginsDir();
+    wxDir::GetAllFiles(plugin_path, &plugins, "*.rpi",
+                       wxDIR_FILES | wxDIR_DIRS);
+
+    if (plugins.empty()) {
+        HidePluginOptions();
+        return;
+    }
+
+    plugin_selector_->Clear();
+    plugin_selector_->Append(_("None"), new wxStringClientData());
+
+    const wxString selected_plugin =
+        config::Option::ByID(config::OptionID::kDisplayFilterPlugin)
+            ->GetString();
+    bool is_plugin_selected = false;
+
+    for (const wxString& plugin : plugins) {
+        wxDynamicLibrary dyn_lib(plugin, wxDL_VERBATIM | wxDL_NOW);
+
+        wxDynamicLibrary filter_plugin;
+        const RENDER_PLUGIN_INFO* plugin_info =
+            widgets::MaybeLoadFilterPlugin(plugin, &filter_plugin);
+        if (!plugin_info) {
+            continue;
+        }
+
+        wxFileName file_name(plugin);
+        file_name.MakeRelativeTo(plugin_path);
+
+        const int added_index = plugin_selector_->Append(
+            file_name.GetName() + ": " +
+                wxString(plugin_info->Name, wxConvUTF8),
+            new wxStringClientData(plugin));
+
+        if (plugin == selected_plugin) {
+            plugin_selector_->SetSelection(added_index);
+            is_plugin_selected = true;
+        }
+    }
+
+    if (plugin_selector_->GetCount() == 1u) {
+        wxLogWarning(wxString::Format(_("No usable rpi plugins found in %s"),
+                                      plugin_path));
+        HidePluginOptions();
+        return;
+    }
+
+    if (!is_plugin_selected) {
+        config::Option::ByID(config::OptionID::kDisplayFilterPlugin)
+            ->SetString(wxEmptyString);
+    }
+
+    plugin_selector_->SetValidator(PluginSelectorValidator());
+    ShowPluginOptions();
+
+    Fit();
+}
+
+void DisplayConfig::OnDialogClosed(wxCloseEvent&) {
+    // Reset the validator to stop handling events while this dialog is not
+    // shown.
+    plugin_selector_->SetValidator(wxValidator());
+}
+
+void DisplayConfig::OnFilterChanged(config::Option* option) {
+    const config::Filter option_filter = option->GetFilter();
+    const bool show_plugin = option_filter == config::Filter::kPlugin;
+    plugin_label_->Enable(show_plugin);
+    plugin_selector_->Enable(show_plugin);
+
+    systemScreenMessage(wxString::Format(
+        _("Using pixel filter: %s"),
+        filter_selector_->GetString(static_cast<size_t>(option_filter))));
+}
+
+void DisplayConfig::OnInterframeChanged(config::Option* option) {
+    const config::Interframe interframe = option->GetInterframe();
+
+    systemScreenMessage(wxString::Format(
+        _("Using interframe blending: %s"),
+        interframe_selector_->GetString(static_cast<size_t>(interframe))));
+}
+
+void DisplayConfig::HidePluginOptions() {
+    plugin_label_->Hide();
+    plugin_selector_->Hide();
+
+    // Remove the Plugin option, which should be the last.
+    if (filter_selector_->GetCount() == config::kNbFilters) {
+        // Make sure we have not selected the plugin option. The validator
+        // will take care of updating the selector value.
+        if (config::Option::GetFilterValue() == config::Filter::kPlugin) {
+            config::Option::ByID(config::OptionID::kDisplayFilter)
+                ->SetFilter(config::Filter::kNone);
+        }
+        filter_selector_->Delete(config::kNbFilters - 1);
+    }
+
+    // Also erase the Plugin value to avoid issues down the line.
+    config::Option::ByID(config::OptionID::kDisplayFilterPlugin)
+        ->SetString(wxEmptyString);
+}
+
+void DisplayConfig::ShowPluginOptions() {
+    plugin_label_->Show();
+    plugin_selector_->Show();
+
+    // Re-add the Plugin option, if needed.
+    if (filter_selector_->GetCount() != config::kNbFilters) {
+        filter_selector_->Append(_("Plugin"));
+    }
+}
+
+}  // namespace dialogs

--- a/src/wx/dialogs/display-config.h
+++ b/src/wx/dialogs/display-config.h
@@ -1,0 +1,54 @@
+#ifndef VBAM_WX_DIALOGS_DISPLAY_CONFIG_H_
+#define VBAM_WX_DIALOGS_DISPLAY_CONFIG_H_
+
+#include <wx/dialog.h>
+#include <wx/event.h>
+
+#include "config/option.h"
+
+// Forward declarations.
+class wxChoice;
+class wxControl;
+class wxWindow;
+
+namespace dialogs {
+
+// Manages the display configuration dialog.
+class DisplayConfig : public wxDialog {
+public:
+    static DisplayConfig* NewInstance(wxWindow* parent);
+    ~DisplayConfig() override = default;
+
+private:
+    // The constructor is private so initialization has to be done via the
+    // static method. This is because this class is destroyed when its
+    // owner, `parent` is destroyed. This prevents accidental deletion.
+    DisplayConfig(wxWindow* parent);
+
+    // Populates the plugin options.
+    void OnDialogShown(wxShowEvent&);
+
+    // 
+    void OnDialogClosed(wxCloseEvent&);
+
+    // Callback called when the render method changes.
+    void OnFilterChanged(config::Option* option);
+
+    // Callback called when the interframe method changes.
+    void OnInterframeChanged(config::Option* option);
+
+    // Hides/Shows the plugin-related filter options.
+    void HidePluginOptions();
+    void ShowPluginOptions();
+
+    wxControl* plugin_label_;
+    wxChoice* plugin_selector_;
+    wxChoice* filter_selector_;
+    wxChoice* interframe_selector_;
+    config::BasicOptionObserver filter_observer_;
+    config::BasicOptionObserver interframe_observer_;
+};
+
+}  // namespace dialogs
+
+#endif  // VBAM_WX_DIALOGS_DISPLAY_CONFIG_H_

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -24,13 +24,8 @@ extern struct opts_t {
 
     /// Display
     bool bilinear;
-    int filter;
-    wxString filter_plugin;
-    int ifb;
     wxVideoMode fs_mode;
     int max_threads;
-    int render_method;
-    double video_scale;
     bool retain_aspect;
     bool keep_on_top;
 

--- a/src/wx/widgets/option-validator.cpp
+++ b/src/wx/widgets/option-validator.cpp
@@ -1,0 +1,33 @@
+#include "widgets/option-validator.h"
+
+namespace widgets {
+
+OptionValidator::OptionValidator(config::OptionID option_id)
+    : wxValidator(), config::Option::Observer(option_id) {}
+
+bool OptionValidator::TransferFromWindow() {
+    return WriteToOption();
+}
+
+bool OptionValidator::Validate(wxWindow*) {
+    return IsWindowValueValid();
+}
+
+bool OptionValidator::TransferToWindow() {
+    return WriteToWindow();
+}
+
+#if WX_HAS_VALIDATOR_SET_WINDOW_OVERRIDE
+void OptionValidator::SetWindow(wxWindow* window) {
+    wxValidator::SetWindow(window);
+    [[maybe_unused]] const bool write_success = WriteToWindow();
+    assert(write_success);
+}
+#endif
+
+void OptionValidator::OnValueChanged() {
+    [[maybe_unused]] const bool write_success = WriteToWindow();
+    assert(write_success);
+}
+
+}  // namespace widgets

--- a/src/wx/widgets/option-validator.h
+++ b/src/wx/widgets/option-validator.h
@@ -1,0 +1,90 @@
+#ifndef VBAM_WX_WIDGETS_OPTION_VALIDATOR_H_
+#define VBAM_WX_WIDGETS_OPTION_VALIDATOR_H_
+
+#include <wx/validate.h>
+
+#include "config/option.h"
+
+#if wxCHECK_VERSION(3, 1, 1)
+#define WX_HAS_VALIDATOR_SET_WINDOW_OVERRIDE 1
+#else
+#define WX_HAS_VALIDATOR_SET_WINDOW_OVERRIDE 0
+#endif  // wxCHECK_VERSION(3,1,1)
+
+namespace widgets {
+
+// Generic wxWidgets validator for a config::Option. This base class acts as a
+// Controller in a Model-View-Controller pattern. Implementers should only have
+// to provide the OptionID and implement the 4 methods indicated below.
+//
+// Sample usage:
+//
+// class MyOptionValidator : public widgets::OptionValidator {
+// public:
+//     MyOptionValidator()
+//         : widgets::OptionValidator(config::OptionID::kOptionID) {}
+//     ~MyOptionValidator() override = default;
+//
+// private:
+//     // widgets::OptionValidator implementation.
+//     wxObject* Clone() const override {
+//         return MyOptionValidator();
+//     }
+//
+//     bool IsWindowValueValid() override {
+//         wxWindow* window = GetWindow();
+//         // Validate window value here.
+//     }
+//
+//     bool WriteToWindow() override {
+//         wxWindow* window = GetWindow();
+//         OptionType value = option()->GetType();
+//         return window->SetValue(value);
+//     }
+//
+//     bool WriteToOption() override {
+//         wxWindow* window = GetWindow();
+//         return option()->SetType(window->GetValue());
+//     }
+//
+// };
+//
+// void DialogInitializer() {
+//     wxWindow* window = dialog->FindWindow("WindowId");
+//     window->SetValidator(MyOptionValidator());
+// }
+class OptionValidator : public wxValidator, public config::Option::Observer {
+public:
+    explicit OptionValidator(config::OptionID option_id);
+    ~OptionValidator() override = default;
+
+    // Returns a copy of the object.
+    wxObject* Clone() const override = 0;
+
+    // Returns true if the value held by GetWindow() is valid.
+    [[nodiscard]] virtual bool IsWindowValueValid() = 0;
+
+    // Updates the GetWindow() value, from the option() value.
+    // Returns true on success, false on failure.
+    [[nodiscard]] virtual bool WriteToWindow() = 0;
+
+    // Updates the option() value, from the GetWindow() value.
+    // Returns true on success, false on failure.
+    [[nodiscard]] virtual bool WriteToOption() = 0;
+
+private:
+    // wxValidator implementation.
+    bool TransferFromWindow() final;
+    bool Validate(wxWindow*) final;
+    bool TransferToWindow() final;
+#if WX_HAS_VALIDATOR_SET_WINDOW_OVERRIDE
+    void SetWindow(wxWindow* window) final;
+#endif
+
+    // config::Option::Observer implementation.
+    void OnValueChanged() final;
+};
+
+}  // namespace widgets
+
+#endif  // VBAM_WX_WIDGETS_OPTION_VALIDATOR_H_

--- a/src/wx/widgets/render-plugin.cpp
+++ b/src/wx/widgets/render-plugin.cpp
@@ -1,0 +1,43 @@
+#include "widgets/render-plugin.h"
+
+namespace widgets {
+
+RENDER_PLUGIN_INFO* MaybeLoadFilterPlugin(const wxString& path, wxDynamicLibrary* filter_plugin) {
+    assert(filter_plugin);
+
+    if (!filter_plugin->Load(path, wxDL_VERBATIM | wxDL_NOW | wxDL_QUIET)) {
+        return nullptr;
+    }
+
+    RENDPLUG_GetInfo get_info =
+        (RENDPLUG_GetInfo)filter_plugin->GetSymbol("RenderPluginGetInfo");
+
+    if (!get_info) {
+        filter_plugin->Unload();
+        return nullptr;
+    }
+
+    // need to be able to write to plugin_info to set Output() and Flags
+    RENDER_PLUGIN_INFO* plugin_info = get_info();
+    if (!plugin_info) {
+        filter_plugin->Unload();
+        return nullptr;
+    }
+
+    // TODO: Should this be < RPI_VERISON?
+    if ((plugin_info->Flags & 0xff) != RPI_VERSION) {
+        filter_plugin->Unload();
+        return nullptr;
+    }
+
+    // RPI_565_SUPP is not supported, although it would be possible and it
+    // would make Cairo more efficient
+    if ((plugin_info->Flags & (RPI_555_SUPP | RPI_888_SUPP)) == 0) {
+        filter_plugin->Unload();
+        return nullptr;
+    }
+
+    return plugin_info;
+}
+
+}  // namespace widgets

--- a/src/wx/widgets/render-plugin.h
+++ b/src/wx/widgets/render-plugin.h
@@ -1,0 +1,18 @@
+#ifndef VBAM_WX_WIDGETS_RENDER_PLUGIN_H_
+#define VBAM_WX_WIDGETS_RENDER_PLUGIN_H_
+
+#include <cstdint>
+#include <wx/dynlib.h>
+#include <wx/string.h>
+
+#include "rpi.h"
+
+namespace widgets {
+
+// Initializes a RENDER_PLUGIN_INFO, if the plugin at `path` is valid.
+// Otherwise, returns nullptr.
+RENDER_PLUGIN_INFO* MaybeLoadFilterPlugin(const wxString& path, wxDynamicLibrary* filter_plugin);
+
+}  // namespace widgets
+
+#endif  // VBAM_WX_WIDGETS_RENDER_PLUGIN_H_

--- a/src/wx/widgets/wx/wxmisc.h
+++ b/src/wx/widgets/wx/wxmisc.h
@@ -60,19 +60,6 @@ public:
 protected:
     int val, mask, *vptr;
 };
-
-class wxPositiveDoubleValidator : public wxGenericValidator {
-public:
-    wxPositiveDoubleValidator(double* _val);
-    bool TransferToWindow();
-    bool TransferFromWindow();
-    bool Validate(wxWindow* parent);
-    wxObject* Clone() const;
-protected:
-    double* double_val;
-    wxString str_val;
-};
-
 class wxUIntValidator : public wxValidator {
 public:
     wxUIntValidator(uint32_t* _val);

--- a/src/wx/widgets/wxmisc.cpp
+++ b/src/wx/widgets/wxmisc.cpp
@@ -384,61 +384,6 @@ static const wxString  val_unsdigits_s[] = {
 const wxArrayString val_unsdigits(sizeof(val_unsdigits_s) / sizeof(val_unsdigits_s[0]),
     val_unsdigits_s);
 
-
-wxPositiveDoubleValidator::wxPositiveDoubleValidator(double* _val)
-    : wxGenericValidator(&str_val)
-    , double_val(_val)
-{
-    if (double_val) {
-        str_val = wxString::Format(wxT("%.1f"), *double_val);
-        TransferToWindow();
-    }
-}
-
-bool wxPositiveDoubleValidator::TransferToWindow()
-{
-    if (double_val) {
-        str_val = wxString::Format(wxT("%.1f"), *double_val);
-        return wxGenericValidator::TransferToWindow();
-    }
-    return true;
-}
-
-bool wxPositiveDoubleValidator::TransferFromWindow()
-{
-    if (wxGenericValidator::TransferFromWindow()) {
-        if (double_val) {
-            return str_val.ToDouble(double_val);
-        }
-    }
-    return false;
-}
-
-bool wxPositiveDoubleValidator::Validate(wxWindow* parent)
-{
-    if (wxGenericValidator::Validate(parent)) {
-        wxTextCtrl* ctrl = wxDynamicCast(GetWindow(), wxTextCtrl);
-
-        if (ctrl) {
-            wxString cur_txt = ctrl->GetValue();
-            double val;
-            if (cur_txt.ToDouble(&val)) {
-                return val >= 0;
-            }
-            return false;
-        }
-
-        return true;
-    }
-    return false;
-}
-
-wxObject* wxPositiveDoubleValidator::Clone() const
-{
-    return new wxPositiveDoubleValidator(double_val);
-}
-
-
 wxUIntValidator::wxUIntValidator(uint32_t* _val)
     : uint_val(_val)
 {

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -360,8 +360,9 @@ bool wxvbamApp::OnInit() {
 
     // wxGLCanvas segfaults under wayland before wx 3.2
 #if defined(__WXGTK__) && !wxCHECK_VERSION(3, 2, 0)
-    if (UsingWayland() && gopts.render_method == RND_OPENGL) {
-        gopts.render_method = RND_SIMPLE;
+    if (UsingWayland()) {
+        config::Option::ByID(config::OptionID::kDisplayRenderMethod)
+            ->SetRenderMethod(config::RenderMethod::kSimple);
     }
 #endif
 
@@ -671,7 +672,7 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
                    " configuration changes are made in the user interface.\n\n"
                    "For flag options, true and false are specified as 1 and 0, respectively.\n\n"));
 
-        for (const config::Option& opt : config::Option::AllOptions()) {
+        for (const config::Option& opt : config::Option::All()) {
             wxPrintf("%s\n", opt.ToHelperString());
         }
 

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -11,6 +11,7 @@
 #include <wx/propdlg.h>
 #include <wx/datetime.h>
 
+#include "config/option.h"
 #include "widgets/dpi-support.h"
 #include "wx/joyedit.h"
 #include "wx/keyedit.h"
@@ -383,9 +384,6 @@ private:
     // Load a named wxDialog from the XRC file
     wxDialog* LoadXRCropertySheetDialog(const char* name);
 
-    wxChoice* pixel_filters_       = nullptr;
-    wxChoice* interframe_blenders_ = nullptr;
-
 #include "cmdhandlers.h"
 };
 
@@ -421,63 +419,6 @@ enum showspeed {
     SS_NONE,
     SS_PERCENT,
     SS_DETAILED
-};
-
-// This enum must be kept in sync with the one in vbam-options-static.cpp.
-// TODO: These 2 enums should be unified and a validator created for this enum.
-enum filtfunc {
-    // this order must match order of option enum and selector widget
-    FF_NONE,
-    FF_2XSAI,
-    FF_SUPER2XSAI,
-    FF_SUPEREAGLE,
-    FF_PIXELATE,
-    FF_ADVMAME,
-    FF_BILINEAR,
-    FF_BILINEARPLUS,
-    FF_SCANLINES,
-    FF_TV,
-    FF_HQ2X,
-    FF_LQ2X,
-    FF_SIMPLE2X,
-    FF_SIMPLE3X,
-    FF_HQ3X,
-    FF_SIMPLE4X,
-    FF_HQ4X,
-    FF_XBRZ2X,
-    FF_XBRZ3X,
-    FF_XBRZ4X,
-    FF_XBRZ5X,
-    FF_XBRZ6X,
-    FF_PLUGIN // plugin must always be last
-};
-#define builtin_ff_scale(x)                                                \
-    ((x == FF_XBRZ6X) ? 6 : (x == FF_XBRZ5X)                               \
-                ? 5                                                        \
-                : (x == FF_XBRZ4X || x == FF_HQ4X || x == FF_SIMPLE4X)     \
-                    ? 4                                                    \
-                    : (x == FF_XBRZ3X || x == FF_HQ3X || x == FF_SIMPLE3X) \
-                        ? 3                                                \
-                        : x == FF_PLUGIN ? 0 : x == FF_NONE ? 1 : 2)
-
-// This enum must be kept in sync with the one in vbam-options-static.cpp.
-// TODO: These 2 enums should be unified and a validator created for this enum.
-enum ifbfunc {
-    IFB_NONE,
-    IFB_SMART,
-    IFB_MOTION_BLUR
-};
-
-// This enum must be kept in sync with the one in vbam-options-static.cpp.
-// TODO: These 2 enums should be unified and a validator created for this enum.
-enum renderer {
-    RND_SIMPLE,
-    RND_OPENGL,
-#if defined(__WXMSW__)
-    RND_DIRECT3D,
-#elif defined(__WXMAC__)
-    RND_QUARTZ2D,
-#endif
 };
 
 // This enum must be kept in sync with the one in vbam-options-static.cpp.
@@ -674,6 +615,17 @@ protected:
 
     DECLARE_DYNAMIC_CLASS(GameArea)
     DECLARE_EVENT_TABLE()
+
+private:
+    // Callback for Render and Interframe changed events.
+    void OnRenderingChanged(config::Option*);
+
+    // Callback for VideoScale changed events.
+    void OnScaleChanged(config::Option*);
+
+    config::BasicOptionObserver filter_observer_;
+    config::BasicOptionObserver interframe_observer_;
+    config::BasicOptionObserver scale_observer_;
 };
 
 // wxString version of OSD message
@@ -726,8 +678,8 @@ protected:
     FilterThread* threads;
     int nthreads;
     wxSemaphore filt_done;
-    wxDynamicLibrary filt_plugin;
-    const RENDER_PLUGIN_INFO* rpi; // also flag indicating plugin loaded
+    wxDynamicLibrary filter_plugin_;
+    RENDER_PLUGIN_INFO* rpi_; // also flag indicating plugin loaded
     // largest buffer required is 32-bit * (max width + 1) * (max height + 2)
     uint8_t delta[257 * 4 * 226];
 };


### PR DESCRIPTION
This adds a generic Observer interface to config::Option. To demonstrate its intended usage, the Display Configuration dialog and the options it controls have been updated to be entirely handled via the config::Option class.

Implementations for wxValidator are used to validate the flow between the UI and the underlying Option. In turn, modifying the Option value triggers all of its observers that should then do what they need to do.

Rather than explicitly calling all of the needed methods after modifying a global option value, the UI elements that need to be notified when an Option value is modified will be notified via their observers. Runtime assert checks are put in place to prevent infinite recursion if an observer attempts to modify an Option while handling the observer callback.

Once all uses of Options have been updated, we should get into a state where the following will be true:
* cmdevents.cpp will no longer rely on the application state.
* All dialogs will have been moved to specific implementations, reducing the size of guiinit.cpp
* update_opts() will no longer need to be called and will be removed.

This will then make it easier to update accelerator handling to be done with config::UserInput.

Bug: #745