### PR TITLE
Move core options to a struct

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -428,11 +428,9 @@ bool utilWriteBMPFile(const char *fileName, int w, int h, uint8_t *pix)
 }
 #endif /* !__LIBRETRO__ */
 
-extern bool cpuIsMultiBoot;
-
 bool utilIsGBAImage(const char *file)
 {
-        cpuIsMultiBoot = false;
+        coreOptions.cpuIsMultiBoot = false;
         if (strlen(file) > 4) {
                 const char *p = strrchr(file, '.');
 
@@ -441,7 +439,7 @@ bool utilIsGBAImage(const char *file)
                             (_stricmp(p, ".bin") == 0) || (_stricmp(p, ".elf") == 0))
                                 return true;
                         if (_stricmp(p, ".mb") == 0) {
-                                cpuIsMultiBoot = true;
+                                coreOptions.cpuIsMultiBoot = true;
                                 return true;
                         }
                 }
@@ -870,7 +868,7 @@ void utilGBAFindSave(const int size)
         }
         rtcEnable(rtcFound);
         rtcEnableRumble(!rtcFound);
-        saveType = detectedSaveType;
+        coreOptions.saveType = detectedSaveType;
         flashSetSize(flashSize);
 }
 

--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -99,11 +99,6 @@ char path[2048];
 
 dictionary* preferences;
 
-bool cpuIsMultiBoot = false;
-bool mirroringEnable = true;
-bool parseDebug = true;
-bool speedHack = false;
-bool speedup = false;
 const char* batteryDir;
 const char* biosFileNameGB;
 const char* biosFileNameGBA;
@@ -117,36 +112,23 @@ int autoFireMaxCount = 1;
 int autoFrameSkip = 0;
 int autoPatch;
 int captureFormat = 0;
-int cheatsEnabled = true;
 int colorizerHack = 0;
-int cpuDisableSfx = false;
-int cpuSaveType = 0;
 int disableStatusMessages = 0;
 int filter = kStretch2x;
 int frameSkip = 1;
 int fullScreen;
 int ifbType = kIFBNone;
-int layerEnable = 0xff00;
-int layerSettings = 0xff00;
 int openGL;
 int optFlashSize;
 int optPrintUsage;
 int pauseWhenInactive = 0;
 int preparedCheats = 0;
 int rewindTimer = 0;
-int rtcEnabled;
-int saveType = GBA_SAVE_AUTO;
 int showSpeed;
 int showSpeedTransparent;
-int skipBios = 0;
-int skipSaveGameBattery = true;
-int skipSaveGameCheats = false;
-int useBios = 0;
-int winGbPrinterEnabled;
 uint32_t throttle = 100;
 uint32_t speedup_throttle = 100;
 uint32_t speedup_frame_skip = 9;
-bool speedup_throttle_frame_skip = false;
 bool allowKeyboardBackgroundInput = false;
 bool allowJoystickBackgroundInput = true;
 
