### PR TITLE
Add stdint includes

### DIFF
--- a/src/wx/config/option.h
+++ b/src/wx/config/option.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <unordered_set>
 
+#include <stdint.h>
 #include <wx/string.h>
 
 #include "config/option-id.h"

--- a/src/wx/widgets/wx/wxmisc.h
+++ b/src/wx/widgets/wx/wxmisc.h
@@ -2,6 +2,7 @@
 #define WX_MISC_H
 // utility widgets
 
+#include <stdint.h>
 #include <wx/checkbox.h>
 #include <wx/valgen.h>
 


### PR DESCRIPTION
I believe this is needed on newer GCC's

I noticed this when trying to compile on latest Fedora.