### PR TITLE
Sanitize allocations in the Game Boy emulator

### DIFF
--- a/src/common/sizes.h
+++ b/src/common/sizes.h
@@ -21,4 +21,33 @@ constexpr size_t k2MiB = 2 * k1MiB;
 constexpr size_t k4MiB = 2 * k2MiB;
 constexpr size_t k8MiB = 2 * k4MiB;
 
+// Game Boy BIOS Sizes.
+constexpr size_t kGBBiosSize = k256B;
+constexpr size_t kCGBBiosSize = k2KiB + k256B;
+
+// Size of the buffer containing the BIOS, we alawys use the larger size.
+constexpr size_t kGBBiosBufferSize = kCGBBiosSize;
+
+// Game Boy-related screen sizes.
+constexpr size_t kGBWidth = 160;
+constexpr size_t kGBHeight = 144;
+constexpr size_t kSGBWidth = 256;
+constexpr size_t kSGBHeight = 224;
+#ifdef __LIBRETRO__
+constexpr size_t kGBPixSize = 4 * kSGBWidth * kSGBHeight;
+#else
+// Some of the filters and interframe blenders write beyond the end of the line
+// or the screen, so we allocate extra space here.
+constexpr size_t kGBPixSize = 4 * (kSGBWidth + 1) * (kSGBHeight + 2);
+#endif
+
+// Game Boy VRAM is 16 KiB.
+constexpr size_t kGBVRamSize = k16KiB;
+
+// Game Boy WRAM is 32 KiB.
+constexpr size_t kGBWRamSize = k32KiB;
+
+// A Game Boy line buffer size is the width of the screen at 2 bytes per pizel.
+constexpr size_t kGBLineBufferSize = kGBWidth * 2;
+
 #endif  // VBAM_COMMON_SIZES_H_

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -5636,14 +5636,14 @@ bool gbReadSaveState(const uint8_t* data)
             gbVram = (uint8_t*)calloc(1, kGBVRamSize);
             if (gbVram == nullptr) {
                 assert(false);
-                return;
+                return false;
             }
         }
         if (gbWram == nullptr) {
             gbWram = (uint8_t*)malloc(kGBWRamSize);
             if (gbWram == nullptr) {
                 assert(false);
-                return;
+                return false;
             }
         }
         memset(gbPalette, 0, sizeof(gbPalette));
