### PR TITLE
Fix issues with the DisplayConfig dialog

### DIFF
--- a/src/wx/config/option.cpp
+++ b/src/wx/config/option.cpp
@@ -483,6 +483,36 @@ bool Option::SetGbPalette(const wxString& value) {
     return true;
 }
 
+double Option::GetDoubleMin() const {
+    assert(is_double());
+    return nonstd::get<double>(min_);
+}
+
+double Option::GetDoubleMax() const {
+    assert(is_double());
+    return nonstd::get<double>(max_);
+}
+
+int32_t Option::GetIntMin() const {
+    assert(is_int());
+    return nonstd::get<int32_t>(min_);
+}
+
+int32_t Option::GetIntMax() const {
+    assert(is_int());
+    return nonstd::get<int32_t>(max_);
+}
+
+uint32_t Option::GetUnsignedMin() const {
+    assert(is_unsigned());
+    return nonstd::get<uint32_t>(min_);
+}
+
+uint32_t Option::GetUnsignedMax() const {
+    assert(is_unsigned());
+    return nonstd::get<uint32_t>(max_);
+}
+
 void Option::NextFilter() {
     assert(is_filter());
     const int old_value = static_cast<int>(GetFilter());

--- a/src/wx/config/option.h
+++ b/src/wx/config/option.h
@@ -192,6 +192,14 @@ public:
     bool SetEnumString(const wxString& value);
     bool SetGbPalette(const wxString& value);
 
+    // Min/Max accessors.
+    double GetDoubleMin() const;
+    double GetDoubleMax() const;
+    int32_t GetIntMin() const;
+    int32_t GetIntMax() const;
+    uint32_t GetUnsignedMin() const;
+    uint32_t GetUnsignedMax() const;
+
     // Special convenience modifiers.
     void NextFilter();
     void NextInterframe();

--- a/src/wx/dialogs/display-config.h
+++ b/src/wx/dialogs/display-config.h
@@ -29,11 +29,17 @@ private:
     // owner, `parent` is destroyed. This prevents accidental deletion.
     DisplayConfig(wxWindow* parent);
 
+    // Handler for the wxEVT_SHOW event.
+    void OnDialogShowEvent(wxShowEvent& event);
+
     // Populates the plugin options.
-    void OnDialogShown(wxShowEvent&);
+    void PopulatePluginOptions();
 
     // Stops handling the plugin options.
-    void OnDialogClosed(wxCloseEvent&);
+    void StopPluginHandler();
+
+    // Update the plugin display.
+    void UpdatePlugin(wxCommandEvent& event);
 
     // Displays the new filter name on the screen.
     void OnFilterChanged(config::Option* option);


### PR DESCRIPTION
The DisplayConfig dialog had a few issues:
* The OK/Cancel buttons were not working as expected. The configuration options would be immediately written whenever some control values were changed. The configuration options are now properly being set on a click to OK, and ignored on a click to Cancel.
* The X button works again.
* There is now proper validation for the Display Scale option, validation ensures that the value is in the right range and incorrect data can no longer be input in that field.
* The Direct3D option is now properly enabled on Direct3D builds.