### PR TITLE
Move ConfigManager to SDL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -862,7 +862,6 @@ endif()
 set(
     SRC_MAIN
     src/Util.cpp
-    src/common/ConfigManager.cpp
     src/common/dictionary.c
     src/common/iniparser.c
     src/common/Patch.cpp
@@ -879,7 +878,6 @@ set(
     src/System.h
     src/Util.h
     src/common/array.h
-    src/common/ConfigManager.h
     src/common/dictionary.h
     src/common/iniparser.h
     src/common/memgzio.h
@@ -1015,6 +1013,7 @@ set(
 
 set(
     SRC_SDL
+    src/sdl/ConfigManager.cpp
     src/sdl/SDL.cpp
     src/sdl/filters.cpp
     src/sdl/text.cpp
@@ -1027,6 +1026,7 @@ set(
 
 set(
     HDR_SDL
+    src/sdl/ConfigManager.h
     src/sdl/filters.h
     src/sdl/text.h
     src/sdl/inputSDL.h

--- a/src/System.h
+++ b/src/System.h
@@ -49,6 +49,32 @@ struct EmulatedSystem {
         int emuCount;
 };
 
+extern struct CoreOptions {
+    bool cpuIsMultiBoot = false;
+    bool mirroringEnable = true;
+    bool parseDebug = true;
+    bool speedHack = false;
+    bool speedup = false;
+    bool speedup_throttle_frame_skip = false;
+    int cheatsEnabled = 1;
+    int cpuDisableSfx = 0;
+    int cpuSaveType = 0;
+    int layerSettings = 0xff00;
+    int layerEnable = 0xff00;
+    int rtcEnabled = 0;
+    int saveType = 0;
+    int skipBios = 0;
+    int skipSaveGameBattery = 1;
+    int skipSaveGameCheats = 0;
+    int useBios = 0;
+    int winGbPrinterEnabled = 1;
+    uint32_t speedup_throttle = 100;
+    uint32_t speedup_frame_skip = 9;
+    uint32_t throttle = 100;
+    const char *loadDotCodeFile = nullptr;
+    const char *saveDotCodeFile = nullptr;
+} coreOptions;
+
 extern void log(const char *, ...);
 extern bool systemPauseOnFrame();
 extern void systemGbPrint(uint8_t *, int, int, int, int, int);
@@ -96,6 +122,7 @@ extern int systemVerbose;
 extern int systemFrameSkip;
 extern int systemSaveUpdateCounter;
 extern int systemSpeed;
+#define MAX_CHEATS 16384
 #define SYSTEM_SAVE_UPDATED 30
 #define SYSTEM_SAVE_NOT_UPDATED 0
 #endif // SYSTEM_H

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -9,7 +9,6 @@
 #include "../NLS.h"
 #include "../System.h"
 #include "../Util.h"
-#include "../common/ConfigManager.h"
 #include "../gba/GBALink.h"
 #include "../gba/Sound.h"
 #include "gb.h"

--- a/src/gb/gbCheats.cpp
+++ b/src/gb/gbCheats.cpp
@@ -7,7 +7,6 @@
 #include "../System.h"
 #include "../Util.h"
 
-#include "../common/ConfigManager.h"
 #include "gb.h"
 #include "gbCheats.h"
 #include "gbGlobals.h"

--- a/src/gb/gbCheats.h
+++ b/src/gb/gbCheats.h
@@ -2,7 +2,6 @@
 #define GBCHEATS_H
 
 #include "../System.h"
-#include "../common/ConfigManager.h"
 
 struct gbXxCheat {
     char cheatDesc[100];

--- a/src/gb/gbGfx.cpp
+++ b/src/gb/gbGfx.cpp
@@ -1,7 +1,6 @@
 #include <memory.h>
 
 #include "../Util.h"
-#include "../common/ConfigManager.h"
 #include "gbGlobals.h"
 #include "gbSGB.h"
 

--- a/src/gba/Cheats.h
+++ b/src/gba/Cheats.h
@@ -1,7 +1,9 @@
 #ifndef CHEATS_H
 #define CHEATS_H
 
-#include "../common/ConfigManager.h"
+#include <cstdint>
+
+#include "../System.h"
 
 struct CheatsData {
     int code;

--- a/src/gba/GBA-arm.cpp
+++ b/src/gba/GBA-arm.cpp
@@ -7,7 +7,6 @@
 #include "../NLS.h"
 #include "../System.h"
 #include "../Util.h"
-#include "../common/ConfigManager.h"
 #include "Cheats.h"
 #include "EEprom.h"
 #include "Flash.h"

--- a/src/gba/GBA-thumb.cpp
+++ b/src/gba/GBA-thumb.cpp
@@ -10,7 +10,6 @@
 #include "../NLS.h"
 #include "../System.h"
 #include "../Util.h"
-#include "../common/ConfigManager.h"
 #include "Cheats.h"
 #include "EEprom.h"
 #include "Flash.h"

--- a/src/gba/GBA.cpp
+++ b/src/gba/GBA.cpp
@@ -11,7 +11,6 @@
 #include "../NLS.h"
 #include "../System.h"
 #include "../Util.h"
-#include "../common/ConfigManager.h"
 #include "../common/Port.h"
 #include "Cheats.h"
 #include "EEprom.h"
@@ -35,6 +34,10 @@
 
 #ifdef __GNUC__
 #define _stricmp strcasecmp
+#endif
+
+#ifdef _MSC_VER
+#define strdup _strdup
 #endif
 
 extern int emulating;

--- a/src/libretro/UtilRetro.cpp
+++ b/src/libretro/UtilRetro.cpp
@@ -8,7 +8,6 @@
 #include "System.h"
 #include "Util.h"
 #include "common/Port.h"
-#include "common/ConfigManager.h"
 #include "gba/Flash.h"
 #include "gba/GBA.h"
 #include "gba/Globals.h"

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -16,7 +16,6 @@
 #include "../apu/Gb_Apu.h"
 #include "../apu/Gb_Oscs.h"
 #include "../common/Port.h"
-#include "../common/ConfigManager.h"
 #include "../gba/Cheats.h"
 #include "../gba/EEprom.h"
 #include "../gba/Flash.h"
@@ -65,6 +64,7 @@ static unsigned option_gbPalette = 0;
 static bool option_lcdfilter = false;
 
 // filters
+typedef void (*IFBFilterFunc)(uint8_t*, uint32_t, int, int);
 static IFBFilterFunc ifb_filter_func = NULL;
 
 static unsigned retropad_device[4] = {0};

--- a/src/sdl/ConfigManager.cpp
+++ b/src/sdl/ConfigManager.cpp
@@ -16,10 +16,8 @@ extern "C" {
 #include <sys/stat.h>
 #include <cmath>
 #include <cerrno>
-#include <unistd.h>
 
 #include "../common/Patch.h"
-#include "../common/ConfigManager.h"
 #include "../gba/GBA.h"
 #include "../gba/agbprint.h"
 #include "../gba/Flash.h"

--- a/src/sdl/ConfigManager.h
+++ b/src/sdl/ConfigManager.h
@@ -18,34 +18,6 @@
 #endif
 #endif // ! __GNUC__
 
-#define MAX_CHEATS 16384
-
-extern struct CoreOptions {
-    bool cpuIsMultiBoot = false;
-    bool mirroringEnable = true;
-    bool parseDebug = true;
-    bool speedHack = false;
-    bool speedup = false;
-    bool speedup_throttle_frame_skip = false;
-    int cheatsEnabled = 1;
-    int cpuDisableSfx = 0;
-    int cpuSaveType = 0;
-    int layerSettings = 0xff00;
-    int layerEnable = 0xff00;
-    int rtcEnabled = 0;
-    int saveType = 0;
-    int skipBios = 0;
-    int skipSaveGameBattery = 1;
-    int skipSaveGameCheats = 0;
-    int useBios = 0;
-    int winGbPrinterEnabled = 1;
-    uint32_t speedup_throttle = 100;
-    uint32_t speedup_frame_skip = 9;
-    uint32_t throttle = 100;
-    const char *loadDotCodeFile = nullptr;
-    const char *saveDotCodeFile = nullptr;
-} coreOptions;
-
 extern const char *biosFileNameGB;
 extern const char *biosFileNameGBA;
 extern const char *biosFileNameGBC;

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -46,7 +46,6 @@
 #include "SDL.h"
 
 #include "../Util.h"
-#include "../common/ConfigManager.h"
 #include "../common/Patch.h"
 #include "../gb/gb.h"
 #include "../gb/gbCheats.h"
@@ -60,6 +59,8 @@
 #include "../gba/agbprint.h"
 
 #include "../common/SoundSDL.h"
+
+#include "ConfigManager.h"
 #include "filters.h"
 #include "inputSDL.h"
 #include "text.h"

--- a/src/sdl/inputSDL.cpp
+++ b/src/sdl/inputSDL.cpp
@@ -16,7 +16,7 @@
 // Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include "inputSDL.h"
-#include "../common/ConfigManager.h"
+#include "ConfigManager.h"
 
 #define SDLBUTTONS_NUM 14
 

--- a/src/wx/config/internal/option-internal.cpp
+++ b/src/wx/config/internal/option-internal.cpp
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <limits>
 
-#include "../common/ConfigManager.h"
+#include "../System.h"
 #include "../gb/gbGlobals.h"
 #include "opts.h"
 

--- a/src/wx/faudio.cpp
+++ b/src/wx/faudio.cpp
@@ -544,7 +544,7 @@ void FAudio_Output::write(uint16_t* finalWave, int length)
             break;
         } else {
             // the maximum number of buffers is currently queued
-            if (!coreOptions.speedup && throttle && !gba_joybus_active) {
+            if (!coreOptions.speedup && coreOptions.throttle && !gba_joybus_active) {
                 // wait for one buffer to finish playing
                 if (WaitForSingleObject(notify.hBufferEndEvent, 10000) == WAIT_TIMEOUT) {
                     device_changed = true;

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -25,8 +25,8 @@
 
 #include "../gba/CheatSearch.h"
 #include "config/game-control.h"
-#include "config/option.h"
 #include "config/option-proxy.h"
+#include "config/option.h"
 #include "config/user-input.h"
 #include "dialogs/display-config.h"
 #include "opts.h"
@@ -2881,7 +2881,7 @@ bool MainFrame::BindControls()
         MenuOptionIntMask("VideoLayersOBJWIN", coreOptions.layerSettings, (1 << 15));
         MenuOptionBool("CheatsAutoSaveLoad", gopts.autoload_cheats);
         MenuOptionIntMask("CheatsEnable", coreOptions.cheatsEnabled, 1);
-        SetMenuOption("ColorizerHack", OPTION(kGBColorizerHack) ? 1 : 0);
+        SetMenuOption("ColorizerHack", OPTION(kGBColorizerHack));
         MenuOptionIntMask("KeepSaves", coreOptions.skipSaveGameBattery, 1);
         MenuOptionIntMask("KeepCheats", coreOptions.skipSaveGameCheats, 1);
         MenuOptionBool("LoadGameAutoLoad", gopts.autoload_state);

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -26,6 +26,8 @@
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
 
+#include "../gba/remote.h"
+
 // The built-in xrc file
 #include "builtin-xrc.h"
 
@@ -41,7 +43,14 @@
 namespace {
 static const wxString kOldConfigFileName("vbam.conf");
 static const wxString knewConfigFileName("vbam.ini");
+static const char kDotDir[] = "visualboyadvance-m";
 }  // namespace
+
+#ifndef NO_DEBUGGER
+void(*dbgMain)() = remoteStubMain;
+void(*dbgSignal)(int, int) = remoteStubSignal;
+void(*dbgOutput)(const char *, uint32_t) = debuggerOutput;
+#endif
 
 #ifdef __WXMSW__
 
@@ -743,21 +752,17 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
         }
     }
 
-    home = strdup(wxString(wxApp::argv[0]).char_str());
-    SetHome(home);
-    LoadConfig(); // Parse command line arguments (overrides ini)
-    ReadOpts(argc, (char**)argv);
     return true;
 }
 
 wxString wxvbamApp::GetConfigDir()
 {
-    return GetAbsolutePath(wxString((get_xdg_user_config_home() + DOT_DIR).c_str(), wxConvLibc));
+    return GetAbsolutePath(wxString((get_xdg_user_config_home() + kDotDir).c_str(), wxConvLibc));
 }
 
 wxString wxvbamApp::GetDataDir()
 {
-    return GetAbsolutePath(wxString((get_xdg_user_data_home() + DOT_DIR).c_str(), wxConvLibc));
+    return GetAbsolutePath(wxString((get_xdg_user_data_home() + kDotDir).c_str(), wxConvLibc));
 }
 
 wxvbamApp::~wxvbamApp() {
@@ -929,7 +934,7 @@ wxString MainFrame::GetGamePath(wxString path)
 
     if (!wxIsWritable(game_path))
     {
-        game_path = wxGetApp().GetAbsolutePath(wxString((get_xdg_user_data_home() + DOT_DIR).c_str(), wxConvLibc));
+        game_path = wxGetApp().GetAbsolutePath(wxString((get_xdg_user_data_home() + kDotDir).c_str(), wxConvLibc));
         wxFileName::Mkdir(game_path, 0777, wxPATH_MKDIR_FULL);
     }
 


### PR DESCRIPTION
This removes ConfigManager from common source and header files and moves it to be only used by the SDL frontend.