### PR TITLE
Fix automatic dynamic frame skipping

### DIFF
--- a/src/System.h
+++ b/src/System.h
@@ -76,7 +76,7 @@ extern void systemPossibleCartridgeRumble(bool);
 extern void updateRumbleFrame();
 extern bool systemCanChangeSoundQuality();
 extern void systemShowSpeed(int);
-extern void system10Frames(int);
+extern void system10Frames();
 extern void systemFrame();
 extern void systemGbBorderOn();
 extern void Sm60FPS_Init();

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -5016,7 +5016,7 @@ void gbEmulate(int ticksToStop)
                             gbSoundTick(soundTicks);
 
                             if ((gbFrameCount % 10) == 0)
-                                system10Frames(60);
+                                system10Frames();
 
                             if (gbFrameCount >= 60) {
                                 uint32_t currentTime = systemGetClock();
@@ -5224,7 +5224,7 @@ void gbEmulate(int ticksToStop)
                         gbSoundTick(soundTicks);
 
                         if ((gbFrameCount % 10) == 0)
-                            system10Frames(60);
+                            system10Frames();
 
                         if (gbFrameCount >= 60) {
                             uint32_t currentTime = systemGetClock();

--- a/src/gba/GBA.cpp
+++ b/src/gba/GBA.cpp
@@ -3859,7 +3859,7 @@ void CPULoop(int ticks)
                             systemFrame();
 
                             if ((count % 10) == 0) {
-                                system10Frames(60);
+                                system10Frames();
                             }
                             if (count == 60) {
                                 uint32_t time = systemGetClock();

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -1896,7 +1896,7 @@ void systemShowSpeed(int)
 {
 }
 
-void system10Frames(int)
+void system10Frames()
 {
 }
 

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -2091,7 +2091,7 @@ void systemFrame()
 {
 }
 
-void system10Frames(int rate)
+void system10Frames()
 {
     uint32_t time = systemGetClock();
     if (!wasPaused && autoFrameSkip) {
@@ -2099,7 +2099,7 @@ void system10Frames(int rate)
         int speed = 100;
 
         if (diff)
-            speed = (1000000 / rate) / diff;
+            speed = (1000000 / 60) / diff;
 
         if (speed >= 98) {
             frameskipadjust++;


### PR DESCRIPTION
The previously used algorithm was too aggressive. This fixes the issue by using the last second data and using a more gentle adjustment curve to prevent huge changes in frame skipping.