### PR TITLE
Lets fix Stuart Little 2 properly (maybe?)

### DIFF
--- a/src/gba/Flash.cpp
+++ b/src/gba/Flash.cpp
@@ -103,6 +103,9 @@ void flashSaveDecide(uint32_t address, uint8_t byte)
             cpuSramEnabled ? "SRAM" : "FLASH", address, byte);
     }
 
+    if (coreOptions.saveType == GBA_SAVE_NONE)
+        return;
+
     (*cpuSaveGameFunc)(address, byte);
 }
 

--- a/src/vba-over.ini
+++ b/src/vba-over.ini
@@ -21,10 +21,6 @@ saveType=1
 [AR8e]
 saveType=1
 
-# Stuart Little 2 (USA, Europe)
-[ASLE]
-saveType=2
-
 # Pokemon - Ruby Version (USA, Europe)
 [AXVE]
 rtcEnabled=1


### PR DESCRIPTION
This game cart may have a flashcontroller but no flashram onboard, the game automatically goes down the Flash Type path and hits a stackoverflow at cpuSaveGameFunc after cpuSramEnabled returns as false

Avoid this condition by exiting flashSaveDecide when GBA_SAVE_NONE

I have tested a number of titles that create Sram, 512 and 1024Mbit flash and they all still seem to just fine.

Closes #1086 