### PR TITLE
[ConfigManager] Move wx options to g_owned_opts

### DIFF
--- a/src/common/ConfigManager.cpp
+++ b/src/common/ConfigManager.cpp
@@ -110,7 +110,6 @@ int autoFireMaxCount = 1;
 int autoFrameSkip = 0;
 int autoPatch;
 int captureFormat = 0;
-int colorizerHack = 0;
 int disableStatusMessages = 0;
 int filter = kStretch2x;
 int frameSkip = 1;
@@ -124,8 +123,6 @@ int preparedCheats = 0;
 int rewindTimer = 0;
 int showSpeed;
 int showSpeedTransparent;
-bool allowKeyboardBackgroundInput = false;
-bool allowJoystickBackgroundInput = true;
 
 const char* preparedCheatCodes[MAX_CHEATS];
 
@@ -158,7 +155,6 @@ struct option argOptions[] = {
 	{ "cheat", required_argument, 0, OPT_CHEAT },
 	{ "cheats-enabled", no_argument, &coreOptions.cheatsEnabled, 1 },
 	{ "color-option", no_argument, &gbColorOption, 1 },
-	{ "colorizer-hack", no_argument, &colorizerHack, 1 },
 	{ "config", required_argument, 0, 'c' },
 	{ "cpu-disable-sfx", no_argument, &coreOptions.cpuDisableSfx, 1 },
 	{ "cpu-save-type", required_argument, 0, OPT_CPU_SAVE_TYPE },
@@ -289,8 +285,6 @@ void ValidateConfig()
 void LoadConfig()
 {
 	agbPrint = ReadPrefHex("agbPrint");
-	allowKeyboardBackgroundInput = ReadPref("allowKeyboardBackgroundInput", false);
-	allowJoystickBackgroundInput = ReadPref("allowJoystickBackgroundInput", true);
 	autoFireMaxCount = fromDec(ReadPrefString("autoFireMaxCount"));
 	autoFrameSkip = ReadPref("autoFrameSkip", 0);
 	autoPatch = ReadPref("autoPatch", 1);
@@ -300,7 +294,6 @@ void LoadConfig()
 	biosFileNameGBC = ReadPrefString("biosFileGBC");
 	captureFormat = ReadPref("captureFormat", 0);
 	coreOptions.cheatsEnabled = ReadPref("cheatsEnabled", 0);
-	colorizerHack = ReadPref("colorizerHack", 0);
 	coreOptions.cpuDisableSfx = ReadPref("disableSfx", 0);
 	coreOptions.cpuSaveType = ReadPrefHex("saveType");
 	disableStatusMessages = ReadPrefHex("disableStatus");

--- a/src/common/ConfigManager.h
+++ b/src/common/ConfigManager.h
@@ -54,7 +54,6 @@ extern int autoFireMaxCount;
 extern int autoFrameSkip;
 extern int autoPatch;
 extern int captureFormat;
-extern int colorizerHack;
 extern int disableStatusMessages;
 extern int filter;
 extern int frameSkip;
@@ -67,8 +66,6 @@ extern int pauseWhenInactive;
 extern int rewindTimer;
 extern int showSpeed;
 extern int showSpeedTransparent;
-extern bool allowKeyboardBackgroundInput;
-extern bool allowJoystickBackgroundInput;
 
 extern int preparedCheats;
 extern const char *preparedCheatCodes[MAX_CHEATS];

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -1688,30 +1688,21 @@ EVT_HANDLER(JoypadAutoholdStart, "Autohold Start (toggle)")
 
 EVT_HANDLER(AllowKeyboardBackgroundInput, "Allow keyboard background input (toggle)")
 {
-    bool menuPress = false;
-    GetMenuOptionBool("AllowKeyboardBackgroundInput", &menuPress);
-    toggleBooleanVar(&menuPress, &allowKeyboardBackgroundInput);
-    SetMenuOption("AllowKeyboardBackgroundInput", allowKeyboardBackgroundInput ? 1 : 0);
+    GetMenuOptionConfig("AllowKeyboardBackgroundInput",
+                        config::OptionID::kUIAllowKeyboardBackgroundInput);
 
     disableKeyboardBackgroundInput();
-
-    if (allowKeyboardBackgroundInput) {
+    if (OPTION(kUIAllowKeyboardBackgroundInput)) {
         if (panel && panel->panel) {
             enableKeyboardBackgroundInput(panel->panel->GetWindow());
         }
     }
-
-    update_opts();
 }
 
 EVT_HANDLER(AllowJoystickBackgroundInput, "Allow joystick background input (toggle)")
 {
-    bool menuPress = false;
-    GetMenuOptionBool("AllowJoystickBackgroundInput", &menuPress);
-    toggleBooleanVar(&menuPress, &allowJoystickBackgroundInput);
-    SetMenuOption("AllowJoystickBackgroundInput", allowJoystickBackgroundInput ? 1 : 0);
-
-    update_opts();
+    GetMenuOptionConfig("AllowKeyboardBackgroundInput",
+                        config::OptionID::kUIAllowJoystickBackgroundInput);
 }
 
 EVT_HANDLER_MASK(LoadGameRecent, "Load most recent save", CMDEN_SAVST)
@@ -1996,18 +1987,13 @@ EVT_HANDLER(CheatsEnable, "Enable cheats (toggle)")
 
 EVT_HANDLER(ColorizerHack, "Enable Colorizer Hack (toggle)")
 {
-    bool val = false;
-    GetMenuOptionBool("ColorizerHack", &val);
-
-    if (val && gopts.use_bios_file_gb) {
-        wxLogError(_("Cannot use Colorizer Hack when Game Boy BIOS File is enabled."));
-        val = 0;
+    GetMenuOptionConfig("ColorizerHack", config::OptionID::kGBColorizerHack);
+    if (OPTION(kGBColorizerHack) && gopts.use_bios_file_gb) {
+        wxLogError(
+            _("Cannot use Colorizer Hack when Game Boy BIOS File is enabled."));
         SetMenuOption("ColorizerHack", 0);
+        OPTION(kGBColorizerHack) = false;
     }
-
-    colorizerHack = val;
-
-    update_opts();
 }
 
 // Debug menu
@@ -3128,7 +3114,7 @@ EVT_HANDLER(BootRomGB, "Use the specified BIOS file for GB")
     int val = 0;
     GetMenuOptionInt("BootRomGB", &val, 1);
 
-    if (val == 1 && colorizerHack == 1) {
+    if (val == 1 && OPTION(kGBColorizerHack)) {
         wxLogError(_("Cannot use Game Boy BIOS when Colorizer Hack is enabled."));
         val = 0;
         SetMenuOption("BootRomGB", 0);

--- a/src/wx/config/internal/option-internal.cpp
+++ b/src/wx/config/internal/option-internal.cpp
@@ -161,15 +161,23 @@ std::array<Option, kNbOptions>& Option::All() {
         double video_scale = 3;
         bool retain_aspect = true;
 
+        /// GB
+        bool colorizer_hack = false;
+
         /// General
         uint32_t ini_version = kIniLatestVersion;
 
         /// Geometry
+        bool fullscreen = false;
         bool window_maximized = false;
         uint32_t window_height = 0;
         uint32_t window_width = 0;
         int32_t window_pos_x = -1;
         int32_t window_pos_y = -1;
+
+        /// UI
+        bool allow_keyboard_background_input = false;
+        bool allow_joystick_background_input = true;
     };
     static OwnedOptions g_owned_opts;
 
@@ -194,7 +202,7 @@ std::array<Option, kNbOptions>& Option::All() {
         /// GB
         Option(OptionID::kGBBiosFile, &gopts.gb_bios),
         Option(OptionID::kGBColorOption, &gbColorOption, 0, 1),
-        Option(OptionID::kGBColorizerHack, &colorizerHack, 0, 1),
+        Option(OptionID::kGBColorizerHack, &g_owned_opts.colorizer_hack),
         Option(OptionID::kGBLCDFilter, &gopts.gb_lcd_filter),
         Option(OptionID::kGBGBCBiosFile, &gopts.gbc_bios),
         Option(OptionID::kGBPalette0, systemGbPalette),
@@ -278,7 +286,7 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kPrefVsync, &gopts.vsync),
 
         /// Geometry
-        Option(OptionID::kGeomFullScreen, &fullScreen, 0, 1),
+        Option(OptionID::kGeomFullScreen, &g_owned_opts.fullscreen),
         Option(OptionID::kGeomIsMaximized, &g_owned_opts.window_maximized),
         Option(OptionID::kGeomWindowHeight, &g_owned_opts.window_height, 0, 99999),
         Option(OptionID::kGeomWindowWidth, &g_owned_opts.window_width, 0, 99999),
@@ -286,8 +294,8 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kGeomWindowY, &g_owned_opts.window_pos_y, std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max()),
 
         /// UI
-        Option(OptionID::kUIAllowKeyboardBackgroundInput, &allowKeyboardBackgroundInput),
-        Option(OptionID::kUIAllowJoystickBackgroundInput, &allowJoystickBackgroundInput),
+        Option(OptionID::kUIAllowKeyboardBackgroundInput, &g_owned_opts.allow_keyboard_background_input),
+        Option(OptionID::kUIAllowJoystickBackgroundInput, &g_owned_opts.allow_joystick_background_input),
         Option(OptionID::kUIHideMenuBar, &gopts.hide_menu_bar),
 
         /// Sound

--- a/src/wx/config/option-proxy.h
+++ b/src/wx/config/option-proxy.h
@@ -24,7 +24,7 @@ static constexpr std::array<Option::Type, kNbOptions> kOptionsTypes = {
     /// GB
     /*kGBBiosFile*/ Option::Type::kString,
     /*kGBColorOption*/ Option::Type::kInt,
-    /*kGBColorizerHack*/ Option::Type::kInt,
+    /*kGBColorizerHack*/ Option::Type::kBool,
     /*kGBLCDFilter*/ Option::Type::kBool,
     /*kGBGBCBiosFile*/ Option::Type::kString,
     /*kGBPalette0*/ Option::Type::kGbPalette,
@@ -108,7 +108,7 @@ static constexpr std::array<Option::Type, kNbOptions> kOptionsTypes = {
     /*kPrefVsync*/ Option::Type::kBool,
 
     /// Geometry
-    /*kGeomFullScreen*/ Option::Type::kInt,
+    /*kGeomFullScreen*/ Option::Type::kBool,
     /*kGeomIsMaximized*/ Option::Type::kBool,
     /*kGeomWindowHeight*/ Option::Type::kUnsigned,
     /*kGeomWindowWidth*/ Option::Type::kUnsigned,

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2880,7 +2880,7 @@ bool MainFrame::BindControls()
         MenuOptionIntMask("VideoLayersOBJWIN", coreOptions.layerSettings, (1 << 15));
         MenuOptionBool("CheatsAutoSaveLoad", gopts.autoload_cheats);
         MenuOptionIntMask("CheatsEnable", coreOptions.cheatsEnabled, 1);
-        SetMenuOption("ColorizerHack", colorizerHack ? 1 : 0);
+        SetMenuOption("ColorizerHack", OPTION(kGBColorizerHack) ? 1 : 0);
         MenuOptionIntMask("KeepSaves", coreOptions.skipSaveGameBattery, 1);
         MenuOptionIntMask("KeepCheats", coreOptions.skipSaveGameCheats, 1);
         MenuOptionBool("LoadGameAutoLoad", gopts.autoload_state);

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -260,14 +260,14 @@ void GameArea::LoadGame(const wxString& name)
 
 
         // Disable bios loading when using colorizer hack.
-        if (gopts.use_bios_file_gb && colorizerHack) {
+        if (gopts.use_bios_file_gb && OPTION(kGBColorizerHack)) {
             wxLogError(_("Cannot use Game Boy BIOS file when Colorizer Hack is enabled, disabling Game Boy BIOS file."));
             gopts.use_bios_file_gb = false;
             update_opts();
         }
 
         // Set up the core for the colorizer hack.
-        setColorizerHack(colorizerHack);
+        setColorizerHack(OPTION(kGBColorizerHack));
 
         bool use_bios =
             gbCgbMode ? gopts.use_bios_file_gbc : gopts.use_bios_file_gb;
@@ -1148,7 +1148,7 @@ void GameArea::OnIdle(wxIdleEvent& event)
         w->SetSize(wxSize(basic_width, basic_height));
 
         // Allow input while on background
-        if (allowKeyboardBackgroundInput)
+        if (OPTION(kUIAllowKeyboardBackgroundInput))
             enableKeyboardBackgroundInput(w);
 
         if (gopts.max_scale)

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -984,7 +984,7 @@ wxEvtHandler* MainFrame::GetJoyEventHandler()
     if (!panel)
         return nullptr;
 
-    if (allowJoystickBackgroundInput)
+    if (OPTION(kUIAllowJoystickBackgroundInput))
         return panel->GetEventHandler();
 
     return nullptr;


### PR DESCRIPTION
This is a preliminary change towards removing ConfigManager from the wx build. Usage of these options has also been modified in the wx frontend.