@@ -5790,7 +5790,7 @@ bool gbReadSaveState(const uint8_t* data)
     }
 
     if (gbCgbMode) {
-        utilReadMem(gbVram, data, kGBVramSize);
+        utilReadMem(gbVram, data, kGBVRamSize);
         utilReadMem(gbWram, data, kGBWRamSize);
 
         int value = register_SVBK;

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -114,6 +114,7 @@ bool gbInitializeRom(size_t romSize) {
         switch (g_gbCartData.validity()) {
             case gbCartData::Validity::kValid:
             case gbCartData::Validity::kUninitialized:
+                // Unreachable.
                 assert(false);
                 break;
             case gbCartData::Validity::kSizeTooSmall:
@@ -157,7 +158,6 @@ bool gbInitializeRom(size_t romSize) {
     if (romSize < romHeaderSize) {
         uint8_t* gbRomNew = (uint8_t*)realloc(gbRom, romHeaderSize);
         if (!gbRomNew) {
-            assert(false);
             return false;
         };
         gbRom = gbRomNew;
@@ -230,7 +230,6 @@ bool gbInitializeRom(size_t romSize) {
             if (gbTAMA5ram == nullptr) {
                 gbTAMA5ram = (uint8_t*)calloc(1, kTama5RamSize);
                 if (gbTAMA5ram == nullptr) {
-                    assert(false);
                     return false;
                 }
             }
@@ -258,7 +257,6 @@ bool gbInitializeRom(size_t romSize) {
     if (ramSize > 0) {
         gbRam = (uint8_t*)malloc(ramSize);
         if (gbRam == nullptr) {
-            assert(false);
             return false;
         }
         memset(gbRam, gbRamFill, ramSize);
@@ -270,19 +268,16 @@ bool gbInitializeRom(size_t romSize) {
 
     gbMemory = (uint8_t*)malloc(65536);
     if (gbMemory == nullptr) {
-        assert(false);
         return false;
     }
 
     pix = (uint8_t*)calloc(1, kGBPixSize);
     if (pix == nullptr) {
-        assert(false);
         return false;
     }
 
     gbLineBuffer = (uint16_t*)malloc(kGBLineBufferSize);
     if (gbLineBuffer == nullptr) {
-        assert(false);
         return false;
     }
 
@@ -2514,14 +2509,12 @@ void gbReset()
         if (gbVram == nullptr) {
             gbVram = (uint8_t*)calloc(1, kGBVRamSize);
             if (gbVram == nullptr) {
-                assert(false);
                 return;
             }
         }
         if (gbWram == nullptr) {
             gbWram = (uint8_t*)malloc(kGBWRamSize);
             if (gbWram == nullptr) {
-                assert(false);
                 return;
             }
         }
@@ -3996,14 +3989,12 @@ static bool gbReadSaveState(gzFile gzFile)
         if (gbVram == nullptr) {
             gbVram = (uint8_t*)calloc(1, kGBVRamSize);
             if (gbVram == nullptr) {
-                assert(false);
                 return false;
             }
         }
         if (gbWram == nullptr) {
             gbWram = (uint8_t*)malloc(kGBWRamSize);
             if (gbWram == nullptr) {
-                assert(false);
                 return false;
             }
         }
@@ -4293,8 +4284,10 @@ static bool gbReadSaveState(gzFile gzFile)
 
     systemSaveUpdateCounter = SYSTEM_SAVE_NOT_UPDATED;
 
-    if (version >= 12 && utilReadInt(gzFile) != 0x12345678)
-        assert(false); // fails if something read too much/little from file
+    if (version >= 12 && utilReadInt(gzFile) != 0x12345678) {
+        // fails if something read too much/little from file
+        return false;
+    }
 
     return true;
 }
@@ -4418,7 +4411,6 @@ bool gbLoadRom(const char* filename) {
     }
     bios = (uint8_t*)calloc(1, kGBBiosBufferSize);
     if (bios == nullptr) {
-        assert(false);
         return false;
     }
 
@@ -5479,7 +5471,6 @@ bool gbLoadRomData(const char* data, size_t size) {
 
     gbRom = (uint8_t*)calloc(1, size);
     if (gbRom == nullptr) {
-        assert(false);
         return false;
     }
 
@@ -5494,7 +5485,6 @@ bool gbLoadRomData(const char* data, size_t size) {
 
     bios = (uint8_t*)calloc(1, kGBBiosBufferSize);
     if (bios == nullptr) {
-        assert(false);
         return false;
     }
     return gbInitializeRom(size);
@@ -5635,14 +5625,12 @@ bool gbReadSaveState(const uint8_t* data)
         if (gbVram == nullptr) {
             gbVram = (uint8_t*)calloc(1, kGBVRamSize);
             if (gbVram == nullptr) {
-                assert(false);
                 return false;
             }
         }
         if (gbWram == nullptr) {
             gbWram = (uint8_t*)malloc(kGBWRamSize);
             if (gbWram == nullptr) {
-                assert(false);
                 return false;
             }
         }
@@ -5831,8 +5819,10 @@ bool gbReadSaveState(const uint8_t* data)
 
     systemSaveUpdateCounter = SYSTEM_SAVE_NOT_UPDATED;
 
-    if (version >= 12 && utilReadIntMem(data) != 0x12345678)
-        assert(false); // fails if something read too much/little from file
+    if (version >= 12 && utilReadIntMem(data) != 0x12345678) {
+        // fails if something read too much/little from file
+        return false;
+    }
 
     return true;
 }

--- a/src/gb/gbCartData.cpp
+++ b/src/gb/gbCartData.cpp
@@ -391,6 +391,10 @@ gbCartData::gbCartData(const uint8_t* romData, size_t romDataSize) {
                 ram_size_ = k128KiB;
                 break;
             case 0x05:
+                // Technically, this refers to a 1 Mbit (128 KiB) RAM chip, but
+                // this is only used in Pocket Monsters Crystal JP, which has a
+                // mapper chip referred as "MBC30". This mapper can only address
+                // half of the RAM chip. So, we set the size to 64 KiB.
                 ram_size_ = k64KiB;
                 break;
             default:

--- a/src/gb/gbGlobals.cpp
+++ b/src/gb/gbGlobals.cpp
@@ -8,13 +8,13 @@ int gbRomSize = 0;
 int gbRamSizeMask = 0;
 int gbRamSize = 0;
 
-uint8_t* gbMemory = NULL;
-uint8_t* gbVram = NULL;
-uint8_t* gbRom = NULL;
-uint8_t* gbRam = NULL;
-uint8_t* gbWram = NULL;
-uint16_t* gbLineBuffer = NULL;
-uint8_t* gbTAMA5ram = NULL;
+uint8_t* gbMemory = nullptr;
+uint8_t* gbVram = nullptr;
+uint8_t* gbRom = nullptr;
+uint8_t* gbRam = nullptr;
+uint8_t* gbWram = nullptr;
+uint16_t* gbLineBuffer = nullptr;
+uint8_t* gbTAMA5ram = nullptr;
 
 uint16_t gbPalette[128];
 uint8_t gbBgp[4] = { 0, 1, 2, 3 };


### PR DESCRIPTION
This adds asserts for every allocation failure in the core Game Boy emulator. In addition, this replaces some magic values defined constant expressions and removes an unused function.