### PR TITLE
Backport 800d6ed69b from wx to fix Wayland EGL pos

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -94,6 +94,12 @@ if(NOT WIN32 AND NOT APPLE)
         list(APPEND VBAM_LIBS ${EGL_LIBRARY})
         add_definitions(-DHAVE_EGL)
     endif()
+
+    find_library(WAYLAND_LIBRARY wayland-client)
+
+    if(WAYLAND_LIBRARY)
+        list(APPEND VBAM_LIBS ${WAYLAND_LIBRARY})
+    endif()
 endif()
 
 # Win32 definitions common to all toolchains.

--- a/src/wx/background-input.cpp
+++ b/src/wx/background-input.cpp
@@ -505,7 +505,7 @@ wxThread::ExitCode BackgroundInput::Setup()
     wxLogError(wxT("Yet to be implemented!"));
     return ANY_ERROR;
 #else // defined(__WXGTK__)
-    if (IsItWayland()) {
+    if (IsWayland()) {
         wxLogError(wxT("Wayland does not allow to globally query keypresses for security reasons. \
         Check a better explanation here: https://github.com/albertlauncher/albert/issues/309"));
         return ANY_ERROR;

--- a/src/wx/dialogs/display-config.cpp
+++ b/src/wx/dialogs/display-config.cpp
@@ -292,7 +292,7 @@ DisplayConfig::DisplayConfig(wxWindow* parent)
     GetValidatedChild(this, "OutputOpenGL")->Hide();
 #elif defined(__WXGTK__) && !wxCHECK_VERSION(3, 2, 0)
     // wxGLCanvas segfaults on Wayland before wx 3.2.
-    if (IsItWayland()) {
+    if (IsWayland()) {
         GetValidatedChild(this, "OutputOpenGL")->Hide();
     } else {
         GetValidatedChild(this, "OutputOpenGL")

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2672,7 +2672,7 @@ bool MainFrame::BindControls()
 
             if (cmdtab[i].cmd_id == XRCID("AllowKeyboardBackgroundInput")
 #if defined(__WXGTK__)
-                && IsItWayland()
+                && IsWayland()
 #endif
                ) {
                 if (mi)

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -1302,7 +1302,7 @@ static void process_keyboard_event(const wxKeyEvent& ev, bool down)
     int kc = ev.GetKeyCode();
 
     // Under Wayland or if the key is unicode, we can't use wxGetKeyState().
-    if (!IsItWayland() && kc != WXK_NONE) {
+    if (!IsWayland() && kc != WXK_NONE) {
         // Check if the key state corresponds to the event.
         if (down != wxGetKeyState(static_cast<wxKeyCode>(kc))) {
             return;
@@ -2281,7 +2281,7 @@ void GLDrawingPanel::DrawingPanelInit()
     glClearColor(0.0, 0.0, 0.0, 1.0);
 // non-portable vsync code
 #if defined(__WXGTK__)
-    if (IsItWayland()) {
+    if (IsWayland()) {
 #ifdef HAVE_EGL
         if (vsync)
             wxLogDebug(_("Enabling EGL VSync."));
@@ -2301,9 +2301,8 @@ void GLDrawingPanel::DrawingPanelInit()
         static PFNGLXSWAPINTERVALSGIPROC glXSwapIntervalSGI = NULL;
         static PFNGLXSWAPINTERVALMESAPROC glXSwapIntervalMESA = NULL;
 
-        // These wayland checks don't work.
-        auto display        = IsItWayland() ? 0 : GetX11Display();
-        auto default_screen = IsItWayland() ? 0 : DefaultScreen(display);
+        auto display        = GetX11Display();
+        auto default_screen = DefaultScreen(display);
 
         char* glxQuery = (char*)glXQueryExtensionsString(display, default_screen);
 
@@ -2363,6 +2362,9 @@ void GLDrawingPanel::DrawingPanelInit()
 void GLDrawingPanel::OnSize(wxSizeEvent& ev)
 {
     AdjustViewport();
+
+    // Temporary hack to backport 800d6ed69b from wxWidgets until 3.2.2 is released.
+    MoveWaylandSubsurface(this);
 
     ev.Skip();
 }

--- a/src/wx/wayland.cpp
+++ b/src/wx/wayland.cpp
@@ -1,11 +1,24 @@
-#ifdef __WXGTK__
-#include <gdk/gdk.h>
-#ifdef GDK_WINDOWING_WAYLAND
+#include "wayland.h"
+
+#ifdef HAVE_WAYLAND_SUPPORT
+
 #include <gdk/gdkwayland.h>
-        bool IsItWayland() { return GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default()); }
-#else
-        bool IsItWayland() { return false; }
+
+bool IsWayland() { return GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default()); }
+
 #endif
-#else
-    bool IsItWayland() { return false; }
+
+// Temporary hack to backport 800d6ed69b from wxWidgets until 3.2.2 is released.
+#ifdef WAYLAND_MOVE_SUBSURFACE_BACKPORT
+#include <wayland-egl.h>
+#define private public
+#include <wx/glcanvas.h>
+#undef private
+
+void MoveWaylandSubsurface(wxGLCanvas* win)
+{
+    int x, y;
+    gdk_window_get_origin(win->GTKGetDrawingWindow(), &x, &y);
+    wl_subsurface_set_position(win->m_wlSubsurface, x, y);
+}
 #endif

--- a/src/wx/wayland.h
+++ b/src/wx/wayland.h
@@ -1,1 +1,44 @@
-bool IsItWayland();
+#ifndef VBAM_WAYLAND_H
+#define VBAM_WAYLAND_H
+
+#include <wx/config.h>
+
+class wxGLCanvas; // Forward declare.
+
+#if defined(__WXGTK__)
+#include <gdk/gdk.h>
+
+#ifdef GDK_WINDOWING_WAYLAND
+
+#define HAVE_WAYLAND_SUPPORT
+
+bool IsWayland();
+
+#else
+
+constexpr bool IsWayland() { return false; }
+
+#endif // wayland
+
+// Temporary hack to backport 800d6ed69b from wxWidgets until 3.2.2 is released.
+#if defined(__WXGTK__) && defined(HAVE_EGL) && wxCHECK_VERSION(3, 2, 0) && !wxCHECK_VERSION(3, 2, 2)
+
+#define WAYLAND_MOVE_SUBSURFACE_BACKPORT
+
+void MoveWaylandSubsurface(wxGLCanvas* win);
+
+#else
+
+inline void MoveWaylandSubsurface([[maybe_unused]] wxGLCanvas* win) {};
+
+#endif
+
+#else // gtk
+
+constexpr bool IsWayland() { return false; }
+
+inline void MoveWaylandSubsurface([[maybe_unused]] wxGLCanvas* win) {};
+
+#endif // gtk
+
+#endif // VBAM_WAYLAND_H

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -253,7 +253,7 @@ wxString wxvbamApp::GetAbsolutePath(wxString path)
 }
 
 bool wxvbamApp::OnInit() {
-    using_wayland = IsItWayland();
+    using_wayland = IsWayland();
 
     // use consistent names for config
     SetAppName(_("visualboyadvance-m"));


### PR DESCRIPTION
Backport 800d6ed69b from wxWidgets git to fix resizing the `GLDrawingPanel` in Wayland using the EGL `wxGLCanvas`.

Also rename `IsItWayland()` to `IsWayland()`.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>