### PR TITLE
Refactor the save/load state and battery code

### DIFF
--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -58,10 +58,6 @@ struct VBamIoVec {
 };
 std::vector<VBamIoVec> g_vbamIoVecs;
 
-// TODO: This is set to 256 bytes for compatibility with older versions. We
-// should figure out how to actually get the MBC7 RAM size.
-static constexpr size_t kMbc7RamSizeForSaving = k256B;
-
 void ResetMBC3RTC() {
     time(&gbDataMBC3.mapperLastTime);
     struct tm* lt;
@@ -472,17 +468,12 @@ bool gbInitializeRom(size_t romSize) {
                                         HUC3_RTC_DATA_SIZE, -4,
                                         &ResetHuc3RTC});
                 break;
-            case gbCartData::MapperType::kMbc7:
-                // For MBC7, we don't save the RAM data from the same location.
-                // TODO: Unify handling and find how to get the MBC7 RAM size.
-                g_vbamIoVecs.clear();
-                g_vbamIoVecs.push_back({&gbMemory[0xa000], kMbc7RamSizeForSaving});
-                break;
             case gbCartData::MapperType::kNone:
             case gbCartData::MapperType::kMbc1:
             case gbCartData::MapperType::kMbc2:
             case gbCartData::MapperType::kMbc5:
             case gbCartData::MapperType::kMbc6:
+            case gbCartData::MapperType::kMbc7:
             case gbCartData::MapperType::kHuC1:
             case gbCartData::MapperType::kMmm01:
             case gbCartData::MapperType::kPocketCamera:
@@ -3181,13 +3172,12 @@ bool gbReadGSASnapshot(const char* fileName)
             case gbCartData::MapperType::kMbc1:
             case gbCartData::MapperType::kMbc3:
             case gbCartData::MapperType::kMbc5:
+            case gbCartData::MapperType::kMbc7:
             case gbCartData::MapperType::kHuC1:
                 FREAD_UNCHECKED(gbRam, 1, g_gbCartData.ram_size(), file);
                 break;
             case gbCartData::MapperType::kMbc2:
-            case gbCartData::MapperType::kMbc7:
-                // TODO: Figure out how to get the RAM size for MBC7.
-                FREAD_UNCHECKED(&gbMemory[0xa000], 1, kMbc7RamSizeForSaving, file);
+                FREAD_UNCHECKED(&gbMemory[0xa000], 1, k256B, file);
                 break;
             default:
                 systemMessage(MSG_UNSUPPORTED_SNAPSHOT_FILE,

--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -44,7 +44,6 @@ bool gbApplyPatch(const char* patchName);
 
 void gbEmulate(int);
 void gbWriteMemory(uint16_t, uint8_t);
-void gbDrawLine();
 bool gbIsGameboyRom(const char*);
 void gbGetHardwareType();
 
@@ -56,21 +55,7 @@ void gbResetPalette();
 void gbReset();
 void gbCleanUp();
 void gbCPUInit(const char*, bool);
-#ifdef __LIBRETRO__
-unsigned int gbWriteSaveState(uint8_t*, unsigned);
-bool gbReadSaveState(const uint8_t*, unsigned);
-#else
-bool gbWriteSaveState(const char*);
-bool gbReadSaveState(const char*);
-#endif
-bool gbWriteBatteryFile(const char*);
-bool gbWriteBatteryFile(const char*, bool);
-bool gbReadBatteryFile(const char*);
-bool gbWriteMemSaveState(char*, int, long&);
-bool gbReadMemSaveState(char*, int);
 void gbSgbRenderBorder();
-bool gbWritePNGFile(const char*);
-bool gbWriteBMPFile(const char*);
 bool gbReadGSASnapshot(const char*);
 
 // Allows invalid vram/palette access needed for Colorizer hacked games in GBC/GBA hardware

--- a/src/gb/gbCartData.cpp
+++ b/src/gb/gbCartData.cpp
@@ -356,8 +356,10 @@ gbCartData::gbCartData(const uint8_t* romData, size_t romDataSize) {
             break;
         case 0x22:
             // MBC7 header does not specify a RAM size so set it here.
+            // TODO: Figure out how to get the RAM size for MBC7. It is either
+            // 256 or 512 Bytes.
             mapper_type_ = MapperType::kMbc7;
-            ram_size_ = k256B;
+            ram_size_ = k512B;
             skip_ram = true;
             has_battery_ = true;
             has_rumble_ = true;

--- a/src/gb/gbCartData.cpp
+++ b/src/gb/gbCartData.cpp
@@ -357,7 +357,7 @@ gbCartData::gbCartData(const uint8_t* romData, size_t romDataSize) {
         case 0x22:
             // MBC7 header does not specify a RAM size so set it here.
             mapper_type_ = MapperType::kMbc7;
-            ram_size_ = k512B;
+            ram_size_ = k256B;
             skip_ram = true;
             has_battery_ = true;
             has_rumble_ = true;
@@ -496,6 +496,12 @@ gbCartData::gbCartData(const uint8_t* romData, size_t romDataSize) {
     // The global checksum value is computed here. This does not fail the header
     // verification as it does not on actual hardware either.
     actual_global_checksum_ = get_rom_checksum(romData, romDataSize);
+
+    if (has_battery_ && !has_rtc_ && ram_size_ == 0) {
+        // Some homebrew ROMs have the battery flag set but no RAM or RTC. This
+        // is probably a mistake, so we ignore the battery flag.
+        has_battery_ = false;
+    }
 
     validity_ = Validity::kValid;
 }

--- a/src/gb/gbCartData.cpp
+++ b/src/gb/gbCartData.cpp
@@ -356,10 +356,18 @@ gbCartData::gbCartData(const uint8_t* romData, size_t romDataSize) {
             break;
         case 0x22:
             // MBC7 header does not specify a RAM size so set it here.
-            // TODO: Figure out how to get the RAM size for MBC7. It is either
-            // 256 or 512 Bytes.
             mapper_type_ = MapperType::kMbc7;
-            ram_size_ = k512B;
+            if (header->rom_size == 0x05) {
+                // Kirby Tilt 'n' Tumble / Korokoro Kirby.
+                ram_size_ = k256B;
+            } else if (header->rom_size == 0x06) {
+                // Command Master.
+                ram_size_ = k512B;
+            } else {
+                // Not a licensed MBC7 cart. Default to the larger size and hope
+                // for the best.
+                ram_size_ = k512B;
+            }
             skip_ram = true;
             has_battery_ = true;
             has_rumble_ = true;


### PR DESCRIPTION
* Simplifies most of the GB save/load state code and changes many of the global variable uses to go through gbCartData instead.
* Changes all battery reads to use gzFiles. This seems to have been an oversight in an earlier refactor of the code.
* Removes some unused variables and stops exporting internal-only functions in GB.cpp/gb.h.

Breaking change: Cartridges with no mapper, but a save battery should now properly save and load changes. However, this type of cartridge has not been used in any commercially released software for Game Boy so the exact intended behavior is speculative.