@@ -179,14 +161,14 @@ struct option argOptions[] = {
 	{ "border-on", no_argument, &gbBorderOn, 1 },
 	{ "capture-format", required_argument, 0, OPT_CAPTURE_FORMAT },
 	{ "cheat", required_argument, 0, OPT_CHEAT },
-	{ "cheats-enabled", no_argument, &cheatsEnabled, 1 },
+	{ "cheats-enabled", no_argument, &coreOptions.cheatsEnabled, 1 },
 	{ "color-option", no_argument, &gbColorOption, 1 },
 	{ "colorizer-hack", no_argument, &colorizerHack, 1 },
 	{ "config", required_argument, 0, 'c' },
-	{ "cpu-disable-sfx", no_argument, &cpuDisableSfx, 1 },
+	{ "cpu-disable-sfx", no_argument, &coreOptions.cpuDisableSfx, 1 },
 	{ "cpu-save-type", required_argument, 0, OPT_CPU_SAVE_TYPE },
 	{ "debug", no_argument, 0, 'd' },
-	{ "disable-sfx", no_argument, &cpuDisableSfx, 1 },
+	{ "disable-sfx", no_argument, &coreOptions.cpuDisableSfx, 1 },
 	{ "disable-status-messages", no_argument, &disableStatusMessages, 1 },
 	{ "dotcode-file-name-load", required_argument, 0, OPT_DOTCODE_FILE_NAME_LOAD },
 	{ "dotcode-file-name-save", required_argument, 0, OPT_DOTCODE_FILE_NAME_SAVE },
@@ -202,7 +184,7 @@ struct option argOptions[] = {
 	{ "gb-emulator-type", required_argument, 0, OPT_GB_EMULATOR_TYPE },
 	{ "gb-frame-skip", required_argument, 0, OPT_GB_FRAME_SKIP },
 	{ "gb-palette-option", required_argument, 0, OPT_GB_PALETTE_OPTION },
-	{ "gb-printer", no_argument, &winGbPrinterEnabled, 1 },
+	{ "gb-printer", no_argument, &coreOptions.winGbPrinterEnabled, 1 },
 	{ "gdb", required_argument, 0, 'G' },
 	{ "help", no_argument, &optPrintUsage, 1 },
 	{ "ifb-filter", required_argument, 0, 'I' },
@@ -213,7 +195,7 @@ struct option argOptions[] = {
 	{ "no-opengl", no_argument, &openGL, 0 },
 	{ "no-patch", no_argument, &autoPatch, 0 },
 	{ "no-pause-when-inactive", no_argument, &pauseWhenInactive, 0 },
-	{ "no-rtc", no_argument, &rtcEnabled, 0 },
+	{ "no-rtc", no_argument, &coreOptions.rtcEnabled, 0 },
 	{ "no-show-speed", no_argument, &showSpeed, 0 },
 	{ "opengl", required_argument, 0, 'O' },
 	{ "opengl-bilinear", no_argument, &openGL, 2 },
@@ -223,32 +205,32 @@ struct option argOptions[] = {
 	{ "pause-when-inactive", no_argument, &pauseWhenInactive, 1 },
 	{ "profile", optional_argument, 0, 'p' },
 	{ "rewind-timer", required_argument, 0, OPT_REWIND_TIMER },
-	{ "rtc", no_argument, &rtcEnabled, 1 },
+	{ "rtc", no_argument, &coreOptions.rtcEnabled, 1 },
 	{ "rtc-enabled", required_argument, 0, OPT_RTC_ENABLED },
-	{ "save-auto", no_argument, &cpuSaveType, 0 },
+	{ "save-auto", no_argument, &coreOptions.cpuSaveType, 0 },
 	{ "save-dir", required_argument, 0, OPT_SAVE_DIR },
-	{ "save-eeprom", no_argument, &cpuSaveType, 1 },
-	{ "save-flash", no_argument, &cpuSaveType, 3 },
-	{ "save-none", no_argument, &cpuSaveType, 5 },
-	{ "save-sensor", no_argument, &cpuSaveType, 4 },
-	{ "save-sram", no_argument, &cpuSaveType, 2 },
+	{ "save-eeprom", no_argument, &coreOptions.cpuSaveType, 1 },
+	{ "save-flash", no_argument, &coreOptions.cpuSaveType, 3 },
+	{ "save-none", no_argument, &coreOptions.cpuSaveType, 5 },
+	{ "save-sensor", no_argument, &coreOptions.cpuSaveType, 4 },
+	{ "save-sram", no_argument, &coreOptions.cpuSaveType, 2 },
 	{ "save-type", required_argument, 0, 't' },
 	{ "screen-shot-dir", required_argument, 0, OPT_SCREEN_SHOT_DIR },
 	{ "show-speed", required_argument, 0, OPT_SHOW_SPEED },
 	{ "show-speed-detailed", no_argument, &showSpeed, 2 },
 	{ "show-speed-normal", no_argument, &showSpeed, 1 },
 	{ "show-speed-transparent", required_argument, 0, OPT_SHOW_SPEED_TRANSPARENT },
-	{ "skip-bios", no_argument, &skipBios, 1 },
-	{ "skip-save-game-battery", no_argument, &skipSaveGameBattery, 1 },
-	{ "skip-save-game-cheats", no_argument, &skipSaveGameCheats, 1 },
+	{ "skip-bios", no_argument, &coreOptions.skipBios, 1 },
+	{ "skip-save-game-battery", no_argument, &coreOptions.skipSaveGameBattery, 1 },
+	{ "skip-save-game-cheats", no_argument, &coreOptions.skipSaveGameCheats, 1 },
 	{ "sound-filtering", required_argument, 0, OPT_SOUND_FILTERING },
 	{ "throttle", required_argument, 0, 'T' },
 	{ "speedup-throttle", required_argument, 0, OPT_SPEEDUP_THROTTLE },
 	{ "speedup-frame-skip", required_argument, 0, OPT_SPEEDUP_FRAME_SKIP },
 	{ "no-speedup-throttle-frame-skip", no_argument, 0, OPT_NO_SPEEDUP_THROTTLE_FRAME_SKIP },
-	{ "use-bios", no_argument, &useBios, 1 },
+	{ "use-bios", no_argument, &coreOptions.useBios, 1 },
 	{ "verbose", required_argument, 0, 'v' },
-	{ "win-gb-printer-enabled", no_argument, &winGbPrinterEnabled, 1 },
+	{ "win-gb-printer-enabled", no_argument, &coreOptions.winGbPrinterEnabled, 1 },
 
 
 	{ NULL, no_argument, NULL, 0 }
@@ -295,8 +277,8 @@ void ValidateConfig()
 	if (filter < kStretch1x || filter >= kInvalidFilter)
 		filter = kStretch2x;
 
-	if (cpuSaveType < 0 || cpuSaveType > 5)
-		cpuSaveType = 0;
+	if (coreOptions.cpuSaveType < 0 || coreOptions.cpuSaveType > 5)
+		coreOptions.cpuSaveType = 0;
 	if (optFlashSize != 0 && optFlashSize != 1)
 		optFlashSize = 0;
 	if (ifbType < kIFBNone || ifbType >= kInvalidIFBFilter)
@@ -322,10 +304,10 @@ void LoadConfig()
 	biosFileNameGBA = ReadPrefString("biosFileGBA");
 	biosFileNameGBC = ReadPrefString("biosFileGBC");
 	captureFormat = ReadPref("captureFormat", 0);
-	cheatsEnabled = ReadPref("cheatsEnabled", 0);
+	coreOptions.cheatsEnabled = ReadPref("cheatsEnabled", 0);
 	colorizerHack = ReadPref("colorizerHack", 0);
-	cpuDisableSfx = ReadPref("disableSfx", 0);
-	cpuSaveType = ReadPrefHex("saveType");
+	coreOptions.cpuDisableSfx = ReadPref("disableSfx", 0);
+	coreOptions.cpuSaveType = ReadPrefHex("saveType");
 	disableStatusMessages = ReadPrefHex("disableStatus");
 	filter = ReadPref("filter", 0);
 	frameSkip = ReadPref("frameSkip", 0);
@@ -347,23 +329,23 @@ void LoadConfig()
 	optFlashSize = ReadPref("flashSize", 0);
 	pauseWhenInactive = ReadPref("pauseWhenInactive", 1);
 	rewindTimer = ReadPref("rewindTimer", 0);
-	rtcEnabled = ReadPref("rtcEnabled", 0);
+	coreOptions.rtcEnabled = ReadPref("rtcEnabled", 0);
 	saveDir = ReadPrefString("saveDir");
 	saveDotCodeFile = ReadPrefString("saveDotCodeFile");
 	screenShotDir = ReadPrefString("screenShotDir");
 	showSpeed = ReadPref("showSpeed", 0);
 	showSpeedTransparent = ReadPref("showSpeedTransparent", 1);
-	skipBios = ReadPref("skipBios", 0);
-	skipSaveGameBattery = ReadPref("skipSaveGameBattery", 1);
-	skipSaveGameCheats = ReadPref("skipSaveGameCheats", 0);
+	coreOptions.skipBios = ReadPref("skipBios", 0);
+	coreOptions.skipSaveGameBattery = ReadPref("skipSaveGameBattery", 1);
+	coreOptions.skipSaveGameCheats = ReadPref("skipSaveGameCheats", 0);
 	soundFiltering = (float)ReadPref("gbaSoundFiltering", 50) / 100.0f;
 	soundInterpolation = ReadPref("gbaSoundInterpolation", 1);
 	throttle = ReadPref("throttle", 100);
 	speedup_throttle = ReadPref("speedupThrottle", 100);
 	speedup_frame_skip = ReadPref("speedupFrameSkip", 9);
-	speedup_throttle_frame_skip = ReadPref("speedupThrottleFrameSkip", 0);
-	useBios = ReadPrefHex("useBiosGBA");
-	winGbPrinterEnabled = ReadPref("gbPrinter", 0);
+	coreOptions.speedup_throttle_frame_skip = ReadPref("speedupThrottleFrameSkip", 0);
+	coreOptions.useBios = ReadPrefHex("useBiosGBA");
+	coreOptions.winGbPrinterEnabled = ReadPref("gbPrinter", 0);
 
 	int soundQuality = (ReadPrefHex("soundQuality", 1));
 	switch (soundQuality) {
@@ -400,7 +382,7 @@ void LoadConfig()
 	else
 		flashSetSize(0x20000);
 
-	rtcEnable(rtcEnabled ? true : false);
+	rtcEnable(coreOptions.rtcEnabled ? true : false);
 	agbPrintEnable(agbPrint ? true : false);
 
 	for (int i = 0; i < 24;) {
@@ -677,7 +659,7 @@ int ReadOpts(int argc, char ** argv)
 				autoFireMaxCount = 1;
 			break;
 		case 'b':
-			useBios = true;
+			coreOptions.useBios = true;
 			if (optarg == NULL) {
 				log("Missing BIOS file name\n");
 				break;
@@ -752,7 +734,7 @@ int ReadOpts(int argc, char ** argv)
 			break;
 #endif
 		case 'N':
-			parseDebug = false;
+			coreOptions.parseDebug = false;
 			break;
 		case 'F':
 			fullScreen = 1;
@@ -809,7 +791,7 @@ int ReadOpts(int argc, char ** argv)
 				int a = atoi(optarg);
 				if (a < 0 || a > 5)
 					a = 0;
-				cpuSaveType = a;
+				coreOptions.cpuSaveType = a;
 			}
 			break;
 		case 'v':
@@ -863,7 +845,7 @@ int ReadOpts(int argc, char ** argv)
 		case OPT_RTC_ENABLED:
 			// --rtc-enabled
 			if (optarg) {
-				rtcEnabled = atoi(optarg);
+				coreOptions.rtcEnabled = atoi(optarg);
 			}
 			break;
 
@@ -949,7 +931,7 @@ int ReadOpts(int argc, char ** argv)
 		case OPT_CPU_SAVE_TYPE:
 			// --cpu-save-type
 			if (optarg) {
-				cpuSaveType = atoi(optarg);
+				coreOptions.cpuSaveType = atoi(optarg);
 			}
 			break;
 
@@ -957,8 +939,8 @@ int ReadOpts(int argc, char ** argv)
 			// --opt-flash-size
 			if (optarg) {
 				optFlashSize = atoi(optarg);
-                                if (optFlashSize < 0 || optFlashSize > 1)
-                                    optFlashSize = 0;
+				if (optFlashSize < 0 || optFlashSize > 1)
+					optFlashSize = 0;
 			}
 			break;
 
@@ -971,17 +953,17 @@ int ReadOpts(int argc, char ** argv)
 			// --dotcode-file-name-save
 			saveDotCodeFile = optarg;
 			break;
-                case OPT_SPEEDUP_THROTTLE:
-                        if (optarg)
-                            speedup_throttle = atoi(optarg);
-                        break;
-                case OPT_SPEEDUP_FRAME_SKIP:
-                        if (optarg)
-                            speedup_frame_skip = atoi(optarg);
-                        break;
-                case OPT_NO_SPEEDUP_THROTTLE_FRAME_SKIP:
-			speedup_throttle_frame_skip = false;
-                        break;
+		case OPT_SPEEDUP_THROTTLE:
+			if (optarg)
+				speedup_throttle = atoi(optarg);
+			break;
+		case OPT_SPEEDUP_FRAME_SKIP:
+			if (optarg)
+				speedup_frame_skip = atoi(optarg);
+			break;
+		case OPT_NO_SPEEDUP_THROTTLE_FRAME_SKIP:
+			coreOptions.speedup_throttle_frame_skip = false;
+			break;
 		}
 	}
 	return op;

--- a/src/common/ConfigManager.h
+++ b/src/common/ConfigManager.h
@@ -20,11 +20,27 @@
 
 #define MAX_CHEATS 16384
 
-extern bool cpuIsMultiBoot;
-extern bool mirroringEnable;
-extern bool parseDebug;
-extern bool speedHack;
-extern bool speedup;
+extern struct CoreOptions {
+    bool cpuIsMultiBoot = false;
+    bool mirroringEnable = true;
+    bool parseDebug = true;
+    bool speedHack = false;
+    bool speedup = false;
+    bool speedup_throttle_frame_skip = false;
+    int cheatsEnabled = 1;
+    int cpuDisableSfx = 0;
+    int cpuSaveType = 0;
+    int layerSettings = 0xff00;
+    int layerEnable = 0xff00;
+    int rtcEnabled = 0;
+    int saveType = 0;
+    int skipBios = 0;
+    int skipSaveGameBattery = 1;
+    int skipSaveGameCheats = 0;
+    int useBios = 0;
+    int winGbPrinterEnabled = 1;
+} coreOptions;
+
 extern const char *biosFileNameGB;
 extern const char *biosFileNameGBA;
 extern const char *biosFileNameGBC;
@@ -35,35 +51,22 @@ extern int autoFireMaxCount;
 extern int autoFrameSkip;
 extern int autoPatch;
 extern int captureFormat;
-extern int cheatsEnabled;
 extern int colorizerHack;
-extern int cpuDisableSfx;
-extern int cpuSaveType;
 extern int disableStatusMessages;
 extern int filter;
 extern int frameSkip;
 extern int fullScreen;
 extern int ifbType;
-extern int layerEnable;
-extern int layerSettings;
 extern int openGL;
 extern int optFlashSize;
 extern int optPrintUsage;
 extern int pauseWhenInactive;
 extern int rewindTimer;
-extern int rtcEnabled;
-extern int saveType;
 extern int showSpeed;
 extern int showSpeedTransparent;
-extern int skipBios;
-extern int skipSaveGameBattery;
-extern int skipSaveGameCheats;
-extern int useBios;
-extern int winGbPrinterEnabled;
 extern uint32_t throttle;
 extern uint32_t speedup_throttle;
 extern uint32_t speedup_frame_skip;
-extern bool speedup_throttle_frame_skip;
 extern bool allowKeyboardBackgroundInput;
 extern bool allowJoystickBackgroundInput;
 

--- a/src/common/SoundSDL.cpp
+++ b/src/common/SoundSDL.cpp
@@ -40,7 +40,7 @@ void SoundSDL::soundCallback(void* data, uint8_t* stream, int len) {
 }
 
 bool SoundSDL::should_wait() {
-    return emulating && !speedup && current_rate && !gba_joybus_active;
+    return emulating && !coreOptions.speedup && current_rate && !gba_joybus_active;
 }
 
 std::size_t SoundSDL::buffer_size() {

--- a/src/gb/gbCheats.cpp
+++ b/src/gb/gbCheats.cpp
@@ -434,7 +434,7 @@ bool gbCheatReadGSCodeFile(const char* fileName)
 // Used to emulated GG codes
 uint8_t gbCheatRead(uint16_t address)
 {
-    if (!cheatsEnabled)
+    if (!coreOptions.cheatsEnabled)
         return gbMemoryMap[address >> 12][address & 0xFFF];
 
     for (int i = 0; i < gbCheatNumber; i++) {
@@ -456,7 +456,7 @@ uint8_t gbCheatRead(uint16_t address)
 // Used to emulate GS codes.
 void gbCheatWrite(bool reboot)
 {
-    if (cheatsEnabled) {
+    if (coreOptions.cheatsEnabled) {
         uint16_t address = 0;
 
         if (gbNextCheat >= gbCheatNumber)

--- a/src/gb/gbGfx.cpp
+++ b/src/gb/gbGfx.cpp
@@ -1,6 +1,7 @@
 #include <memory.h>
 
 #include "../Util.h"
+#include "../common/ConfigManager.h"
 #include "gbGlobals.h"
 #include "gbSGB.h"
 
@@ -42,7 +43,6 @@ uint8_t gbInvertTab[256] = {
 uint16_t gbLineMix[160];
 uint16_t gbWindowColor[160];
 extern int inUseRegister_WY;
-extern int layerSettings;
 
 void gbRenderLine()
 {
@@ -104,7 +104,7 @@ void gbRenderLine()
     int tile_pattern_address = tile_pattern + tile * 16 + by * 2;
 
     if (register_LCDC & 0x80) {
-        if ((register_LCDC & 0x01 || gbCgbMode) && (layerSettings & 0x0100)) {
+        if ((register_LCDC & 0x01 || gbCgbMode) && (coreOptions.layerSettings & 0x0100)) {
             while (x < 160) {
 
                 uint8_t tile_a = 0;
@@ -215,7 +215,7 @@ void gbRenderLine()
         // LCDC.0 also enables/disables the window in !gbCgbMode ?!?!
         // (tested on real hardware)
         // This fixes Last Bible II & Zankurou Musouken
-        if ((register_LCDC & 0x01 || gbCgbMode) && (register_LCDC & 0x20) && (layerSettings & 0x2000) && (gbWindowLine != -2)) {
+        if ((register_LCDC & 0x01 || gbCgbMode) && (register_LCDC & 0x20) && (coreOptions.layerSettings & 0x2000) && (gbWindowLine != -2)) {
             int i = 0;
             // Fix (accurate emulation) for most of the window display problems
             // (ie. Zen - Intergalactic Ninja, Urusei Yatsura...).
@@ -536,7 +536,7 @@ void gbDrawSprites(bool draw)
     if (!(register_LCDC & 0x80))
         return;
 
-    if ((register_LCDC & 2) && (layerSettings & 0x1000)) {
+    if ((register_LCDC & 2) && (coreOptions.layerSettings & 0x1000)) {
         int yc = register_LY;
 
         int address = 0xfe00;

--- a/src/gba/Flash.cpp
+++ b/src/gba/Flash.cpp
@@ -85,16 +85,16 @@ uint8_t flashRead(uint32_t address)
 
 void flashSaveDecide(uint32_t address, uint8_t byte)
 {
-    if (saveType == GBA_SAVE_EEPROM)
+    if (coreOptions.saveType == GBA_SAVE_EEPROM)
         return;
 
     if (cpuSramEnabled && cpuFlashEnabled) {
         if (address == 0x0e005555) {
-            saveType = GBA_SAVE_FLASH;
+            coreOptions.saveType = GBA_SAVE_FLASH;
             cpuSramEnabled = false;
             cpuSaveGameFunc = flashWrite;
         } else {
-            saveType = GBA_SAVE_SRAM;
+            coreOptions.saveType = GBA_SAVE_SRAM;
             cpuFlashEnabled = false;
             cpuSaveGameFunc = sramWrite;
         }
@@ -108,7 +108,7 @@ void flashSaveDecide(uint32_t address, uint8_t byte)
 
 void flashDelayedWrite(uint32_t address, uint8_t byte)
 {
-    saveType = GBA_SAVE_FLASH;
+    coreOptions.saveType = GBA_SAVE_FLASH;
     cpuSaveGameFunc = flashWrite;
     flashWrite(address, byte);
 }

--- a/src/gba/GBA-arm.cpp
+++ b/src/gba/GBA-arm.cpp
@@ -2830,7 +2830,7 @@ static void tester(void) {
 int armExecute()
 {
     do {
-        if (cheatsEnabled) {
+        if (coreOptions.cheatsEnabled) {
             cpuMasterCodeCheck();
         }
 

--- a/src/gba/GBA-thumb.cpp
+++ b/src/gba/GBA-thumb.cpp
@@ -2000,7 +2000,7 @@ static insnfunc_t thumbInsnTable[1024] = {
 int thumbExecute()
 {
     do {
-        if (cheatsEnabled) {
+        if (coreOptions.cheatsEnabled) {
             cpuMasterCodeCheck();
         }
 

--- a/src/gba/GBAGfx.h
+++ b/src/gba/GBAGfx.h
@@ -625,7 +625,7 @@ static inline void gfxDrawSprites(uint32_t* lineOBJ)
     int lineOBJpix = (DISPCNT & 0x20) ? 954 : 1226;
     int m = 0;
     gfxClearArray(lineOBJ);
-    if (layerEnable & 0x1000) {
+    if (coreOptions.layerEnable & 0x1000) {
         uint16_t* sprites = (uint16_t*)oam;
         uint16_t* spritePalette = &((uint16_t*)paletteRAM)[256];
         int mosaicY = ((MOSAIC & 0xF000) >> 12) + 1;
@@ -674,7 +674,7 @@ static inline void gfxDrawSprites(uint32_t* lineOBJ)
             int sx = (a1 & 0x1FF);
 
             // computes ticks used by OBJ-WIN if OBJWIN is enabled
-            if (((a0 & 0x0c00) == 0x0800) && (layerEnable & 0x8000)) {
+            if (((a0 & 0x0c00) == 0x0800) && (coreOptions.layerEnable & 0x8000)) {
                 if ((a0 & 0x0300) == 0x0300) {
                     sizeX <<= 1;
                     sizeY <<= 1;
@@ -1142,7 +1142,7 @@ static inline void gfxDrawSprites(uint32_t* lineOBJ)
 static inline void gfxDrawOBJWin(uint32_t* lineOBJWin)
 {
     gfxClearArray(lineOBJWin);
-    if ((layerEnable & 0x9000) == 0x9000) {
+    if ((coreOptions.layerEnable & 0x9000) == 0x9000) {
         uint16_t* sprites = (uint16_t*)oam;
         // uint16_t *spritePalette = &((uint16_t *)paletteRAM)[256];
         for (int x = 0; x < 128; x++) {

--- a/src/gba/GBAinline.h
+++ b/src/gba/GBAinline.h
@@ -796,7 +796,7 @@ static inline void CPUWriteByte(uint32_t address, uint8_t b)
         goto unwritable;
     case 14:
     case 15:
-        if ((saveType != 5) && ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled)) {
+        if ((coreOptions.saveType != 5) && ((!eepromInUse) | cpuSramEnabled | cpuFlashEnabled)) {
             // if(!cpuEEPROMEnabled && (cpuSramEnabled | cpuFlashEnabled)) {
 
             (*cpuSaveGameFunc)(address, b);

--- a/src/gba/Globals.h
+++ b/src/gba/Globals.h
@@ -26,13 +26,8 @@ extern bool armIrqEnable;
 extern uint32_t armNextPC;
 extern int armMode;
 extern uint32_t stop;
-extern int saveType;
-extern int frameSkip;
 extern bool gba_joybus_enabled;
 extern bool gba_joybus_active;
-extern int layerSettings;
-extern int layerEnable;
-extern int cpuSaveType;
 extern int customBackdropColor;
 
 extern uint8_t* bios;

--- a/src/gba/Mode0.cpp
+++ b/src/gba/Mode0.cpp
@@ -13,19 +13,19 @@ void mode0RenderLine()
         return;
     }
 
-    if (layerEnable & 0x0100) {
+    if (coreOptions.layerEnable & 0x0100) {
         gfxDrawTextScreen(BG0CNT, BG0HOFS, BG0VOFS, line0);
     }
 
-    if (layerEnable & 0x0200) {
+    if (coreOptions.layerEnable & 0x0200) {
         gfxDrawTextScreen(BG1CNT, BG1HOFS, BG1VOFS, line1);
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         gfxDrawTextScreen(BG2CNT, BG2HOFS, BG2VOFS, line2);
     }
 
-    if (layerEnable & 0x0800) {
+    if (coreOptions.layerEnable & 0x0800) {
         gfxDrawTextScreen(BG3CNT, BG3HOFS, BG3VOFS, line3);
     }
 
@@ -125,19 +125,19 @@ void mode0RenderLineNoWindow()
         return;
     }
 
-    if (layerEnable & 0x0100) {
+    if (coreOptions.layerEnable & 0x0100) {
         gfxDrawTextScreen(BG0CNT, BG0HOFS, BG0VOFS, line0);
     }
 
-    if (layerEnable & 0x0200) {
+    if (coreOptions.layerEnable & 0x0200) {
         gfxDrawTextScreen(BG1CNT, BG1HOFS, BG1VOFS, line1);
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         gfxDrawTextScreen(BG2CNT, BG2HOFS, BG2VOFS, line2);
     }
 
-    if (layerEnable & 0x0800) {
+    if (coreOptions.layerEnable & 0x0800) {
         gfxDrawTextScreen(BG3CNT, BG3HOFS, BG3VOFS, line3);
     }
 
@@ -300,7 +300,7 @@ void mode0RenderLineAll()
     bool inWindow0 = false;
     bool inWindow1 = false;
 
-    if (layerEnable & 0x2000) {
+    if (coreOptions.layerEnable & 0x2000) {
         uint8_t v0 = WIN0V >> 8;
         uint8_t v1 = WIN0V & 255;
         inWindow0 = ((v0 == v1) && (v0 >= 0xe8));
@@ -309,7 +309,7 @@ void mode0RenderLineAll()
         else
             inWindow0 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
-    if (layerEnable & 0x4000) {
+    if (coreOptions.layerEnable & 0x4000) {
         uint8_t v0 = WIN1V >> 8;
         uint8_t v1 = WIN1V & 255;
         inWindow1 = ((v0 == v1) && (v0 >= 0xe8));
@@ -319,19 +319,19 @@ void mode0RenderLineAll()
             inWindow1 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
 
-    if ((layerEnable & 0x0100)) {
+    if ((coreOptions.layerEnable & 0x0100)) {
         gfxDrawTextScreen(BG0CNT, BG0HOFS, BG0VOFS, line0);
     }
 
-    if ((layerEnable & 0x0200)) {
+    if ((coreOptions.layerEnable & 0x0200)) {
         gfxDrawTextScreen(BG1CNT, BG1HOFS, BG1VOFS, line1);
     }
 
-    if ((layerEnable & 0x0400)) {
+    if ((coreOptions.layerEnable & 0x0400)) {
         gfxDrawTextScreen(BG2CNT, BG2HOFS, BG2VOFS, line2);
     }
 
-    if ((layerEnable & 0x0800)) {
+    if ((coreOptions.layerEnable & 0x0800)) {
         gfxDrawTextScreen(BG3CNT, BG3HOFS, BG3VOFS, line3);
     }
 

--- a/src/gba/Mode1.cpp
+++ b/src/gba/Mode1.cpp
@@ -14,15 +14,15 @@ void mode1RenderLine()
         return;
     }
 
-    if (layerEnable & 0x0100) {
+    if (coreOptions.layerEnable & 0x0100) {
         gfxDrawTextScreen(BG0CNT, BG0HOFS, BG0VOFS, line0);
     }
 
-    if (layerEnable & 0x0200) {
+    if (coreOptions.layerEnable & 0x0200) {
         gfxDrawTextScreen(BG1CNT, BG1HOFS, BG1VOFS, line1);
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
         if (gfxLastVCOUNT > VCOUNT)
             changed = 3;
@@ -120,15 +120,15 @@ void mode1RenderLineNoWindow()
         return;
     }
 
-    if (layerEnable & 0x0100) {
+    if (coreOptions.layerEnable & 0x0100) {
         gfxDrawTextScreen(BG0CNT, BG0HOFS, BG0VOFS, line0);
     }
 
-    if (layerEnable & 0x0200) {
+    if (coreOptions.layerEnable & 0x0200) {
         gfxDrawTextScreen(BG1CNT, BG1HOFS, BG1VOFS, line1);
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
         if (gfxLastVCOUNT > VCOUNT)
             changed = 3;
@@ -280,7 +280,7 @@ void mode1RenderLineAll()
     bool inWindow0 = false;
     bool inWindow1 = false;
 
-    if (layerEnable & 0x2000) {
+    if (coreOptions.layerEnable & 0x2000) {
         uint8_t v0 = WIN0V >> 8;
         uint8_t v1 = WIN0V & 255;
         inWindow0 = ((v0 == v1) && (v0 >= 0xe8));
@@ -289,7 +289,7 @@ void mode1RenderLineAll()
         else
             inWindow0 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
-    if (layerEnable & 0x4000) {
+    if (coreOptions.layerEnable & 0x4000) {
         uint8_t v0 = WIN1V >> 8;
         uint8_t v1 = WIN1V & 255;
         inWindow1 = ((v0 == v1) && (v0 >= 0xe8));
@@ -299,15 +299,15 @@ void mode1RenderLineAll()
             inWindow1 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
 
-    if (layerEnable & 0x0100) {
+    if (coreOptions.layerEnable & 0x0100) {
         gfxDrawTextScreen(BG0CNT, BG0HOFS, BG0VOFS, line0);
     }
 
-    if (layerEnable & 0x0200) {
+    if (coreOptions.layerEnable & 0x0200) {
         gfxDrawTextScreen(BG1CNT, BG1HOFS, BG1VOFS, line1);
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
         if (gfxLastVCOUNT > VCOUNT)
             changed = 3;

--- a/src/gba/Mode2.cpp
+++ b/src/gba/Mode2.cpp
@@ -14,7 +14,7 @@ void mode2RenderLine()
         return;
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
         if (gfxLastVCOUNT > VCOUNT)
             changed = 3;
@@ -24,7 +24,7 @@ void mode2RenderLine()
             changed, line2);
     }
 
-    if (layerEnable & 0x0800) {
+    if (coreOptions.layerEnable & 0x0800) {
         int changed = gfxBG3Changed;
         if (gfxLastVCOUNT > VCOUNT)
             changed = 3;
@@ -114,7 +114,7 @@ void mode2RenderLineNoWindow()
         return;
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
         if (gfxLastVCOUNT > VCOUNT)
             changed = 3;
@@ -124,7 +124,7 @@ void mode2RenderLineNoWindow()
             changed, line2);
     }
 
-    if (layerEnable & 0x0800) {
+    if (coreOptions.layerEnable & 0x0800) {
         int changed = gfxBG3Changed;
         if (gfxLastVCOUNT > VCOUNT)
             changed = 3;
@@ -262,7 +262,7 @@ void mode2RenderLineAll()
     bool inWindow0 = false;
     bool inWindow1 = false;
 
-    if (layerEnable & 0x2000) {
+    if (coreOptions.layerEnable & 0x2000) {
         uint8_t v0 = WIN0V >> 8;
         uint8_t v1 = WIN0V & 255;
         inWindow0 = ((v0 == v1) && (v0 >= 0xe8));
@@ -271,7 +271,7 @@ void mode2RenderLineAll()
         else
             inWindow0 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
-    if (layerEnable & 0x4000) {
+    if (coreOptions.layerEnable & 0x4000) {
         uint8_t v0 = WIN1V >> 8;
         uint8_t v1 = WIN1V & 255;
         inWindow1 = ((v0 == v1) && (v0 >= 0xe8));
@@ -281,7 +281,7 @@ void mode2RenderLineAll()
             inWindow1 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
         if (gfxLastVCOUNT > VCOUNT)
             changed = 3;
@@ -291,7 +291,7 @@ void mode2RenderLineAll()
             changed, line2);
     }
 
-    if (layerEnable & 0x0800) {
+    if (coreOptions.layerEnable & 0x0800) {
         int changed = gfxBG3Changed;
         if (gfxLastVCOUNT > VCOUNT)
             changed = 3;

--- a/src/gba/Mode3.cpp
+++ b/src/gba/Mode3.cpp
@@ -14,7 +14,7 @@ void mode3RenderLine()
         return;
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
 
         if (gfxLastVCOUNT > VCOUNT)
@@ -96,7 +96,7 @@ void mode3RenderLineNoWindow()
         return;
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
 
         if (gfxLastVCOUNT > VCOUNT)
@@ -219,7 +219,7 @@ void mode3RenderLineAll()
     bool inWindow0 = false;
     bool inWindow1 = false;
 
-    if (layerEnable & 0x2000) {
+    if (coreOptions.layerEnable & 0x2000) {
         uint8_t v0 = WIN0V >> 8;
         uint8_t v1 = WIN0V & 255;
         inWindow0 = ((v0 == v1) && (v0 >= 0xe8));
@@ -228,7 +228,7 @@ void mode3RenderLineAll()
         else
             inWindow0 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
-    if (layerEnable & 0x4000) {
+    if (coreOptions.layerEnable & 0x4000) {
         uint8_t v0 = WIN1V >> 8;
         uint8_t v1 = WIN1V & 255;
         inWindow1 = ((v0 == v1) && (v0 >= 0xe8));
@@ -238,7 +238,7 @@ void mode3RenderLineAll()
             inWindow1 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
 
         if (gfxLastVCOUNT > VCOUNT)

--- a/src/gba/Mode4.cpp
+++ b/src/gba/Mode4.cpp
@@ -14,7 +14,7 @@ void mode4RenderLine()
         return;
     }
 
-    if (layerEnable & 0x400) {
+    if (coreOptions.layerEnable & 0x400) {
         int changed = gfxBG2Changed;
 
         if (gfxLastVCOUNT > VCOUNT)
@@ -95,7 +95,7 @@ void mode4RenderLineNoWindow()
         return;
     }
 
-    if (layerEnable & 0x400) {
+    if (coreOptions.layerEnable & 0x400) {
         int changed = gfxBG2Changed;
 
         if (gfxLastVCOUNT > VCOUNT)
@@ -217,7 +217,7 @@ void mode4RenderLineAll()
     bool inWindow0 = false;
     bool inWindow1 = false;
 
-    if (layerEnable & 0x2000) {
+    if (coreOptions.layerEnable & 0x2000) {
         uint8_t v0 = WIN0V >> 8;
         uint8_t v1 = WIN0V & 255;
         inWindow0 = ((v0 == v1) && (v0 >= 0xe8));
@@ -226,7 +226,7 @@ void mode4RenderLineAll()
         else
             inWindow0 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
-    if (layerEnable & 0x4000) {
+    if (coreOptions.layerEnable & 0x4000) {
         uint8_t v0 = WIN1V >> 8;
         uint8_t v1 = WIN1V & 255;
         inWindow1 = ((v0 == v1) && (v0 >= 0xe8));
@@ -236,7 +236,7 @@ void mode4RenderLineAll()
             inWindow1 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
 
-    if (layerEnable & 0x400) {
+    if (coreOptions.layerEnable & 0x400) {
         int changed = gfxBG2Changed;
 
         if (gfxLastVCOUNT > VCOUNT)

--- a/src/gba/Mode5.cpp
+++ b/src/gba/Mode5.cpp
@@ -14,7 +14,7 @@ void mode5RenderLine()
 
     uint16_t* palette = (uint16_t*)paletteRAM;
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
 
         if (gfxLastVCOUNT > VCOUNT)
@@ -96,7 +96,7 @@ void mode5RenderLineNoWindow()
 
     uint16_t* palette = (uint16_t*)paletteRAM;
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
 
         if (gfxLastVCOUNT > VCOUNT)
@@ -216,7 +216,7 @@ void mode5RenderLineAll()
 
     uint16_t* palette = (uint16_t*)paletteRAM;
 
-    if (layerEnable & 0x0400) {
+    if (coreOptions.layerEnable & 0x0400) {
         int changed = gfxBG2Changed;
 
         if (gfxLastVCOUNT > VCOUNT)
@@ -235,7 +235,7 @@ void mode5RenderLineAll()
     bool inWindow0 = false;
     bool inWindow1 = false;
 
-    if (layerEnable & 0x2000) {
+    if (coreOptions.layerEnable & 0x2000) {
         uint8_t v0 = WIN0V >> 8;
         uint8_t v1 = WIN0V & 255;
         inWindow0 = ((v0 == v1) && (v0 >= 0xe8));
@@ -244,7 +244,7 @@ void mode5RenderLineAll()
         else
             inWindow0 |= (VCOUNT >= v0 || VCOUNT < v1);
     }
-    if (layerEnable & 0x4000) {
+    if (coreOptions.layerEnable & 0x4000) {
         uint8_t v0 = WIN1V >> 8;
         uint8_t v1 = WIN1V & 255;
         inWindow1 = ((v0 == v1) && (v0 >= 0xe8));

--- a/src/gba/RTC.cpp
+++ b/src/gba/RTC.cpp
@@ -217,7 +217,7 @@ bool rtcWrite(uint32_t address, uint16_t value)
                             break;
 
                         case 0x65: {
-                            if (rtcEnabled)
+                            if (coreOptions.rtcEnabled)
                                 SetGBATime();
 
                             rtcClockData.dataLen = 7;
@@ -232,7 +232,7 @@ bool rtcWrite(uint32_t address, uint16_t value)
                         } break;
 
                         case 0x67: {
-                            if (rtcEnabled)
+                            if (coreOptions.rtcEnabled)
                                 SetGBATime();
 
                             rtcClockData.dataLen = 3;

--- a/src/gba/Sram.cpp
+++ b/src/gba/Sram.cpp
@@ -9,7 +9,7 @@ uint8_t sramRead(uint32_t address)
 }
 void sramDelayedWrite(uint32_t address, uint8_t byte)
 {
-    saveType = GBA_SAVE_SRAM;
+    coreOptions.saveType = GBA_SAVE_SRAM;
     cpuSaveGameFunc = sramWrite;
     sramWrite(address, byte);
 }

--- a/src/libretro/UtilRetro.cpp
+++ b/src/libretro/UtilRetro.cpp
@@ -22,24 +22,6 @@
 #define _stricmp strcasecmp
 #endif // ! _MSC_VER
 
-// Because Configmanager was introduced, this has to be done.
-int  rtcEnabled          = 0;
-int  cpuDisableSfx       = 0;
-int  skipBios            = 0;
-int  saveType            = 0;
-int  cpuSaveType         = 0;
-int  skipSaveGameBattery = 0;
-int  skipSaveGameCheats  = 0;
-int  useBios             = 0;
-int  cheatsEnabled       = 0;
-int  layerSettings       = 0xff00;
-int  layerEnable         = 0xff00;
-bool speedup             = false;
-bool parseDebug          = false;
-bool speedHack           = false;
-bool mirroringEnable     = false;
-bool cpuIsMultiBoot      = false;
-
 const char* loadDotCodeFile;
 const char* saveDotCodeFile;
 
@@ -57,11 +39,9 @@ void utilPutWord(uint8_t* p, uint16_t value)
     *p = (value >> 8) & 255;
 }
 
-extern bool cpuIsMultiBoot;
-
 bool utilIsGBAImage(const char* file)
 {
-    cpuIsMultiBoot = false;
+    coreOptions.cpuIsMultiBoot = false;
     if (strlen(file) > 4) {
         const char* p = strrchr(file, '.');
 
@@ -69,7 +49,7 @@ bool utilIsGBAImage(const char* file)
             if ((_stricmp(p, ".agb") == 0) || (_stricmp(p, ".gba") == 0) || (_stricmp(p, ".bin") == 0) || (_stricmp(p, ".elf") == 0))
                 return true;
             if (_stricmp(p, ".mb") == 0) {
-                cpuIsMultiBoot = true;
+                coreOptions.cpuIsMultiBoot = true;
                 return true;
             }
         }
@@ -205,8 +185,8 @@ void utilGBAFindSave(const int size)
     if (detectedSaveType == 4)
         detectedSaveType = 3;
 
-    cpuSaveType = detectedSaveType;
-    rtcEnabled = rtcFound_;
+    coreOptions.cpuSaveType = detectedSaveType;
+    coreOptions.rtcEnabled = rtcFound_;
     flashSize = flashSize_;
 }
 

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -1803,9 +1803,9 @@ EVT_HANDLER(KeepSaves, "Do not load battery saves (toggle)")
 {
     bool menuPress = false;
     GetMenuOptionBool("KeepSaves", &menuPress);
-    toggleBitVar(&menuPress, &skipSaveGameBattery, 1);
+    toggleBitVar(&menuPress, &coreOptions.skipSaveGameBattery, 1);
     SetMenuOption("KeepSaves", menuPress ? 1 : 0);
-    GetMenuOptionInt("KeepSaves", &skipSaveGameBattery, 1);
+    GetMenuOptionInt("KeepSaves", &coreOptions.skipSaveGameBattery, 1);
     update_opts();
 }
 
@@ -1814,9 +1814,9 @@ EVT_HANDLER(KeepCheats, "Do not change cheat list (toggle)")
 {
     bool menuPress = false;
     GetMenuOptionBool("KeepCheats", &menuPress);
-    toggleBitVar(&menuPress, &skipSaveGameCheats, 1);
+    toggleBitVar(&menuPress, &coreOptions.skipSaveGameCheats, 1);
     SetMenuOption("KeepCheats", menuPress ? 1 : 0);
-    GetMenuOptionInt("KeepCheats", &skipSaveGameCheats, 1);
+    GetMenuOptionInt("KeepCheats", &coreOptions.skipSaveGameCheats, 1);
     update_opts();
 }
 
@@ -1990,9 +1990,9 @@ EVT_HANDLER(CheatsEnable, "Enable cheats (toggle)")
 {
     bool menuPress = false;
     GetMenuOptionBool("CheatsEnable", &menuPress);
-    toggleBitVar(&menuPress, &cheatsEnabled, 1);
+    toggleBitVar(&menuPress, &coreOptions.cheatsEnabled, 1);
     SetMenuOption("CheatsEnable", menuPress ? 1 : 0);
-    GetMenuOptionInt("CheatsEnable", &cheatsEnabled, 1);
+    GetMenuOptionInt("CheatsEnable", &coreOptions.cheatsEnabled, 1);
     update_opts();
 }
 
@@ -2018,10 +2018,10 @@ EVT_HANDLER_MASK(VideoLayersBG0, "Video layer BG0 (toggle)", CMDEN_GB | CMDEN_GB
     bool menuPress = false;
     char keyName[] = "VideoLayersBG0";
     GetMenuOptionBool(keyName, &menuPress);
-    toggleBitVar(&menuPress, &layerSettings, (1 << 8));
+    toggleBitVar(&menuPress, &coreOptions.layerSettings, (1 << 8));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, &layerSettings, (1 << 8));
-    layerEnable = DISPCNT & layerSettings;
+    GetMenuOptionInt(keyName, &coreOptions.layerSettings, (1 << 8));
+    coreOptions.layerEnable = DISPCNT & coreOptions.layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
@@ -2030,10 +2030,10 @@ EVT_HANDLER_MASK(VideoLayersBG1, "Video layer BG1 (toggle)", CMDEN_GB | CMDEN_GB
     bool menuPress = false;
     char keyName[] = "VideoLayersBG1";
     GetMenuOptionBool(keyName, &menuPress);
-    toggleBitVar(&menuPress, &layerSettings, (1 << 9));
+    toggleBitVar(&menuPress, &coreOptions.layerSettings, (1 << 9));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, &layerSettings, (1 << 9));
-    layerEnable = DISPCNT & layerSettings;
+    GetMenuOptionInt(keyName, &coreOptions.layerSettings, (1 << 9));
+    coreOptions.layerEnable = DISPCNT & coreOptions.layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
@@ -2042,10 +2042,10 @@ EVT_HANDLER_MASK(VideoLayersBG2, "Video layer BG2 (toggle)", CMDEN_GB | CMDEN_GB
     bool menuPress = false;
     char keyName[] = "VideoLayersBG2";
     GetMenuOptionBool(keyName, &menuPress);
-    toggleBitVar(&menuPress, &layerSettings, (1 << 10));
+    toggleBitVar(&menuPress, &coreOptions.layerSettings, (1 << 10));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, &layerSettings, (1 << 10));
-    layerEnable = DISPCNT & layerSettings;
+    GetMenuOptionInt(keyName, &coreOptions.layerSettings, (1 << 10));
+    coreOptions.layerEnable = DISPCNT & coreOptions.layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
@@ -2054,10 +2054,10 @@ EVT_HANDLER_MASK(VideoLayersBG3, "Video layer BG3 (toggle)", CMDEN_GB | CMDEN_GB
     bool menuPress = false;
     char keyName[] = "VideoLayersBG3";
     GetMenuOptionBool(keyName, &menuPress);
-    toggleBitVar(&menuPress, &layerSettings, (1 << 11));
+    toggleBitVar(&menuPress, &coreOptions.layerSettings, (1 << 11));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, &layerSettings, (1 << 11));
-    layerEnable = DISPCNT & layerSettings;
+    GetMenuOptionInt(keyName, &coreOptions.layerSettings, (1 << 11));
+    coreOptions.layerEnable = DISPCNT & coreOptions.layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
@@ -2066,10 +2066,10 @@ EVT_HANDLER_MASK(VideoLayersOBJ, "Video layer OBJ (toggle)", CMDEN_GB | CMDEN_GB
     bool menuPress = false;
     char keyName[] = "VideoLayersOBJ";
     GetMenuOptionBool(keyName, &menuPress);
-    toggleBitVar(&menuPress, &layerSettings, (1 << 12));
+    toggleBitVar(&menuPress, &coreOptions.layerSettings, (1 << 12));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, &layerSettings, (1 << 12));
-    layerEnable = DISPCNT & layerSettings;
+    GetMenuOptionInt(keyName, &coreOptions.layerSettings, (1 << 12));
+    coreOptions.layerEnable = DISPCNT & coreOptions.layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
@@ -2078,10 +2078,10 @@ EVT_HANDLER_MASK(VideoLayersWIN0, "Video layer WIN0 (toggle)", CMDEN_GB | CMDEN_
     bool menuPress = false;
     char keyName[] = "VideoLayersWIN0";
     GetMenuOptionBool(keyName, &menuPress);
-    toggleBitVar(&menuPress, &layerSettings, (1 << 13));
+    toggleBitVar(&menuPress, &coreOptions.layerSettings, (1 << 13));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, &layerSettings, (1 << 13));
-    layerEnable = DISPCNT & layerSettings;
+    GetMenuOptionInt(keyName, &coreOptions.layerSettings, (1 << 13));
+    coreOptions.layerEnable = DISPCNT & coreOptions.layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
@@ -2090,10 +2090,10 @@ EVT_HANDLER_MASK(VideoLayersWIN1, "Video layer WIN1 (toggle)", CMDEN_GB | CMDEN_
     bool menuPress = false;
     char keyName[] = "VideoLayersWIN1";
     GetMenuOptionBool(keyName, &menuPress);
-    toggleBitVar(&menuPress, &layerSettings, (1 << 14));
+    toggleBitVar(&menuPress, &coreOptions.layerSettings, (1 << 14));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, &layerSettings, (1 << 14));
-    layerEnable = DISPCNT & layerSettings;
+    GetMenuOptionInt(keyName, &coreOptions.layerSettings, (1 << 14));
+    coreOptions.layerEnable = DISPCNT & coreOptions.layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
@@ -2102,10 +2102,10 @@ EVT_HANDLER_MASK(VideoLayersOBJWIN, "Video layer OBJWIN (toggle)", CMDEN_GB | CM
     bool menuPress = false;
     char keyName[] = "VideoLayersOBJWIN";
     GetMenuOptionBool(keyName, &menuPress);
-    toggleBitVar(&menuPress, &layerSettings, (1 << 15));
+    toggleBitVar(&menuPress, &coreOptions.layerSettings, (1 << 15));
     SetMenuOption(keyName, menuPress ? 1 : 0);
-    GetMenuOptionInt(keyName, &layerSettings, (1 << 15));
-    layerEnable = DISPCNT & layerSettings;
+    GetMenuOptionInt(keyName, &coreOptions.layerSettings, (1 << 15));
+    coreOptions.layerEnable = DISPCNT & coreOptions.layerSettings;
     CPUUpdateRenderBuffers(false);
 }
 
@@ -2120,8 +2120,8 @@ EVT_HANDLER_MASK(VideoLayersReset, "Show all video layers", CMDEN_GB | CMDEN_GBA
                 break;                                \
             }                                         \
     } while (0)
-    layerSettings = 0x7f00;
-    layerEnable = DISPCNT & layerSettings;
+    coreOptions.layerSettings = 0x7f00;
+    coreOptions.layerEnable = DISPCNT & coreOptions.layerSettings;
     set_vl("VideoLayersBG0");
     set_vl("VideoLayersBG1");
     set_vl("VideoLayersBG2");
@@ -2491,7 +2491,7 @@ EVT_HANDLER(SpeedupConfigure, "Speedup / Turbo options...")
 
     unsigned save_speedup_throttle            = speedup_throttle;
     unsigned save_speedup_frame_skip          = speedup_frame_skip;
-    bool     save_speedup_throttle_frame_skip = speedup_throttle_frame_skip;
+    bool     save_speedup_throttle_frame_skip = coreOptions.speedup_throttle_frame_skip;
 
     if (ShowModal(dlg) == wxID_OK)
         update_opts();
@@ -2499,7 +2499,7 @@ EVT_HANDLER(SpeedupConfigure, "Speedup / Turbo options...")
         // Restore values if cancel pressed.
         speedup_throttle            = save_speedup_throttle;
         speedup_frame_skip          = save_speedup_frame_skip;
-        speedup_throttle_frame_skip = save_speedup_throttle_frame_skip;
+        coreOptions.speedup_throttle_frame_skip = save_speedup_throttle_frame_skip;
     }
 }
 
@@ -2979,7 +2979,7 @@ EVT_HANDLER(RetainAspect, "Retain aspect ratio when resizing")
 
 EVT_HANDLER(Printer, "Enable printer emulation")
 {
-    GetMenuOptionInt("Printer", &winGbPrinterEnabled, 1);
+    GetMenuOptionInt("Printer", &coreOptions.winGbPrinterEnabled, 1);
 #if (defined __WIN32__ || defined _WIN32)
 #ifndef NO_LINK
     gbSerialFunction = gbStartLink;
@@ -2987,7 +2987,7 @@ EVT_HANDLER(Printer, "Enable printer emulation")
     gbSerialFunction = NULL;
 #endif
 #endif
-    if (winGbPrinterEnabled)
+    if (coreOptions.winGbPrinterEnabled)
         gbSerialFunction = gbPrinterSend;
 
     update_opts();
@@ -3125,7 +3125,7 @@ EVT_HANDLER(PauseWhenInactive, "Pause game when main window loses focus")
 
 EVT_HANDLER(RTC, "Enable RTC (vba-over.ini override is rtcEnabled")
 {
-    GetMenuOptionInt("RTC", &rtcEnabled, 1);
+    GetMenuOptionInt("RTC", &coreOptions.rtcEnabled, 1);
     update_opts();
 }
 
@@ -3137,7 +3137,7 @@ EVT_HANDLER(Transparent, "Draw on-screen messages transparently")
 
 EVT_HANDLER(SkipIntro, "Skip BIOS initialization")
 {
-    GetMenuOptionInt("SkipIntro", &skipBios, 1);
+    GetMenuOptionInt("SkipIntro", &coreOptions.skipBios, 1);
     update_opts();
 }
 

--- a/src/wx/config/internal/option-internal.cpp
+++ b/src/wx/config/internal/option-internal.cpp
@@ -15,6 +15,8 @@
 #include "config/internal/option-internal.h"
 #undef VBAM_OPTION_INTERNAL_INCLUDE
 
+struct CoreOptions coreOptions;
+
 namespace config {
 
 namespace {
@@ -234,14 +236,14 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kPrefBorderAutomatic, &gbBorderAutomatic, 0, 1),
         Option(OptionID::kPrefBorderOn, &gbBorderOn, 0, 1),
         Option(OptionID::kPrefCaptureFormat, &captureFormat, 0, 1),
-        Option(OptionID::kPrefCheatsEnabled, &cheatsEnabled, 0, 1),
+        Option(OptionID::kPrefCheatsEnabled, &coreOptions.cheatsEnabled, 0, 1),
         Option(OptionID::kPrefDisableStatus, &disableStatusMessages, 0,
                1),
         Option(OptionID::kPrefEmulatorType, &gbEmulatorType, 0, 5),
         Option(OptionID::kPrefFlashSize, &optFlashSize, 0, 1),
         Option(OptionID::kPrefFrameSkip, &frameSkip, -1, 9),
         Option(OptionID::kPrefGBPaletteOption, &gbPaletteOption, 0, 2),
-        Option(OptionID::kPrefGBPrinter, &winGbPrinterEnabled, 0, 1),
+        Option(OptionID::kPrefGBPrinter, &coreOptions.winGbPrinterEnabled, 0, 1),
         Option(OptionID::kPrefGDBBreakOnLoad, &gopts.gdb_break_on_load),
         Option(OptionID::kPrefGDBPort, &gopts.gdb_port, 0, 65535),
 #ifndef NO_LINK
@@ -250,15 +252,15 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kPrefMaxScale, &gopts.max_scale, 0, 100),
         Option(OptionID::kPrefPauseWhenInactive, &pauseWhenInactive, 0,
                1),
-        Option(OptionID::kPrefRTCEnabled, &rtcEnabled, 0, 1),
-        Option(OptionID::kPrefSaveType, &cpuSaveType, 0, 5),
+        Option(OptionID::kPrefRTCEnabled, &coreOptions.rtcEnabled, 0, 1),
+        Option(OptionID::kPrefSaveType, &coreOptions.cpuSaveType, 0, 5),
         Option(OptionID::kPrefShowSpeed, &showSpeed, 0, 2),
         Option(OptionID::kPrefShowSpeedTransparent,
                &showSpeedTransparent, 0, 1),
-        Option(OptionID::kPrefSkipBios, &skipBios, 0, 1),
-        Option(OptionID::kPrefSkipSaveGameCheats, &skipSaveGameCheats, 0,
+        Option(OptionID::kPrefSkipBios, &coreOptions.skipBios, 0, 1),
+        Option(OptionID::kPrefSkipSaveGameCheats, &coreOptions.skipSaveGameCheats, 0,
                1),
-        Option(OptionID::kPrefSkipSaveGameBattery, &skipSaveGameBattery,
+        Option(OptionID::kPrefSkipSaveGameBattery, &coreOptions.skipSaveGameBattery,
                0, 1),
         Option(OptionID::kPrefThrottle, &throttle, 0, 450),
         Option(OptionID::kPrefSpeedupThrottle, &speedup_throttle, 0,
@@ -266,7 +268,7 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kPrefSpeedupFrameSkip, &speedup_frame_skip, 0,
                300),
         Option(OptionID::kPrefSpeedupThrottleFrameSkip,
-               &speedup_throttle_frame_skip),
+               &coreOptions.speedup_throttle_frame_skip),
         Option(OptionID::kPrefUseBiosGB, &gopts.use_bios_file_gb),
         Option(OptionID::kPrefUseBiosGBA, &gopts.use_bios_file_gba),
         Option(OptionID::kPrefUseBiosGBC, &gopts.use_bios_file_gbc),

--- a/src/wx/dsound.cpp
+++ b/src/wx/dsound.cpp
@@ -252,7 +252,7 @@ void DirectSound::write(uint16_t* finalWave, int length)
     LPVOID lpvPtr2;
     DWORD dwBytes2 = 0;
 
-    if (!speedup && throttle && !gba_joybus_active) {
+    if (!coreOptions.speedup && throttle && !gba_joybus_active) {
         hr = dsbSecondary->GetStatus(&status);
 
         if (status & DSBSTATUS_PLAYING) {

--- a/src/wx/faudio.cpp
+++ b/src/wx/faudio.cpp
@@ -544,7 +544,7 @@ void FAudio_Output::write(uint16_t* finalWave, int length)
             break;
         } else {
             // the maximum number of buffers is currently queued
-            if (!speedup && throttle && !gba_joybus_active) {
+            if (!coreOptions.speedup && throttle && !gba_joybus_active) {
                 // wait for one buffer to finish playing
                 if (WaitForSingleObject(notify.hBufferEndEvent, 10000) == WAIT_TIMEOUT) {
                     device_changed = true;

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -1513,9 +1513,9 @@ public:
         (void)ev; // unused params
         uint32_t sz = wxGetApp().frame->GetPanel()->game_size();
         utilGBAFindSave(sz);
-        type->SetSelection(saveType);
+        type->SetSelection(coreOptions.saveType);
 
-        if (saveType == GBA_SAVE_FLASH) {
+        if (coreOptions.saveType == GBA_SAVE_FLASH) {
             size->SetSelection(flashSize == 0x20000 ? 1 : 0);
             size->Enable();
         } else {
@@ -2206,7 +2206,7 @@ public:
         if (val == 0) {
             speedup_throttle            = 0;
             speedup_frame_skip          = 0;
-            speedup_throttle_frame_skip = false;
+            coreOptions.speedup_throttle_frame_skip = false;
 
             frame_skip_cb->SetValue(false);
             frame_skip_cb->Disable();
@@ -2223,7 +2223,7 @@ public:
         }
         else { // val > 450
             speedup_throttle            = 100;
-            speedup_throttle_frame_skip = false;
+            coreOptions.speedup_throttle_frame_skip = false;
 
             unsigned rounded = std::round((double)val / 100) * 100;
 
@@ -2252,7 +2252,7 @@ public:
 
         bool checked = frame_skip_cb->GetValue();
 
-        speedup_throttle_frame_skip = prev_frame_skip_cb = checked;
+        coreOptions.speedup_throttle_frame_skip = prev_frame_skip_cb = checked;
     }
 
     void Init(wxShowEvent& ev)
@@ -2264,7 +2264,7 @@ public:
         }
         else {
             speedup_throttle_spin->SetValue(speedup_throttle);
-            frame_skip_cb->SetValue(speedup_throttle_frame_skip);
+            frame_skip_cb->SetValue(coreOptions.speedup_throttle_frame_skip);
 
             if (speedup_throttle != 0)
                 frame_skip_cb->Enable();
@@ -2275,7 +2275,7 @@ public:
         ev.Skip();
     }
 private:
-    bool prev_frame_skip_cb = speedup_throttle_frame_skip;
+    bool prev_frame_skip_cb = coreOptions.speedup_throttle_frame_skip;
 } speedup_throttle_ctrl;
 
 /////////////////////////////
@@ -2869,19 +2869,19 @@ bool MainFrame::BindControls()
         MenuOptionIntMask("SoundChannel4", gopts.sound_en, (1 << 3));
         MenuOptionIntMask("DirectSoundA", gopts.sound_en, (1 << 8));
         MenuOptionIntMask("DirectSoundB", gopts.sound_en, (1 << 9));
-        MenuOptionIntMask("VideoLayersBG0", layerSettings, (1 << 8));
-        MenuOptionIntMask("VideoLayersBG1", layerSettings, (1 << 9));
-        MenuOptionIntMask("VideoLayersBG2", layerSettings, (1 << 10));
-        MenuOptionIntMask("VideoLayersBG3", layerSettings, (1 << 11));
-        MenuOptionIntMask("VideoLayersOBJ", layerSettings, (1 << 12));
-        MenuOptionIntMask("VideoLayersWIN0", layerSettings, (1 << 13));
-        MenuOptionIntMask("VideoLayersWIN1", layerSettings, (1 << 14));
-        MenuOptionIntMask("VideoLayersOBJWIN", layerSettings, (1 << 15));
+        MenuOptionIntMask("VideoLayersBG0", coreOptions.layerSettings, (1 << 8));
+        MenuOptionIntMask("VideoLayersBG1", coreOptions.layerSettings, (1 << 9));
+        MenuOptionIntMask("VideoLayersBG2", coreOptions.layerSettings, (1 << 10));
+        MenuOptionIntMask("VideoLayersBG3", coreOptions.layerSettings, (1 << 11));
+        MenuOptionIntMask("VideoLayersOBJ", coreOptions.layerSettings, (1 << 12));
+        MenuOptionIntMask("VideoLayersWIN0", coreOptions.layerSettings, (1 << 13));
+        MenuOptionIntMask("VideoLayersWIN1", coreOptions.layerSettings, (1 << 14));
+        MenuOptionIntMask("VideoLayersOBJWIN", coreOptions.layerSettings, (1 << 15));
         MenuOptionBool("CheatsAutoSaveLoad", gopts.autoload_cheats);
-        MenuOptionIntMask("CheatsEnable", cheatsEnabled, 1);
+        MenuOptionIntMask("CheatsEnable", coreOptions.cheatsEnabled, 1);
         SetMenuOption("ColorizerHack", colorizerHack ? 1 : 0);
-        MenuOptionIntMask("KeepSaves", skipSaveGameBattery, 1);
-        MenuOptionIntMask("KeepCheats", skipSaveGameCheats, 1);
+        MenuOptionIntMask("KeepSaves", coreOptions.skipSaveGameBattery, 1);
+        MenuOptionIntMask("KeepCheats", coreOptions.skipSaveGameCheats, 1);
         MenuOptionBool("LoadGameAutoLoad", gopts.autoload_state);
         MenuOptionIntMask("JoypadAutofireA", autofire, KEYM_A);
         MenuOptionIntMask("JoypadAutofireB", autofire, KEYM_B);
@@ -3452,7 +3452,7 @@ bool MainFrame::BindControls()
         d = LoadXRCropertySheetDialog("GameBoyAdvanceConfig");
         {
             /// System and peripherals
-            ch = GetValidatedChild<wxChoice, wxGenericValidator>(d, "SaveType", wxGenericValidator(&cpuSaveType));
+            ch = GetValidatedChild<wxChoice, wxGenericValidator>(d, "SaveType", wxGenericValidator(&coreOptions.cpuSaveType));
             BatConfigHandler.type = ch;
             ch = GetValidatedChild<wxChoice, wxGenericValidator>(d, "FlashSize", wxGenericValidator(&optFlashSize));
             BatConfigHandler.size = ch;

--- a/src/wx/openal.cpp
+++ b/src/wx/openal.cpp
@@ -292,7 +292,7 @@ void OpenAL::write(uint16_t* finalWave, int length)
             }
         }
 
-        if (!speedup && throttle && !gba_joybus_active) {
+        if (!coreOptions.speedup && throttle && !gba_joybus_active) {
             // wait until at least one buffer has finished
             while (nBuffersProcessed == 0) {
                 winlog(" waiting...\n");

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -305,8 +305,7 @@ const std::map<config::GameControl, std::set<config::UserInput>> kDefaultBinding
 
 wxAcceleratorEntry_v sys_accels;
 
-// This constructor only works with globally allocated gopts.  It relies on
-// the default value of every non-object to be 0.
+// This constructor only works with globally allocated gopts.
 opts_t::opts_t()
 {
     // handle erroneous thread count values appropriately
@@ -322,7 +321,6 @@ opts_t::opts_t()
     // These are globals being set here.
     frameSkip = -1;
     autoPatch = true;
-    skipSaveGameBattery = true;
 }
 
 // FIXME: simulate MakeInstanceFilename(vbam.ini) using subkeys (Slave%d/*)

--- a/src/wx/xaudio2.cpp
+++ b/src/wx/xaudio2.cpp
@@ -541,7 +541,7 @@ void XAudio2_Output::write(uint16_t* finalWave, int length)
             break;
         } else {
             // the maximum number of buffers is currently queued
-            if (!speedup && throttle && !gba_joybus_active) {
+            if (!coreOptions.speedup && throttle && !gba_joybus_active) {
                 // wait for one buffer to finish playing
                 if (WaitForSingleObject(notify.hBufferEndEvent, 10000) == WAIT_TIMEOUT) {
                     device_changed = true;


### PR DESCRIPTION
Options used by the core emulator were set with global variables. This moves all of the options used by the core emulator into a new struct, shared by all 3 frontends.