### PR TITLE
Move display options to owned_opts

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -765,6 +765,7 @@ set(
     config/option.cpp
     config/user-input.cpp
     dialogs/display-config.cpp
+    widgets/keep-on-top-styler.cpp
     widgets/keyedit.cpp
     widgets/joyedit.cpp
     widgets/option-validator.cpp
@@ -811,6 +812,7 @@ set(
     config/user-input.h
     dialogs/display-config.h
     widgets/dpi-support.h
+    widgets/keep-on-top-styler.h
     widgets/option-validator.h
     widgets/render-plugin.h
     widgets/wx/keyedit.h

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2267,12 +2267,6 @@ EVT_HANDLER(Logging, "Logging...")
 {
     wxDialog* dlg = wxGetApp().frame->logdlg;
     dlg->SetWindowStyle(wxCAPTION | wxRESIZE_BORDER);
-
-    if (gopts.keep_on_top)
-        dlg->SetWindowStyle(dlg->GetWindowStyle() | wxSTAY_ON_TOP);
-    else
-        dlg->SetWindowStyle(dlg->GetWindowStyle() & ~wxSTAY_ON_TOP);
-
     dlg->Show();
     dlg->Raise();
 }
@@ -2741,15 +2735,6 @@ EVT_HANDLER(GameBoyAdvanceConfigure, "Game Boy Advance options...")
 
 EVT_HANDLER_MASK(DisplayConfigure, "Display options...", CMDEN_NREC_ANY)
 {
-    if (gopts.max_threads != 1) {
-        gopts.max_threads = wxThread::GetCPUCount();
-    }
-
-    // Just in case GetCPUCount() returns 0 or -1
-    if (gopts.max_threads < 0) {
-        gopts.max_threads = 1;
-    }
-
     wxDialog* dlg = GetXRCDialog("DisplayConfig");
     if (ShowModal(dlg) != wxID_OK) {
         return;
@@ -2965,18 +2950,12 @@ EVT_HANDLER(wxID_ABOUT, "About...")
 
 EVT_HANDLER(Bilinear, "Use bilinear filter with 3d renderer")
 {
-    GetMenuOptionBool("Bilinear", &gopts.bilinear);
-    // Force new panel with new bilinear option.
-    panel->ResetPanel();
-    update_opts();
+    GetMenuOptionConfig("Bilinear", config::OptionID::kDispBilinear);
 }
 
 EVT_HANDLER(RetainAspect, "Retain aspect ratio when resizing")
 {
-    GetMenuOptionBool("RetainAspect", &gopts.retain_aspect);
-    // Force new panel with new aspect ratio options.
-    panel->ResetPanel();
-    update_opts();
+    GetMenuOptionConfig("RetainAspect", config::OptionID::kDispStretch);
 }
 
 EVT_HANDLER(Printer, "Enable printer emulation")
@@ -3080,15 +3059,7 @@ EVT_HANDLER(ApplyPatches, "Apply IPS/UPS/IPF patches if found")
 
 EVT_HANDLER(KeepOnTop, "Keep window on top")
 {
-    GetMenuOptionBool("KeepOnTop", &gopts.keep_on_top);
-    MainFrame* mf = wxGetApp().frame;
-
-    if (gopts.keep_on_top)
-        mf->SetWindowStyle(mf->GetWindowStyle() | wxSTAY_ON_TOP);
-    else
-        mf->SetWindowStyle(mf->GetWindowStyle() & ~wxSTAY_ON_TOP);
-
-    update_opts();
+    GetMenuOptionConfig("KeepOnTop", config::OptionID::kDispKeepOnTop);
 }
 
 EVT_HANDLER(StatusBar, "Enable status bar")

--- a/src/wx/config/internal/option-internal.cpp
+++ b/src/wx/config/internal/option-internal.cpp
@@ -6,6 +6,7 @@
 
 #include <wx/log.h>
 #include <algorithm>
+#include <limits>
 
 #include "../common/ConfigManager.h"
 #include "../gb/gbGlobals.h"
@@ -145,20 +146,27 @@ wxString AllEnumValuesForArray(const std::array<wxString, SIZE>& input) {
 // static
 std::array<Option, kNbOptions>& Option::All() {
     struct OwnedOptions {
-        double video_scale = 3;
-        wxString filter_plugin = wxEmptyString;
+        /// Display
+        bool bilinear = true;
         Filter filter = Filter::kNone;
+        wxString filter_plugin = wxEmptyString;
         Interframe interframe = Interframe::kNone;
+        bool keep_on_top = false;
+        int32_t max_threads = 0;
 #if defined(NO_OGL)
         RenderMethod render_method = RenderMethod::kSimple;
 #else
         RenderMethod render_method = RenderMethod::kOpenGL;
 #endif
+        double video_scale = 3;
+        bool retain_aspect = true;
+
+        /// Geometry
         bool window_maximized = false;
         uint32_t window_height = 0;
         uint32_t window_width = 0;
-        int window_pos_x = -1;
-        int window_pos_y = -1;
+        int32_t window_pos_x = -1;
+        int32_t window_pos_y = -1;
     };
     static OwnedOptions g_owned_opts;
 
@@ -170,15 +178,15 @@ std::array<Option, kNbOptions>& Option::All() {
     // clang-format off
     static std::array<Option, kNbOptions> g_all_opts = {
         /// Display
-        Option(OptionID::kDispBilinear, &gopts.bilinear),
+        Option(OptionID::kDispBilinear, &g_owned_opts.bilinear),
         Option(OptionID::kDispFilter, &g_owned_opts.filter),
         Option(OptionID::kDispFilterPlugin, &g_owned_opts.filter_plugin),
         Option(OptionID::kDispIFB, &g_owned_opts.interframe),
-        Option(OptionID::kDispKeepOnTop, &gopts.keep_on_top),
-        Option(OptionID::kDispMaxThreads, &gopts.max_threads, 1, 256),
+        Option(OptionID::kDispKeepOnTop, &g_owned_opts.keep_on_top),
+        Option(OptionID::kDispMaxThreads, &g_owned_opts.max_threads, 0, 256),
         Option(OptionID::kDispRenderMethod, &g_owned_opts.render_method),
         Option(OptionID::kDispScale, &g_owned_opts.video_scale, 1, 6),
-        Option(OptionID::kDispStretch, &gopts.retain_aspect),
+        Option(OptionID::kDispStretch, &g_owned_opts.retain_aspect),
 
         /// GB
         Option(OptionID::kGBBiosFile, &gopts.gb_bios),
@@ -270,8 +278,8 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kGeomIsMaximized, &g_owned_opts.window_maximized),
         Option(OptionID::kGeomWindowHeight, &g_owned_opts.window_height, 0, 99999),
         Option(OptionID::kGeomWindowWidth, &g_owned_opts.window_width, 0, 99999),
-        Option(OptionID::kGeomWindowX, &g_owned_opts.window_pos_x, -1, 99999),
-        Option(OptionID::kGeomWindowY, &g_owned_opts.window_pos_y, -1, 99999),
+        Option(OptionID::kGeomWindowX, &g_owned_opts.window_pos_x, std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max()),
+        Option(OptionID::kGeomWindowY, &g_owned_opts.window_pos_y, std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max()),
 
         /// UI
         Option(OptionID::kUIAllowKeyboardBackgroundInput, &allowKeyboardBackgroundInput),

--- a/src/wx/config/option-id.h
+++ b/src/wx/config/option-id.h
@@ -4,7 +4,7 @@
 namespace config {
 
 enum class OptionID {
-    // Display
+    /// Display
     kDispBilinear = 0,
     kDispFilter,
     kDispFilterPlugin,

--- a/src/wx/dialogs/display-config.cpp
+++ b/src/wx/dialogs/display-config.cpp
@@ -18,6 +18,7 @@
 #include "config/option-id.h"
 #include "config/option-proxy.h"
 #include "config/option.h"
+#include "keep-on-top-styler.h"
 #include "rpi.h"
 #include "wayland.h"
 #include "widgets/option-validator.h"
@@ -250,7 +251,8 @@ DisplayConfig::DisplayConfig(wxWindow* parent)
       interframe_observer_(config::OptionID::kDispIFB,
                            std::bind(&DisplayConfig::OnInterframeChanged,
                                      this,
-                                     std::placeholders::_1)) {
+                                     std::placeholders::_1)),
+      keep_on_top_styler_(this) {
 #if !wxCHECK_VERSION(3, 1, 0)
     // This needs to be set before loading any element on the window. This also
     // has no effect since wx 3.1.0, where it became the default.
@@ -337,6 +339,9 @@ void DisplayConfig::OnDialogShowEvent(wxShowEvent& event) {
     } else {
         StopPluginHandler();
     }
+
+    // Let the event propagate.
+    event.Skip();
 }
 
 void DisplayConfig::PopulatePluginOptions() {
@@ -408,6 +413,9 @@ void DisplayConfig::UpdatePlugin(wxCommandEvent& event) {
                             config::Filter::kPlugin);
     plugin_label_->Enable(is_plugin);
     plugin_selector_->Enable(is_plugin);
+
+    // Let the event propagate.
+    event.Skip();
 }
 
 void DisplayConfig::OnFilterChanged(config::Option* option) {

--- a/src/wx/dialogs/display-config.h
+++ b/src/wx/dialogs/display-config.h
@@ -5,6 +5,7 @@
 #include <wx/event.h>
 
 #include "config/option-observer.h"
+#include "widgets/keep-on-top-styler.h"
 
 // Forward declarations.
 class wxChoice;
@@ -55,8 +56,9 @@ private:
     wxChoice* plugin_selector_;
     wxChoice* filter_selector_;
     wxChoice* interframe_selector_;
-    config::OptionsObserver filter_observer_;
-    config::OptionsObserver interframe_observer_;
+    const config::OptionsObserver filter_observer_;
+    const config::OptionsObserver interframe_observer_;
+    const widgets::KeepOnTopStyler keep_on_top_styler_;
 };
 
 }  // namespace dialogs

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -26,6 +26,7 @@
 #include "../gba/CheatSearch.h"
 #include "config/game-control.h"
 #include "config/option.h"
+#include "config/option-proxy.h"
 #include "config/user-input.h"
 #include "dialogs/display-config.h"
 #include "opts.h"
@@ -322,7 +323,7 @@ public:
             wxDialog* subdlg = GetXRCDialog("CheatEdit");
             dlg->SetWindowStyle(wxCAPTION | wxRESIZE_BORDER);
 
-            if (gopts.keep_on_top)
+            if (OPTION(kDispKeepOnTop))
                 subdlg->SetWindowStyle(subdlg->GetWindowStyle() | wxSTAY_ON_TOP);
             else
                 subdlg->SetWindowStyle(subdlg->GetWindowStyle() & ~wxSTAY_ON_TOP);
@@ -545,7 +546,7 @@ public:
         wxDialog* subdlg = GetXRCDialog("CheatEdit");
         dlg->SetWindowStyle(wxCAPTION | wxRESIZE_BORDER);
 
-        if (gopts.keep_on_top)
+        if (OPTION(kDispKeepOnTop))
             subdlg->SetWindowStyle(subdlg->GetWindowStyle() | wxSTAY_ON_TOP);
         else
             subdlg->SetWindowStyle(subdlg->GetWindowStyle() & ~wxSTAY_ON_TOP);
@@ -1075,7 +1076,7 @@ public:
         wxDialog* subdlg = GetXRCDialog("CheatAdd");
         dlg->SetWindowStyle(wxCAPTION | wxRESIZE_BORDER);
 
-        if (gopts.keep_on_top)
+        if (OPTION(kDispKeepOnTop))
             subdlg->SetWindowStyle(subdlg->GetWindowStyle() | wxSTAY_ON_TOP);
         else
             subdlg->SetWindowStyle(subdlg->GetWindowStyle() & ~wxSTAY_ON_TOP);
@@ -3785,7 +3786,7 @@ bool MainFrame::BindControls()
     else
         mf->GetStatusBar()->Hide();
 
-    if (gopts.keep_on_top)
+    if (OPTION(kDispKeepOnTop))
         mf->SetWindowStyle(mf->GetWindowStyle() | wxSTAY_ON_TOP);
     else
         mf->SetWindowStyle(mf->GetWindowStyle() & ~wxSTAY_ON_TOP);

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -23,11 +23,7 @@ extern struct opts_t {
     // I instead organized this by opts.cpp table order
 
     /// Display
-    bool bilinear = true;
     wxVideoMode fs_mode;
-    int max_threads = 0;
-    bool retain_aspect = true;
-    bool keep_on_top = false;
 
     /// GB
     wxString gb_bios;

--- a/src/wx/sys.cpp
+++ b/src/wx/sys.cpp
@@ -1,5 +1,6 @@
 #include "../common/SoundSDL.h"
 #include "config/game-control.h"
+#include "config/option-proxy.h"
 #include "wxvbam.h"
 #include "SDL.h"
 #include <wx/ffile.h>
@@ -777,7 +778,7 @@ public:
     {
         dlg->SetWindowStyle(wxCAPTION | wxRESIZE_BORDER);
 
-        if (gopts.keep_on_top)
+        if (OPTION(kDispKeepOnTop))
             dlg->SetWindowStyle(dlg->GetWindowStyle() | wxSTAY_ON_TOP);
         else
             dlg->SetWindowStyle(dlg->GetWindowStyle() & ~wxSTAY_ON_TOP);

--- a/src/wx/viewers.cpp
+++ b/src/wx/viewers.cpp
@@ -4,11 +4,13 @@
 
 #include "../common/cstdint.h"
 
-#include "../gba/armdis.h"
-#include "viewsupt.h"
-#include "wxvbam.h"
 #include <wx/ffile.h>
 #include <wx/vlbox.h>
+#include "../gba/armdis.h"
+#include "config/option-proxy.h"
+#include "keep-on-top-styler.h"
+#include "viewsupt.h"
+#include "wxvbam.h"
 
 // avoid exporting classes
 namespace Viewers {
@@ -515,8 +517,7 @@ void MainFrame::IOViewer()
             baddialog();                                                \
         cb->SetValidator(wxBoolIntValidator(&systemVerbose, val, val)); \
     } while (0)
-LogDialog::LogDialog()
-{
+LogDialog::LogDialog() : keep_on_top_styler_(this) {
     const wxString dname = wxT("Logging");
 
     if (!wxXmlResource::Get()->LoadDialog(this, wxGetApp().frame, dname))
@@ -727,7 +728,7 @@ public:
         selreg_len->SetValue(s);
         selregion->SetWindowStyle(wxCAPTION | wxRESIZE_BORDER);
 
-        if (gopts.keep_on_top)
+        if (OPTION(kDispKeepOnTop))
             selregion->SetWindowStyle(selregion->GetWindowStyle() | wxSTAY_ON_TOP);
         else
             selregion->SetWindowStyle(selregion->GetWindowStyle() & ~wxSTAY_ON_TOP);
@@ -752,7 +753,7 @@ public:
         selreg_len->SetValue(wxEmptyString);
         selregion->SetWindowStyle(wxCAPTION | wxRESIZE_BORDER);
 
-        if (gopts.keep_on_top)
+        if (OPTION(kDispKeepOnTop))
             selregion->SetWindowStyle(selregion->GetWindowStyle() | wxSTAY_ON_TOP);
         else
             selregion->SetWindowStyle(selregion->GetWindowStyle() & ~wxSTAY_ON_TOP);

--- a/src/wx/widgets/keep-on-top-styler.cpp
+++ b/src/wx/widgets/keep-on-top-styler.cpp
@@ -1,0 +1,44 @@
+#include "widgets/keep-on-top-styler.h"
+
+#include <wx/toplevel.h>
+
+#include "config/option-proxy.h"
+#include "config/option.h"
+
+namespace widgets {
+
+KeepOnTopStyler::KeepOnTopStyler(wxTopLevelWindow* window)
+    : window_(window),
+      on_top_observer_(config::OptionID::kDispKeepOnTop,
+                       std::bind(&KeepOnTopStyler::OnKeepOnTopChanged,
+                                 this,
+                                 std::placeholders::_1)) {
+    assert(window_);
+    window_->Bind(wxEVT_SHOW, &KeepOnTopStyler::OnShow, this);
+}
+
+KeepOnTopStyler::~KeepOnTopStyler() {
+    // Need to manually unbind to stop processing events for this window.
+    window_->Unbind(wxEVT_SHOW, &KeepOnTopStyler::OnShow, this);
+}
+
+void KeepOnTopStyler::OnShow(wxShowEvent& show_event) {
+    if (show_event.IsShown()) {
+        // This must be called when the window is shown or it has no effect.
+        OnKeepOnTopChanged(
+            config::Option::ByID(config::OptionID::kDispKeepOnTop));
+    }
+
+    // Let the event propagate.
+    show_event.Skip();
+}
+
+void KeepOnTopStyler::OnKeepOnTopChanged(config::Option* option) {
+    if (option->GetBool()) {
+        window_->SetWindowStyle(window_->GetWindowStyle() | wxSTAY_ON_TOP);
+    } else {
+        window_->SetWindowStyle(window_->GetWindowStyle() & ~wxSTAY_ON_TOP);
+    }
+}
+
+}  // namespace widgets

--- a/src/wx/widgets/keep-on-top-styler.h
+++ b/src/wx/widgets/keep-on-top-styler.h
@@ -1,0 +1,58 @@
+#ifndef VBAM_WX_DIALOGS_BASE_DIALOG_H_
+#define VBAM_WX_DIALOGS_BASE_DIALOG_H_
+
+#include <wx/event.h>
+
+#include "config/option-observer.h"
+
+// Forward declarations.
+class wxTopLevelWindow;
+
+namespace config {
+class Option;
+}
+
+namespace widgets {
+
+// Helper class to automatically set and unset the wxSTAY_ON_TOP to any
+// top-level window. Simply add it as a private member to any top-level window
+// implementation and pass the reference to the window in the constructor.
+//
+// Sample usage:
+//
+// class MyDialog: public wxDialog {
+// public:
+//     MyDialog() : wxDialog(), keep_on_top_styler_(this) {}
+//     ~MyDialog() override = default;
+
+// private:
+//     KeepOnTopStyler keep_on_top_styler_;
+// };
+class KeepOnTopStyler {
+public:
+    // `window` must outlive this object. The easiest way to do so is to add
+    // this object as a private member of the top-level window.
+    explicit KeepOnTopStyler(wxTopLevelWindow* window);
+    ~KeepOnTopStyler();
+
+    // Disable copy and assignment.
+    KeepOnTopStyler(const KeepOnTopStyler&) = delete;
+    KeepOnTopStyler& operator=(const KeepOnTopStyler&) = delete;
+
+private:
+    // Callback for the `window` wxEVT_SHOW event.
+    void OnShow(wxShowEvent& show_event);
+
+    // Callback fired when the KeepOnTop setting has changed.
+    void OnKeepOnTopChanged(config::Option* option);
+
+    // The non-owned window whose style should be modified.
+    wxTopLevelWindow *const window_;
+
+    // Observer for the KeepOnTop setting changed event.
+    const config::OptionsObserver on_top_observer_;
+};
+
+}  // namespace widgets
+
+#endif  // VBAM_WX_DIALOGS_BASE_DIALOG_H_

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -13,6 +13,7 @@
 
 #include "config/option-observer.h"
 #include "widgets/dpi-support.h"
+#include "widgets/keep-on-top-styler.h"
 #include "wx/joyedit.h"
 #include "wx/keyedit.h"
 #include "wx/sdljoy.h"
@@ -212,7 +213,7 @@ extern bool pause_next;
 class MainFrame : public wxFrame {
 public:
     MainFrame();
-    ~MainFrame();
+    ~MainFrame() override;
 
     bool BindControls();
     void MenuOptionIntMask(const wxString& menuName, int field, int mask);
@@ -361,14 +362,15 @@ private:
     // joystick reader
     wxJoyPoller joy;
     JoystickPoller* jpoll = nullptr;
+    // quicker & more accurate than FindFocus() != NULL
+    bool focused;
+    const widgets::KeepOnTopStyler keep_on_top_styler_;
 
     // helper function for adding menu to accel editor
     void add_menu_accels(wxTreeCtrl* tc, wxTreeItemId& parent, wxMenu* menu);
 
     // for detecting window focus
     void OnActivate(wxActivateEvent&);
-    // quicker & more accurate than FindFocus() != NULL
-    bool focused;
     // may work, may not...  if so, load dropped file
     void OnDropFile(wxDropFilesEvent&);
     // pop up menu in fullscreen mode
@@ -689,6 +691,7 @@ public:
 
 private:
     wxTextCtrl* log;
+    widgets::KeepOnTopStyler keep_on_top_styler_;
     void Save(wxCommandEvent& ev);
     void Clear(wxCommandEvent& ev);
 


### PR DESCRIPTION
This also removes limits on the main window position so it can now be negative. This is necessary on Windows where multiple screens to the left and top of the main screen have negative coordinates. A check at startup ensures we always restore the window within the drawable area.