### PR TITLE
Move directory options to g_owned_opts

### DIFF
--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-28 16:20+0000\n"
+"POT-Creation-Date: 2023-04-04 13:53-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -120,203 +120,199 @@ msgstr ""
 msgid "Bad configuration option or multiple ROM files given:\n"
 msgstr ""
 
-#: guiinit.cpp:88
+#: guiinit.cpp:89
 msgid "Start!"
 msgstr ""
 
-#: guiinit.cpp:107 xrc/NetLink.xrc:99
+#: guiinit.cpp:108 xrc/NetLink.xrc:99
 msgid "Connect"
 msgstr ""
 
-#: guiinit.cpp:124
+#: guiinit.cpp:125
 msgid "You must enter a valid host name"
 msgstr ""
 
-#: guiinit.cpp:125
+#: guiinit.cpp:126
 msgid "Host name invalid"
 msgstr ""
 
-#: guiinit.cpp:143
+#: guiinit.cpp:144
 msgid "Waiting for clients..."
 msgstr ""
 
-#: guiinit.cpp:144
+#: guiinit.cpp:145
 #, c-format
 msgid "Server IP address is: %s\n"
 msgstr ""
 
-#: guiinit.cpp:146
+#: guiinit.cpp:147
 msgid "Waiting for connection..."
 msgstr ""
 
-#: guiinit.cpp:147
+#: guiinit.cpp:148
 #, c-format
 msgid "Connecting to %s\n"
 msgstr ""
 
-#: guiinit.cpp:180
+#: guiinit.cpp:181
 msgid ""
 "Error occurred.\n"
 "Please try again."
 msgstr ""
 
-#: guiinit.cpp:247 guiinit.cpp:300
+#: guiinit.cpp:248 guiinit.cpp:301
 msgid "Select cheat file"
 msgstr ""
 
-#: guiinit.cpp:248
+#: guiinit.cpp:249
 msgid "VBA cheat lists (*.clt)|*.clt|CHT cheat lists (*.cht)|*.cht"
 msgstr ""
 
-#: guiinit.cpp:267 panel.cpp:510
+#: guiinit.cpp:268 panel.cpp:513
 msgid "Loaded cheats"
 msgstr ""
 
-#: guiinit.cpp:301
+#: guiinit.cpp:302
 msgid "VBA cheat lists (*.clt)|*.clt"
 msgstr ""
 
-#: guiinit.cpp:319
+#: guiinit.cpp:320
 msgid "Saved cheats"
 msgstr ""
 
-#: guiinit.cpp:350 guiinit.cpp:369
+#: guiinit.cpp:351 guiinit.cpp:370
 msgid "Restore old values?"
 msgstr ""
 
-#: guiinit.cpp:351 guiinit.cpp:370
+#: guiinit.cpp:352 guiinit.cpp:371
 msgid "Removing cheats"
 msgstr ""
 
-#: guiinit.cpp:761 xrc/JoyPanel.xrc:364
+#: guiinit.cpp:762 xrc/JoyPanel.xrc:364
 msgid "Game Shark"
 msgstr ""
 
-#: guiinit.cpp:762 cmdevents.cpp:703
+#: guiinit.cpp:763 cmdevents.cpp:712
 msgid "Game Genie"
 msgstr ""
 
-#: guiinit.cpp:764
+#: guiinit.cpp:765
 msgid "Generic Code"
 msgstr ""
 
-#: guiinit.cpp:765
+#: guiinit.cpp:766
 msgid "Game Shark Advance"
 msgstr ""
 
-#: guiinit.cpp:766
+#: guiinit.cpp:767
 msgid "Code Breaker Advance"
 msgstr ""
 
-#: guiinit.cpp:767
+#: guiinit.cpp:768
 msgid "Flashcart CHT"
 msgstr ""
 
-#: guiinit.cpp:835 guiinit.cpp:1090
+#: guiinit.cpp:836 guiinit.cpp:1091
 msgid "Number cannot be empty"
 msgstr ""
 
-#: guiinit.cpp:885
+#: guiinit.cpp:886
 msgid "Search produced no results"
 msgstr ""
 
-#: guiinit.cpp:1048
+#: guiinit.cpp:1049
 msgid "8-bit "
 msgstr ""
 
-#: guiinit.cpp:1052
+#: guiinit.cpp:1053
 msgid "16-bit "
 msgstr ""
 
-#: guiinit.cpp:1056
+#: guiinit.cpp:1057
 msgid "32-bit "
 msgstr ""
 
-#: guiinit.cpp:1062
+#: guiinit.cpp:1063
 msgid "signed decimal"
 msgstr ""
 
-#: guiinit.cpp:1066
+#: guiinit.cpp:1067
 msgid "unsigned decimal"
 msgstr ""
 
-#: guiinit.cpp:1070
+#: guiinit.cpp:1071
 msgid "unsigned hexadecimal"
 msgstr ""
 
-#: guiinit.cpp:1471
+#: guiinit.cpp:1472
 #, c-format
 msgid "%d frames = %.2f ms"
 msgstr ""
 
-#: guiinit.cpp:1483
+#: guiinit.cpp:1484
 msgid "Default device"
 msgstr ""
 
-#: guiinit.cpp:1823
+#: guiinit.cpp:1824
 msgid "This will clear all user-defined accelerators. Are you sure?"
 msgstr ""
 
-#: guiinit.cpp:1823
+#: guiinit.cpp:1824
 msgid "Confirm"
 msgstr ""
 
-#: guiinit.cpp:2414
+#: guiinit.cpp:2415
 msgid "Main icon not found"
 msgstr ""
 
-#: guiinit.cpp:2424
-msgid "Browse"
-msgstr ""
-
-#: guiinit.cpp:2438
+#: guiinit.cpp:2433
 msgid "Main display panel not found"
 msgstr ""
 
-#: guiinit.cpp:2604
+#: guiinit.cpp:2599
 #, c-format
 msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
 msgstr ""
 
-#: guiinit.cpp:2618
+#: guiinit.cpp:2613
 #, c-format
 msgid "Menu accelerator %s for %s overrides default for %s; keeping menu"
 msgstr ""
 
-#: guiinit.cpp:2757
+#: guiinit.cpp:2752
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: guiinit.cpp:2956
+#: guiinit.cpp:2951
 msgid "Code"
 msgstr ""
 
-#: guiinit.cpp:2965
+#: guiinit.cpp:2960
 msgid "Description"
 msgstr ""
 
-#: guiinit.cpp:3039 xrc/CheatAdd.xrc:31
+#: guiinit.cpp:3034 xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: guiinit.cpp:3040
+#: guiinit.cpp:3035
 msgid "Old Value"
 msgstr ""
 
-#: guiinit.cpp:3041
+#: guiinit.cpp:3036
 msgid "New Value"
 msgstr ""
 
-#: guiinit.cpp:3422
+#: guiinit.cpp:3394
 msgid "Menu commands"
 msgstr ""
 
-#: guiinit.cpp:3445
+#: guiinit.cpp:3417
 msgid "Other commands"
 msgstr ""
 
-#: guiinit.cpp:3556
+#: guiinit.cpp:3528
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -325,7 +321,7 @@ msgid "Text files (*.txt;*.log)|*.txt;*.log|"
 msgstr ""
 
 #: viewers.cpp:563 viewers.cpp:773 gfxviewers.cpp:1603 gfxviewers.cpp:1746
-#: cmdevents.cpp:1186 cmdevents.cpp:1264 cmdevents.cpp:1334 cmdevents.cpp:1405
+#: cmdevents.cpp:1195 cmdevents.cpp:1273 cmdevents.cpp:1343 cmdevents.cpp:1414
 #: viewsupt.cpp:1183
 msgid "Select output file"
 msgstr ""
@@ -412,11 +408,11 @@ msgid ""
 "Table (*.act)|*.act"
 msgstr ""
 
-#: gfxviewers.cpp:1604 gfxviewers.cpp:1747 cmdevents.cpp:1187 viewsupt.cpp:1184
+#: gfxviewers.cpp:1604 gfxviewers.cpp:1747 cmdevents.cpp:1196 viewsupt.cpp:1184
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: cmdevents.cpp:135
+#: cmdevents.cpp:134
 msgid ""
 "Game Boy Advance Files (*.agb;*.gba;*.bin;*.elf;*.mb;*.zip;*.7z;*.rar)|*.agb;"
 "*.gba;*.bin;*.elf;*.mb;*.agb.gz;*.gba.gz;*.bin.gz;*.elf.gz;*.mb.gz;*.agb.z;*."
@@ -426,379 +422,379 @@ msgid ""
 "*.7z;*.rar|"
 msgstr ""
 
-#: cmdevents.cpp:146
+#: cmdevents.cpp:145
 msgid "Open ROM file"
 msgstr ""
 
-#: cmdevents.cpp:163
+#: cmdevents.cpp:166
 msgid ""
 "Game Boy Files (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg;*.gb;*."
 "gbc;*.cgb;*.sgb;*.dmg.gz;*.gb.gz;*.gbc.gz;*.cgb.gz;*.sgb.gz;*.dmg.z;*.gb.z;*."
 "gbc.z;*.cgb.z;*.sgb.z;*.zip;*.7z;*.rar|"
 msgstr ""
 
-#: cmdevents.cpp:169
+#: cmdevents.cpp:172
 msgid "Open GB ROM file"
 msgstr ""
 
-#: cmdevents.cpp:186
+#: cmdevents.cpp:193
 msgid ""
 "Game Boy Color Files (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg;*."
 "gb;*.gbc;*.cgb;*.sgb;*.dmg.gz;*.gb.gz;*.gbc.gz;*.cgb.gz;*.sgb.gz;*.dmg.z;*."
 "gb.z;*.gbc.z;*.cgb.z;*.sgb.z;*.zip;*.7z;*.rar|"
 msgstr ""
 
-#: cmdevents.cpp:192
+#: cmdevents.cpp:199
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: cmdevents.cpp:611 cmdevents.cpp:727 cmdevents.cpp:766 cmdevents.cpp:839
+#: cmdevents.cpp:620 cmdevents.cpp:736 cmdevents.cpp:775 cmdevents.cpp:848
 msgid "Unknown"
 msgstr ""
 
-#: cmdevents.cpp:619
+#: cmdevents.cpp:628
 msgid "ROM"
 msgstr ""
 
-#: cmdevents.cpp:623
+#: cmdevents.cpp:632
 msgid "ROM + MBC1"
 msgstr ""
 
-#: cmdevents.cpp:627
+#: cmdevents.cpp:636
 msgid "ROM + MBC1 + RAM"
 msgstr ""
 
-#: cmdevents.cpp:631
+#: cmdevents.cpp:640
 msgid "ROM + MBC1 + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:635
+#: cmdevents.cpp:644
 msgid "ROM + MBC2"
 msgstr ""
 
-#: cmdevents.cpp:639
+#: cmdevents.cpp:648
 msgid "ROM + MBC2 + BATT"
 msgstr ""
 
-#: cmdevents.cpp:643
+#: cmdevents.cpp:652
 msgid "ROM + MMM01"
 msgstr ""
 
-#: cmdevents.cpp:647
+#: cmdevents.cpp:656
 msgid "ROM + MMM01 + RAM"
 msgstr ""
 
-#: cmdevents.cpp:651
+#: cmdevents.cpp:660
 msgid "ROM + MMM01 + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:655
+#: cmdevents.cpp:664
 msgid "ROM + MBC3 + TIMER + BATT"
 msgstr ""
 
-#: cmdevents.cpp:659
+#: cmdevents.cpp:668
 msgid "ROM + MBC3 + TIMER + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:663
+#: cmdevents.cpp:672
 msgid "ROM + MBC3"
 msgstr ""
 
-#: cmdevents.cpp:667
+#: cmdevents.cpp:676
 msgid "ROM + MBC3 + RAM"
 msgstr ""
 
-#: cmdevents.cpp:671
+#: cmdevents.cpp:680
 msgid "ROM + MBC3 + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:675
+#: cmdevents.cpp:684
 msgid "ROM + MBC5"
 msgstr ""
 
-#: cmdevents.cpp:679
+#: cmdevents.cpp:688
 msgid "ROM + MBC5 + RAM"
 msgstr ""
 
-#: cmdevents.cpp:683
+#: cmdevents.cpp:692
 msgid "ROM + MBC5 + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:687
+#: cmdevents.cpp:696
 msgid "ROM + MBC5 + RUMBLE"
 msgstr ""
 
-#: cmdevents.cpp:691
+#: cmdevents.cpp:700
 msgid "ROM + MBC5 + RUMBLE + RAM"
 msgstr ""
 
-#: cmdevents.cpp:695
+#: cmdevents.cpp:704
 msgid "ROM + MBC5 + RUMBLE + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:699
+#: cmdevents.cpp:708
 msgid "ROM + MBC7 + BATT"
 msgstr ""
 
-#: cmdevents.cpp:707
+#: cmdevents.cpp:716
 msgid "Game Shark 3.0"
 msgstr ""
 
-#: cmdevents.cpp:711
+#: cmdevents.cpp:720
 msgid "ROM + POCKET CAMERA"
 msgstr ""
 
-#: cmdevents.cpp:715
+#: cmdevents.cpp:724
 msgid "ROM + BANDAI TAMA5"
 msgstr ""
 
-#: cmdevents.cpp:719
+#: cmdevents.cpp:728
 msgid "ROM + HuC-3"
 msgstr ""
 
-#: cmdevents.cpp:723
+#: cmdevents.cpp:732
 msgid "ROM + HuC-1"
 msgstr ""
 
-#: cmdevents.cpp:773 dialogs/display-config.cpp:341 xrc/DisplayConfig.xrc:85
+#: cmdevents.cpp:782 dialogs/display-config.cpp:341 xrc/DisplayConfig.xrc:85
 #: xrc/DisplayConfig.xrc:135 xrc/DisplayConfig.xrc:221
 #: xrc/GameBoyAdvanceConfig.xrc:32 xrc/GameBoyAdvanceConfig.xrc:204
 #: xrc/SoundConfig.xrc:219 xrc/SoundConfig.xrc:309
 msgid "None"
 msgstr ""
 
-#: cmdevents.cpp:875 cmdevents.cpp:897
+#: cmdevents.cpp:884 cmdevents.cpp:906
 msgid "Select Dot Code file"
 msgstr ""
 
-#: cmdevents.cpp:877 cmdevents.cpp:899
+#: cmdevents.cpp:886 cmdevents.cpp:908
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: cmdevents.cpp:918 cmdevents.cpp:1113
+#: cmdevents.cpp:927 cmdevents.cpp:1122
 msgid "Select battery file"
 msgstr ""
 
-#: cmdevents.cpp:919 cmdevents.cpp:1114
+#: cmdevents.cpp:928 cmdevents.cpp:1123
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: cmdevents.cpp:927
+#: cmdevents.cpp:936
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write). Do you want to continue?"
 msgstr ""
 
-#: cmdevents.cpp:928 cmdevents.cpp:956 cmdevents.cpp:1076
+#: cmdevents.cpp:937 cmdevents.cpp:965 cmdevents.cpp:1085
 msgid "Confirm import"
 msgstr ""
 
-#: cmdevents.cpp:934 panel.cpp:453
+#: cmdevents.cpp:943 panel.cpp:456
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: cmdevents.cpp:936
+#: cmdevents.cpp:945
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: cmdevents.cpp:945
+#: cmdevents.cpp:954
 msgid "Select code file"
 msgstr ""
 
-#: cmdevents.cpp:946
+#: cmdevents.cpp:955
 msgid "Game Shark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: cmdevents.cpp:946
+#: cmdevents.cpp:955
 msgid "Game Shark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: cmdevents.cpp:955
+#: cmdevents.cpp:964
 msgid ""
 "Importing a code file will replace any loaded cheats. Do you want to "
 "continue?"
 msgstr ""
 
-#: cmdevents.cpp:972
+#: cmdevents.cpp:981
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: cmdevents.cpp:982
+#: cmdevents.cpp:991
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: cmdevents.cpp:1052
+#: cmdevents.cpp:1061
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: cmdevents.cpp:1054
+#: cmdevents.cpp:1063
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: cmdevents.cpp:1065 cmdevents.cpp:1141
+#: cmdevents.cpp:1074 cmdevents.cpp:1150
 msgid "Select snapshot file"
 msgstr ""
 
-#: cmdevents.cpp:1066
+#: cmdevents.cpp:1075
 msgid ""
 "Game Shark & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|Game Shark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: cmdevents.cpp:1066
+#: cmdevents.cpp:1075
 msgid "Game Boy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: cmdevents.cpp:1075
+#: cmdevents.cpp:1084
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write). Do you want to continue?"
 msgstr ""
 
-#: cmdevents.cpp:1100
+#: cmdevents.cpp:1109
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1102
+#: cmdevents.cpp:1111
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1125
+#: cmdevents.cpp:1134
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: cmdevents.cpp:1127 panel.cpp:760
+#: cmdevents.cpp:1136 panel.cpp:763
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: cmdevents.cpp:1135
+#: cmdevents.cpp:1144
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: cmdevents.cpp:1142
+#: cmdevents.cpp:1151
 msgid "Game Shark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: cmdevents.cpp:1156
+#: cmdevents.cpp:1165
 msgid "Exported from Visual Boy Advance-M"
 msgstr ""
 
-#: cmdevents.cpp:1168
+#: cmdevents.cpp:1177
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1170
+#: cmdevents.cpp:1179
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1211 sys.cpp:574
+#: cmdevents.cpp:1220 sys.cpp:574
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: cmdevents.cpp:1232 cmdevents.cpp:1302 cmdevents.cpp:1373 cmdevents.cpp:1439
+#: cmdevents.cpp:1241 cmdevents.cpp:1311 cmdevents.cpp:1382 cmdevents.cpp:1448
 msgid " files ("
 msgstr ""
 
-#: cmdevents.cpp:1472
+#: cmdevents.cpp:1481
 msgid "Select file"
 msgstr ""
 
-#: cmdevents.cpp:1780 cmdevents.cpp:1873
+#: cmdevents.cpp:1789 cmdevents.cpp:1882
 msgid "Select state file"
 msgstr ""
 
-#: cmdevents.cpp:1781 cmdevents.cpp:1874
+#: cmdevents.cpp:1790 cmdevents.cpp:1883
 msgid "Visual Boy Advance saved game files|*.sgm"
 msgstr ""
 
-#: cmdevents.cpp:1904 cmdevents.cpp:1914 cmdevents.cpp:1925
+#: cmdevents.cpp:1913 cmdevents.cpp:1923 cmdevents.cpp:1934
 #, c-format
 msgid "Current state slot #%d"
 msgstr ""
 
-#: cmdevents.cpp:1994
+#: cmdevents.cpp:2003
 msgid "Cannot use Colorizer Hack when Game Boy BIOS File is enabled."
 msgstr ""
 
-#: cmdevents.cpp:2205
+#: cmdevents.cpp:2214
 msgid "Sound enabled"
 msgstr ""
 
-#: cmdevents.cpp:2205
+#: cmdevents.cpp:2214
 msgid "Sound disabled"
 msgstr ""
 
-#: cmdevents.cpp:2218 cmdevents.cpp:2232
+#: cmdevents.cpp:2227 cmdevents.cpp:2241
 #, c-format
 msgid "Volume: %d %%"
 msgstr ""
 
-#: cmdevents.cpp:2301
+#: cmdevents.cpp:2310
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: cmdevents.cpp:2303
+#: cmdevents.cpp:2312
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: cmdevents.cpp:2304
+#: cmdevents.cpp:2313
 msgid "GDB Connection"
 msgstr ""
 
-#: cmdevents.cpp:2357
+#: cmdevents.cpp:2366
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: cmdevents.cpp:2364
+#: cmdevents.cpp:2373
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: cmdevents.cpp:2367
+#: cmdevents.cpp:2376
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: cmdevents.cpp:2740 panel.cpp:252 panel.cpp:365
+#: cmdevents.cpp:2749 panel.cpp:255 panel.cpp:368
 msgid "Could not initialize the sound driver!"
 msgstr ""
 
-#: cmdevents.cpp:2806
+#: cmdevents.cpp:2812
 msgid ""
 "YOUR CONFIGURATION WILL BE DELETED!\n"
 "\n"
 "Are you sure?"
 msgstr ""
 
-#: cmdevents.cpp:2807
+#: cmdevents.cpp:2813
 msgid "FACTORY RESET"
 msgstr ""
 
-#: cmdevents.cpp:2842
+#: cmdevents.cpp:2848
 msgid "Nintendo Game Boy / Color / Advance emulator."
 msgstr ""
 
-#: cmdevents.cpp:2843
+#: cmdevents.cpp:2849
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2020 VBA-M development team"
 msgstr ""
 
-#: cmdevents.cpp:2845
+#: cmdevents.cpp:2851
 msgid ""
 "This program is free software: you can redistribute it and / or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -814,15 +810,15 @@ msgid ""
 "along with this program. If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: cmdevents.cpp:3065
+#: cmdevents.cpp:3071
 msgid "Cannot use Game Boy BIOS when Colorizer Hack is enabled."
 msgstr ""
 
-#: cmdevents.cpp:3126
+#: cmdevents.cpp:3132
 msgid "LAN link is already active. Disable link mode to disconnect."
 msgstr ""
 
-#: cmdevents.cpp:3132
+#: cmdevents.cpp:3138
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -950,177 +946,177 @@ msgstr ""
 msgid "Error setting up server socket (%d)"
 msgstr ""
 
-#: panel.cpp:174
+#: panel.cpp:177
 #, c-format
 msgid "%s is not a valid ROM file"
 msgstr ""
 
-#: panel.cpp:175 panel.cpp:236 panel.cpp:303
+#: panel.cpp:178 panel.cpp:239 panel.cpp:306
 msgid "Problem loading file"
 msgstr ""
 
-#: panel.cpp:235
+#: panel.cpp:238
 #, c-format
 msgid "Unable to load Game Boy ROM %s"
 msgstr ""
 
-#: panel.cpp:264
+#: panel.cpp:267
 msgid ""
 "Cannot use Game Boy BIOS file when Colorizer Hack is enabled, disabling Game "
 "Boy BIOS file."
 msgstr ""
 
-#: panel.cpp:279 panel.cpp:379
+#: panel.cpp:282 panel.cpp:382
 #, c-format
 msgid "Could not load BIOS %s"
 msgstr ""
 
-#: panel.cpp:302
+#: panel.cpp:305
 #, c-format
 msgid "Unable to load Game Boy Advance ROM %s"
 msgstr ""
 
-#: panel.cpp:542
+#: panel.cpp:545
 msgid " player "
 msgstr ""
 
-#: panel.cpp:708
+#: panel.cpp:711
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: panel.cpp:708
+#: panel.cpp:711
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: panel.cpp:732
+#: panel.cpp:735
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: panel.cpp:732
+#: panel.cpp:735
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: panel.cpp:936
+#: panel.cpp:939
 #, c-format
 msgid "Fullscreen mode %d x %d - %d @ %d not supported; looking for another"
 msgstr ""
 
-#: panel.cpp:974
+#: panel.cpp:977
 #, c-format
 msgid "Fullscreen mode %d x %d - %d @ %d not supported"
 msgstr ""
 
-#: panel.cpp:979
+#: panel.cpp:982
 #, c-format
 msgid "Valid mode: %d x %d - %d @ %d"
 msgstr ""
 
-#: panel.cpp:987
+#: panel.cpp:990
 #, c-format
 msgid "Chose mode %d x %d - %d @ %d"
 msgstr ""
 
-#: panel.cpp:991
+#: panel.cpp:994
 #, c-format
 msgid "Failed to change mode to %d x %d - %d @ %d"
 msgstr ""
 
-#: panel.cpp:1081
+#: panel.cpp:1084
 msgid "Not a valid Game Boy Advance cartridge"
 msgstr ""
 
-#: panel.cpp:1249
+#: panel.cpp:1252
 msgid "No memory for rewinding"
 msgstr ""
 
-#: panel.cpp:1259
+#: panel.cpp:1262
 msgid "Error writing rewind state"
 msgstr ""
 
-#: panel.cpp:2277
+#: panel.cpp:2280
 msgid "Enabling EGL VSync."
 msgstr ""
 
-#: panel.cpp:2279
+#: panel.cpp:2282
 msgid "Disabling EGL VSync."
 msgstr ""
 
-#: panel.cpp:2286
+#: panel.cpp:2289
 msgid "Enabling GLX VSync."
 msgstr ""
 
-#: panel.cpp:2288
+#: panel.cpp:2291
 msgid "Disabling GLX VSync."
 msgstr ""
 
-#: panel.cpp:2306
+#: panel.cpp:2309
 msgid "Failed to set glXSwapIntervalEXT"
 msgstr ""
 
-#: panel.cpp:2315
+#: panel.cpp:2318
 msgid "Failed to set glXSwapIntervalSGI"
 msgstr ""
 
-#: panel.cpp:2324
+#: panel.cpp:2327
 msgid "Failed to set glXSwapIntervalMESA"
 msgstr ""
 
-#: panel.cpp:2331
+#: panel.cpp:2334
 msgid "No support for wglGetExtensionsStringEXT"
 msgstr ""
 
-#: panel.cpp:2334
+#: panel.cpp:2337
 msgid "No support for WGL_EXT_swap_control"
 msgstr ""
 
-#: panel.cpp:2343
+#: panel.cpp:2346
 msgid "Failed to set wglSwapIntervalEXT"
 msgstr ""
 
-#: panel.cpp:2349
+#: panel.cpp:2352
 msgid "No VSYNC available on this platform"
 msgstr ""
 
-#: panel.cpp:2449
+#: panel.cpp:2452
 msgid "memory allocation error"
 msgstr ""
 
-#: panel.cpp:2452
+#: panel.cpp:2455
 msgid "error initializing codec"
 msgstr ""
 
-#: panel.cpp:2455
+#: panel.cpp:2458
 msgid "error writing to output file"
 msgstr ""
 
-#: panel.cpp:2458
+#: panel.cpp:2461
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: panel.cpp:2463
+#: panel.cpp:2466
 msgid "programming error; aborting!"
 msgstr ""
 
-#: panel.cpp:2475 panel.cpp:2504
+#: panel.cpp:2478 panel.cpp:2507
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: panel.cpp:2532
+#: panel.cpp:2535
 #, c-format
 msgid "Error in audio / video recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2538
+#: panel.cpp:2541
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2548
+#: panel.cpp:2551
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -1137,174 +1133,174 @@ msgstr ""
 msgid "B:"
 msgstr ""
 
-#: config/internal/option-internal.cpp:343
+#: config/internal/option-internal.cpp:353
 msgid "Use bilinear filter with 3d renderer"
 msgstr ""
 
-#: config/internal/option-internal.cpp:344
+#: config/internal/option-internal.cpp:354
 msgid "Full-screen filter to apply"
 msgstr ""
 
-#: config/internal/option-internal.cpp:345
+#: config/internal/option-internal.cpp:355
 msgid "Filter plugin library"
 msgstr ""
 
-#: config/internal/option-internal.cpp:346
+#: config/internal/option-internal.cpp:356
 msgid "Interframe blending function"
 msgstr ""
 
-#: config/internal/option-internal.cpp:347
+#: config/internal/option-internal.cpp:357
 msgid "Keep window on top"
 msgstr ""
 
-#: config/internal/option-internal.cpp:349
+#: config/internal/option-internal.cpp:359
 msgid "Maximum number of threads to run filters in"
 msgstr ""
 
-#: config/internal/option-internal.cpp:351
+#: config/internal/option-internal.cpp:361
 msgid "Render method; if unsupported, simple method will be used"
 msgstr ""
 
-#: config/internal/option-internal.cpp:352
+#: config/internal/option-internal.cpp:362
 msgid "Default scale factor"
 msgstr ""
 
-#: config/internal/option-internal.cpp:354
+#: config/internal/option-internal.cpp:364
 msgid "Retain aspect ratio when resizing"
 msgstr ""
 
-#: config/internal/option-internal.cpp:358
+#: config/internal/option-internal.cpp:368
 msgid "BIOS file to use for Game Boy, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:360
+#: config/internal/option-internal.cpp:370
 msgid "Game Boy color enhancement, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:362
+#: config/internal/option-internal.cpp:372
 msgid "Enable DX Colorization Hacks"
 msgstr ""
 
-#: config/internal/option-internal.cpp:364
-#: config/internal/option-internal.cpp:390
+#: config/internal/option-internal.cpp:374
+#: config/internal/option-internal.cpp:400
 msgid "Apply LCD filter, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:366
+#: config/internal/option-internal.cpp:376
 msgid "BIOS file to use for Game Boy Color, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:368
+#: config/internal/option-internal.cpp:378
 msgid ""
 "The default palette, as 8 comma-separated 4-digit hex integers (rgb555)."
 msgstr ""
 
-#: config/internal/option-internal.cpp:371
+#: config/internal/option-internal.cpp:381
 msgid ""
 "The first user palette, as 8 comma-separated 4-digit hex integers (rgb555)."
 msgstr ""
 
-#: config/internal/option-internal.cpp:374
+#: config/internal/option-internal.cpp:384
 msgid ""
 "The second user palette, as 8 comma-separated 4-digit hex integers (rgb555)."
 msgstr ""
 
-#: config/internal/option-internal.cpp:377
+#: config/internal/option-internal.cpp:387
 msgid "Automatically gather a full page before printing"
 msgstr ""
 
-#: config/internal/option-internal.cpp:379
+#: config/internal/option-internal.cpp:389
 msgid "Automatically save printouts as screen captures with -print suffix"
 msgstr ""
 
-#: config/internal/option-internal.cpp:381
-#: config/internal/option-internal.cpp:411
+#: config/internal/option-internal.cpp:391
+#: config/internal/option-internal.cpp:421
 msgid "Directory to look for ROM files"
 msgstr ""
 
-#: config/internal/option-internal.cpp:383
+#: config/internal/option-internal.cpp:393
 msgid "Directory to look for Game Boy Color ROM files"
 msgstr ""
 
-#: config/internal/option-internal.cpp:386
+#: config/internal/option-internal.cpp:396
 msgid "BIOS file to use, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:396
+#: config/internal/option-internal.cpp:406
 msgid "Enable link at boot"
 msgstr ""
 
-#: config/internal/option-internal.cpp:401
+#: config/internal/option-internal.cpp:411
 msgid "Enable faster network protocol by default"
 msgstr ""
 
-#: config/internal/option-internal.cpp:403
+#: config/internal/option-internal.cpp:413
 msgid "Default network link client host"
 msgstr ""
 
-#: config/internal/option-internal.cpp:404
+#: config/internal/option-internal.cpp:414
 msgid "Default network link server IP to bind"
 msgstr ""
 
-#: config/internal/option-internal.cpp:406
+#: config/internal/option-internal.cpp:416
 msgid "Default network link port (server and client)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:407
+#: config/internal/option-internal.cpp:417
 msgid "Default network protocol"
 msgstr ""
 
-#: config/internal/option-internal.cpp:408
+#: config/internal/option-internal.cpp:418
 msgid "Link timeout (ms)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:409
+#: config/internal/option-internal.cpp:419
 msgid "Link cable type"
 msgstr ""
 
-#: config/internal/option-internal.cpp:415
+#: config/internal/option-internal.cpp:425
 msgid "Automatically load last saved state"
 msgstr ""
 
-#: config/internal/option-internal.cpp:417
+#: config/internal/option-internal.cpp:427
 msgid ""
 "Directory to store game save files (relative paths are relative to ROM; "
 "blank is config dir)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:419
+#: config/internal/option-internal.cpp:429
 msgid "Freeze recent load list"
 msgstr ""
 
-#: config/internal/option-internal.cpp:421
+#: config/internal/option-internal.cpp:431
 msgid ""
 "Directory to store A / V and game recordings (relative paths are relative to "
 "ROM)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:424
+#: config/internal/option-internal.cpp:434
 msgid "Number of seconds between rewind snapshots (0 to disable)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:426
+#: config/internal/option-internal.cpp:436
 msgid "Directory to store screenshots (relative paths are relative to ROM)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:429
+#: config/internal/option-internal.cpp:439
 msgid ""
 "Directory to store saved state files (relative paths are relative to "
 "BatteryDir)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:431
+#: config/internal/option-internal.cpp:441
 msgid "Enable status bar"
 msgstr ""
 
-#: config/internal/option-internal.cpp:432
+#: config/internal/option-internal.cpp:442
 msgid "INI file version (DO NOT MODIFY)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:436
+#: config/internal/option-internal.cpp:446
 msgid ""
 "The parameter Joypad/<n>/<button> contains a comma-separated list of key "
 "names which map to joypad #<n> button <button>. Button is one of Up, Down, "
@@ -1312,254 +1308,254 @@ msgid ""
 "MotionRight, AutoA, AutoB, Speed, Capture, GS"
 msgstr ""
 
-#: config/internal/option-internal.cpp:442
+#: config/internal/option-internal.cpp:452
 msgid "The autofire toggle period, in frames (1/60 s)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:444
+#: config/internal/option-internal.cpp:454
 msgid "The number of the stick to use in single-player mode"
 msgstr ""
 
-#: config/internal/option-internal.cpp:448
+#: config/internal/option-internal.cpp:458
 msgid ""
 "The parameter Keyboard/<cmd> contains a comma-separated list of key names (e."
 "g. Alt-Shift-F1).  When the named key is pressed, the command <cmd> is "
 "executed."
 msgstr ""
 
-#: config/internal/option-internal.cpp:454
+#: config/internal/option-internal.cpp:464
 msgid "Enable AGB debug print"
 msgstr ""
 
-#: config/internal/option-internal.cpp:456
+#: config/internal/option-internal.cpp:466
 msgid "Auto skip frames"
 msgstr ""
 
-#: config/internal/option-internal.cpp:458
+#: config/internal/option-internal.cpp:468
 msgid "Apply IPS / UPS / IPF patches if found"
 msgstr ""
 
-#: config/internal/option-internal.cpp:460
+#: config/internal/option-internal.cpp:470
 msgid "Automatically save and load cheat list"
 msgstr ""
 
-#: config/internal/option-internal.cpp:464
+#: config/internal/option-internal.cpp:474
 msgid "Automatically enable border for Super Game Boy games"
 msgstr ""
 
-#: config/internal/option-internal.cpp:466
+#: config/internal/option-internal.cpp:476
 msgid "Always enable border"
 msgstr ""
 
-#: config/internal/option-internal.cpp:468
+#: config/internal/option-internal.cpp:478
 msgid "Screen capture file format"
 msgstr ""
 
-#: config/internal/option-internal.cpp:469
+#: config/internal/option-internal.cpp:479
 msgid "Enable cheats"
 msgstr ""
 
-#: config/internal/option-internal.cpp:471
+#: config/internal/option-internal.cpp:481
 msgid "Disable on-screen status messages"
 msgstr ""
 
-#: config/internal/option-internal.cpp:472
+#: config/internal/option-internal.cpp:482
 msgid "Type of system to emulate"
 msgstr ""
 
-#: config/internal/option-internal.cpp:474
+#: config/internal/option-internal.cpp:484
 msgid "Flash size 0 = 64 KB 1 = 128 KB"
 msgstr ""
 
-#: config/internal/option-internal.cpp:476
+#: config/internal/option-internal.cpp:486
 msgid "Skip frames. Values are 0-9 or -1 to skip automatically based on time."
 msgstr ""
 
-#: config/internal/option-internal.cpp:478
+#: config/internal/option-internal.cpp:488
 msgid "The palette to use"
 msgstr ""
 
-#: config/internal/option-internal.cpp:480
+#: config/internal/option-internal.cpp:490
 msgid "Enable printer emulation"
 msgstr ""
 
-#: config/internal/option-internal.cpp:482
+#: config/internal/option-internal.cpp:492
 msgid "Break into GDB after loading the game."
 msgstr ""
 
-#: config/internal/option-internal.cpp:484
+#: config/internal/option-internal.cpp:494
 msgid "Port to connect GDB to"
 msgstr ""
 
-#: config/internal/option-internal.cpp:487
+#: config/internal/option-internal.cpp:497
 msgid "Number of players in network"
 msgstr ""
 
-#: config/internal/option-internal.cpp:490
+#: config/internal/option-internal.cpp:500
 msgid "Maximum scale factor (0 = no limit)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:492
+#: config/internal/option-internal.cpp:502
 msgid "Pause game when main window loses focus"
 msgstr ""
 
-#: config/internal/option-internal.cpp:494
+#: config/internal/option-internal.cpp:504
 msgid "Enable RTC (vba-over.ini override is rtcEnabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:496
+#: config/internal/option-internal.cpp:506
 msgid "Native save (\"battery\") hardware type"
 msgstr ""
 
-#: config/internal/option-internal.cpp:497
+#: config/internal/option-internal.cpp:507
 msgid "Show speed indicator"
 msgstr ""
 
-#: config/internal/option-internal.cpp:499
+#: config/internal/option-internal.cpp:509
 msgid "Draw on-screen messages transparently"
 msgstr ""
 
-#: config/internal/option-internal.cpp:501
+#: config/internal/option-internal.cpp:511
 msgid "Skip BIOS initialization"
 msgstr ""
 
-#: config/internal/option-internal.cpp:503
+#: config/internal/option-internal.cpp:513
 msgid "Do not overwrite cheat list when loading state"
 msgstr ""
 
-#: config/internal/option-internal.cpp:505
+#: config/internal/option-internal.cpp:515
 msgid "Do not overwrite native (battery) save when loading state"
 msgstr ""
 
-#: config/internal/option-internal.cpp:507
+#: config/internal/option-internal.cpp:517
 msgid "Throttle game speed, even when accelerated (0-450 %, 0 = no throttle)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:510
+#: config/internal/option-internal.cpp:520
 msgid "Set throttle for speedup key (0-3000 %, 0 = no throttle)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:512
+#: config/internal/option-internal.cpp:522
 msgid "Number of frames to skip with speedup (instead of speedup throttle)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:515
+#: config/internal/option-internal.cpp:525
 msgid "Use frame skip for speedup throttle"
 msgstr ""
 
-#: config/internal/option-internal.cpp:517
+#: config/internal/option-internal.cpp:527
 msgid "Use the specified BIOS file for Game Boy"
 msgstr ""
 
-#: config/internal/option-internal.cpp:519
+#: config/internal/option-internal.cpp:529
 msgid "Use the specified BIOS file"
 msgstr ""
 
-#: config/internal/option-internal.cpp:521
+#: config/internal/option-internal.cpp:531
 msgid "Use the specified BIOS file for Game Boy Color"
 msgstr ""
 
-#: config/internal/option-internal.cpp:522
+#: config/internal/option-internal.cpp:532
 msgid "Wait for vertical sync"
 msgstr ""
 
-#: config/internal/option-internal.cpp:526
+#: config/internal/option-internal.cpp:536
 msgid "Enter fullscreen mode at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:527
+#: config/internal/option-internal.cpp:537
 msgid "Window maximized"
 msgstr ""
 
-#: config/internal/option-internal.cpp:529
+#: config/internal/option-internal.cpp:539
 msgid "Window height at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:530
+#: config/internal/option-internal.cpp:540
 msgid "Window width at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:531
+#: config/internal/option-internal.cpp:541
 msgid "Window axis X position at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:532
+#: config/internal/option-internal.cpp:542
 msgid "Window axis Y position at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:537
+#: config/internal/option-internal.cpp:547
 msgid "Capture key events while on background"
 msgstr ""
 
-#: config/internal/option-internal.cpp:540
+#: config/internal/option-internal.cpp:550
 msgid "Capture joy events while on background"
 msgstr ""
 
-#: config/internal/option-internal.cpp:541
+#: config/internal/option-internal.cpp:551
 msgid "Hide menu bar when mouse is inactive"
 msgstr ""
 
-#: config/internal/option-internal.cpp:542
+#: config/internal/option-internal.cpp:552
 msgid "Suspend screensaver when game is running"
 msgstr ""
 
-#: config/internal/option-internal.cpp:546
+#: config/internal/option-internal.cpp:556
 msgid "Sound API; if unsupported, default API will be used"
 msgstr ""
 
-#: config/internal/option-internal.cpp:548
+#: config/internal/option-internal.cpp:558
 msgid "Device ID of chosen audio device for chosen driver"
 msgstr ""
 
-#: config/internal/option-internal.cpp:549
+#: config/internal/option-internal.cpp:559
 msgid "Number of sound buffers"
 msgstr ""
 
-#: config/internal/option-internal.cpp:550
+#: config/internal/option-internal.cpp:560
 msgid "Bit mask of sound channels to enable"
 msgstr ""
 
-#: config/internal/option-internal.cpp:552
+#: config/internal/option-internal.cpp:562
 msgid "Game Boy Advance sound filtering (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:554
+#: config/internal/option-internal.cpp:564
 msgid "Game Boy Advance sound interpolation"
 msgstr ""
 
-#: config/internal/option-internal.cpp:556
+#: config/internal/option-internal.cpp:566
 msgid "Game Boy sound declicking"
 msgstr ""
 
-#: config/internal/option-internal.cpp:557
+#: config/internal/option-internal.cpp:567
 msgid "Game Boy echo effect (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:559
+#: config/internal/option-internal.cpp:569
 msgid "Enable Game Boy sound effects"
 msgstr ""
 
-#: config/internal/option-internal.cpp:560
+#: config/internal/option-internal.cpp:570
 msgid "Game Boy stereo effect (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:562
+#: config/internal/option-internal.cpp:572
 msgid "Game Boy surround sound effect (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:563
+#: config/internal/option-internal.cpp:573
 msgid "Sound sample rate (kHz)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:564
+#: config/internal/option-internal.cpp:574
 msgid "Sound volume (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:630
-#: config/internal/option-internal.cpp:650
-#: config/internal/option-internal.cpp:671
-#: config/internal/option-internal.cpp:691
-#: config/internal/option-internal.cpp:711
+#: config/internal/option-internal.cpp:640
+#: config/internal/option-internal.cpp:660
+#: config/internal/option-internal.cpp:681
+#: config/internal/option-internal.cpp:701
+#: config/internal/option-internal.cpp:721
 #, c-format
 msgid "Invalid value %s for option %s; valid values are %s"
 msgstr ""
@@ -1577,6 +1573,10 @@ msgstr ""
 #: config/option.cpp:455
 #, c-format
 msgid "Invalid value %d for option %s; valid values are %s"
+msgstr ""
+
+#: dialogs/directories-config.cpp:50
+msgid "Browse"
 msgstr ""
 
 #: dialogs/display-config.cpp:54
@@ -1603,7 +1603,7 @@ msgstr ""
 msgid "Using interframe blending: %s"
 msgstr ""
 
-#: dialogs/game-boy-config.cpp:143 xrc/GameBoyAdvanceConfig.xrc:122
+#: dialogs/game-boy-config.cpp:142 xrc/GameBoyAdvanceConfig.xrc:122
 #: xrc/GameBoyConfig.xrc:138 xrc/GameBoyConfig.xrc:159
 msgid "(None)"
 msgstr ""

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -765,6 +765,7 @@ set(
     config/option-observer.cpp
     config/option.cpp
     config/user-input.cpp
+    dialogs/directories-config.cpp
     dialogs/display-config.cpp
     dialogs/game-boy-config.cpp
     widgets/group-check-box.cpp
@@ -813,6 +814,7 @@ set(
     config/option-proxy.h
     config/option.h
     config/user-input.h
+    dialogs/directories-config.h
     dialogs/display-config.h
     dialogs/game-boy-config.h
     dialogs/validated-child.h

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -124,12 +124,11 @@ static void toggleBitVar(bool *menuValue, int *globalVar, int mask)
 
 //// File menu
 
-static int open_ft = 0;
-static wxString open_dir;
-
 EVT_HANDLER(wxID_OPEN, "Open ROM...")
 {
-    open_dir = wxGetApp().GetAbsolutePath(gopts.gba_rom_dir);
+    static int open_ft = 0;
+    const wxString& gba_rom_dir = OPTION(kGBAROMDir);
+
     // FIXME: ignore if non-existent or not a dir
     wxString pats = _(
         "Game Boy Advance Files (*.agb;*.gba;*.bin;*.elf;*.mb;*.zip;*.7z;*.rar)|"
@@ -143,7 +142,7 @@ EVT_HANDLER(wxID_OPEN, "Open ROM...")
         "*.dmg.z;*.gb.z;*.gbc.z;*.cgb.z;*.sgb.z;"
         "*.zip;*.7z;*.rar|");
     pats.append(wxALL_FILES);
-    wxFileDialog dlg(this, _("Open ROM file"), open_dir, wxT(""),
+    wxFileDialog dlg(this, _("Open ROM file"), gba_rom_dir, "",
         pats,
         wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     dlg.SetFilterIndex(open_ft);
@@ -152,12 +151,16 @@ EVT_HANDLER(wxID_OPEN, "Open ROM...")
         wxGetApp().pending_load = dlg.GetPath();
 
     open_ft = dlg.GetFilterIndex();
-    open_dir = dlg.GetDirectory();
+    if (gba_rom_dir.empty()) {
+        OPTION(kGBAROMDir) = dlg.GetDirectory();
+    }
 }
 
 EVT_HANDLER(OpenGB, "Open GB...")
 {
-    open_dir = wxGetApp().GetAbsolutePath(gopts.gb_rom_dir);
+    static int open_ft = 0;
+    const wxString& gb_rom_dir = OPTION(kGBROMDir);
+
     // FIXME: ignore if non-existent or not a dir
     wxString pats = _(
         "Game Boy Files (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|"
@@ -166,7 +169,7 @@ EVT_HANDLER(OpenGB, "Open GB...")
         "*.dmg.z;*.gb.z;*.gbc.z;*.cgb.z;*.sgb.z;"
         "*.zip;*.7z;*.rar|");
     pats.append(wxALL_FILES);
-    wxFileDialog dlg(this, _("Open GB ROM file"), open_dir, wxT(""),
+    wxFileDialog dlg(this, _("Open GB ROM file"), gb_rom_dir, "",
         pats,
         wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     dlg.SetFilterIndex(open_ft);
@@ -175,12 +178,16 @@ EVT_HANDLER(OpenGB, "Open GB...")
         wxGetApp().pending_load = dlg.GetPath();
 
     open_ft = dlg.GetFilterIndex();
-    open_dir = dlg.GetDirectory();
+    if (gb_rom_dir.empty()) {
+        OPTION(kGBROMDir) = dlg.GetDirectory();
+    }
 }
 
 EVT_HANDLER(OpenGBC, "Open GBC...")
 {
-    open_dir = wxGetApp().GetAbsolutePath(gopts.gbc_rom_dir);
+    static int open_ft = 0;
+    const wxString& gbc_rom_dir = OPTION(kGBGBCROMDir);
+
     // FIXME: ignore if non-existent or not a dir
     wxString pats = _(
         "Game Boy Color Files (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|"
@@ -189,7 +196,7 @@ EVT_HANDLER(OpenGBC, "Open GBC...")
         "*.dmg.z;*.gb.z;*.gbc.z;*.cgb.z;*.sgb.z;"
         "*.zip;*.7z;*.rar|");
     pats.append(wxALL_FILES);
-    wxFileDialog dlg(this, _("Open GBC ROM file"), open_dir, wxT(""),
+    wxFileDialog dlg(this, _("Open GBC ROM file"), gbc_rom_dir, "",
         pats,
         wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     dlg.SetFilterIndex(open_ft);
@@ -198,7 +205,9 @@ EVT_HANDLER(OpenGBC, "Open GBC...")
         wxGetApp().pending_load = dlg.GetPath();
 
     open_ft = dlg.GetFilterIndex();
-    open_dir = dlg.GetDirectory();
+    if (gbc_rom_dir.empty()) {
+        OPTION(kGBGBCROMDir) = dlg.GetDirectory();
+    }
 }
 
 EVT_HANDLER(RecentReset, "Reset recent ROM list")
@@ -1174,7 +1183,7 @@ EVT_HANDLER_MASK(ExportGamesharkSnapshot, "Export GameShark snapshot...", CMDEN_
 
 EVT_HANDLER_MASK(ScreenCapture, "Screen capture...", CMDEN_GB | CMDEN_GBA)
 {
-    wxString scap_path = GetGamePath(gopts.scrshot_dir);
+    wxString scap_path = GetGamePath(OPTION(kGenScreenshotDir));
     wxString def_name = panel->game_name();
 
     const int capture_format = OPTION(kPrefCaptureFormat);
@@ -1250,7 +1259,7 @@ EVT_HANDLER_MASK(RecordSoundStartRecording, "Start sound recording...", CMDEN_NS
             sound_extno = extno;
     }
 
-    sound_path = GetGamePath(gopts.recording_dir);
+    sound_path = GetGamePath(OPTION(kGenRecordingDir));
     wxString def_name = panel->game_name();
     wxString extoff = sound_exts;
 
@@ -1320,7 +1329,7 @@ EVT_HANDLER_MASK(RecordAVIStartRecording, "Start video recording...", CMDEN_NVRE
             vid_extno = extno;
     }
 
-    vid_path = GetGamePath(gopts.recording_dir);
+    vid_path = GetGamePath(OPTION(kGenRecordingDir));
     wxString def_name = panel->game_name();
     wxString extoff = vid_exts;
 
@@ -1391,7 +1400,7 @@ EVT_HANDLER_MASK(RecordMovieStartRecording, "Start game recording...", CMDEN_NGR
             mov_extno = extno;
     }
 
-    mov_path = GetGamePath(gopts.recording_dir);
+    mov_path = GetGamePath(OPTION(kGenRecordingDir));
     wxString def_name = panel->game_name();
     wxString extoff = mov_exts;
 
@@ -1457,7 +1466,7 @@ EVT_HANDLER_MASK(PlayMovieStartPlaying, "Start playing movie...", CMDEN_NGREC | 
             mov_extno = extno;
     }
 
-    mov_path = GetGamePath(gopts.recording_dir);
+    mov_path = GetGamePath(OPTION(kGenRecordingDir));
     systemStopGamePlayback();
     wxString def_name = panel->game_name();
     wxString extoff = mov_exts;
@@ -2747,10 +2756,7 @@ EVT_HANDLER_MASK(SoundConfigure, "Sound options...", CMDEN_NREC_ANY)
 
 EVT_HANDLER(EmulatorDirectories, "Directories...")
 {
-    wxDialog* dlg = GetXRCDialog("DirectoriesConfig");
-
-    if (ShowModal(dlg) == wxID_OK)
-        update_opts();
+    ShowModal(GetXRCDialog("DirectoriesConfig"));
 }
 
 EVT_HANDLER(JoypadConfigure, "Joypad options...")

--- a/src/wx/config/internal/option-internal.cpp
+++ b/src/wx/config/internal/option-internal.cpp
@@ -4,9 +4,10 @@
 // separately. These should not be updated very often, so having these in a
 // separate file improves incremental build time.
 
-#include <wx/log.h>
 #include <algorithm>
 #include <limits>
+
+#include <wx/log.h>
 
 #include "../System.h"
 #include "../gb/gbGlobals.h"
@@ -165,6 +166,11 @@ std::array<Option, kNbOptions>& Option::All() {
         wxString gb_bios = wxEmptyString;
         bool colorizer_hack = false;
         wxString gbc_bios = wxEmptyString;
+        wxString gb_rom_dir = wxEmptyString;
+        wxString gbc_rom_dir = wxEmptyString;
+
+        /// GBA
+        wxString gba_rom_dir;
 
         /// Core
         bool agb_print = false;
@@ -179,6 +185,10 @@ std::array<Option, kNbOptions>& Option::All() {
         bool show_speed_transparent = false;
 
         /// General
+        wxString battery_dir = wxEmptyString;
+        wxString recording_dir = wxEmptyString;
+        wxString screenshot_dir = wxEmptyString;
+        wxString state_dir = wxEmptyString;
         uint32_t ini_version = kIniLatestVersion;
 
         /// Geometry
@@ -224,8 +234,8 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kGBPalette2, systemGbPalette + 16),
         Option(OptionID::kGBPrintAutoPage, &gopts.print_auto_page),
         Option(OptionID::kGBPrintScreenCap, &gopts.print_screen_cap),
-        Option(OptionID::kGBROMDir, &gopts.gb_rom_dir),
-        Option(OptionID::kGBGBCROMDir, &gopts.gbc_rom_dir),
+        Option(OptionID::kGBROMDir, &g_owned_opts.gb_rom_dir),
+        Option(OptionID::kGBGBCROMDir, &g_owned_opts.gbc_rom_dir),
 
         /// GBA
         Option(OptionID::kGBABiosFile, &gopts.gba_bios),
@@ -240,16 +250,16 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kGBALinkTimeout, &gopts.link_timeout, 0, 9999999),
         Option(OptionID::kGBALinkType, &gopts.gba_link_type, 0, 5),
 #endif
-        Option(OptionID::kGBAROMDir, &gopts.gba_rom_dir),
+        Option(OptionID::kGBAROMDir, &g_owned_opts.gba_rom_dir),
 
         /// General
         Option(OptionID::kGenAutoLoadLastState, &gopts.autoload_state),
-        Option(OptionID::kGenBatteryDir, &gopts.battery_dir),
+        Option(OptionID::kGenBatteryDir, &g_owned_opts.battery_dir),
         Option(OptionID::kGenFreezeRecent, &gopts.recent_freeze),
-        Option(OptionID::kGenRecordingDir, &gopts.recording_dir),
+        Option(OptionID::kGenRecordingDir, &g_owned_opts.recording_dir),
         Option(OptionID::kGenRewindInterval, &gopts.rewind_interval, 0, 600),
-        Option(OptionID::kGenScreenshotDir, &gopts.scrshot_dir),
-        Option(OptionID::kGenStateDir, &gopts.state_dir),
+        Option(OptionID::kGenScreenshotDir, &g_owned_opts.screenshot_dir),
+        Option(OptionID::kGenStateDir, &g_owned_opts.state_dir),
         Option(OptionID::kGenStatusBar, &gopts.statusbar),
         Option(OptionID::kGenIniVersion, &g_owned_opts.ini_version, 0, std::numeric_limits<uint32_t>::max()),
 

--- a/src/wx/config/option-proxy.h
+++ b/src/wx/config/option-proxy.h
@@ -247,7 +247,7 @@ public:
     bool Set(const wxString& value) { return option_->SetString(value); }
 
     bool operator=(wxString value) { return Set(value); }
-    operator wxString() const { return Get(); }
+    operator const wxString&() const { return Get(); }
 
 private:
     Option* option_;

--- a/src/wx/dialogs/directories-config.cpp
+++ b/src/wx/dialogs/directories-config.cpp
@@ -1,0 +1,88 @@
+#include "dialogs/directories-config.h"
+
+#include <wx/filepicker.h>
+
+#include <wx/xrc/xmlres.h>
+
+#include "dialogs/validated-child.h"
+#include "widgets/option-validator.h"
+
+namespace dialogs {
+
+namespace {
+
+// Custom validator for a kString Option and a wxDirPickerCtrl widget.
+class DirectoryStringValidator final : public widgets::OptionValidator {
+public:
+    DirectoryStringValidator(config::OptionID option_id)
+        : widgets::OptionValidator(option_id) {
+        assert(option()->is_string());
+    }
+    ~DirectoryStringValidator() final = default;
+
+private:
+    // widgets::OptionValidator implementation.
+    wxObject* Clone() const final {
+        return new DirectoryStringValidator(option()->id());
+    }
+
+    bool IsWindowValueValid() final { return true; }
+
+    bool WriteToWindow() final {
+        wxDirPickerCtrl* dir_picker =
+            wxDynamicCast(GetWindow(), wxDirPickerCtrl);
+        assert(dir_picker);
+        dir_picker->SetPath(option()->GetString());
+        return true;
+    }
+
+    bool WriteToOption() final {
+        const wxDirPickerCtrl* dir_picker =
+            wxDynamicCast(GetWindow(), wxDirPickerCtrl);
+        assert(dir_picker);
+        return option()->SetString(dir_picker->GetPath());
+    }
+};
+
+void SetUpDirPicker(wxDirPickerCtrl* dir_picker,
+                    const config::OptionID& option_id) {
+    dir_picker->SetValidator(DirectoryStringValidator(option_id));
+    dir_picker->GetPickerCtrl()->SetLabel(_("Browse"));
+}
+
+}  // namespace
+
+// static
+DirectoriesConfig* DirectoriesConfig::NewInstance(wxWindow* parent) {
+    assert(parent);
+    return new DirectoriesConfig(parent);
+}
+
+DirectoriesConfig::DirectoriesConfig(wxWindow* parent)
+    : wxDialog(), keep_on_top_styler_(this) {
+#if !wxCHECK_VERSION(3, 1, 0)
+    // This needs to be set before loading any element on the window. This also
+    // has no effect since wx 3.1.0, where it became the default.
+    this->SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY);
+#endif
+    wxXmlResource::Get()->LoadDialog(this, parent, "DirectoriesConfig");
+
+    SetUpDirPicker(GetValidatedChild<wxDirPickerCtrl>(this, "GBARoms"),
+                   config::OptionID::kGBAROMDir);
+    SetUpDirPicker(GetValidatedChild<wxDirPickerCtrl>(this, "GBRoms"),
+                   config::OptionID::kGBROMDir);
+    SetUpDirPicker(GetValidatedChild<wxDirPickerCtrl>(this, "GBCRoms"),
+                   config::OptionID::kGBGBCROMDir);
+    SetUpDirPicker(GetValidatedChild<wxDirPickerCtrl>(this, "BatSaves"),
+                   config::OptionID::kGenBatteryDir);
+    SetUpDirPicker(GetValidatedChild<wxDirPickerCtrl>(this, "StateSaves"),
+                   config::OptionID::kGenStateDir);
+    SetUpDirPicker(GetValidatedChild<wxDirPickerCtrl>(this, "Screenshots"),
+                   config::OptionID::kGenScreenshotDir);
+    SetUpDirPicker(GetValidatedChild<wxDirPickerCtrl>(this, "Recordings"),
+                   config::OptionID::kGenRecordingDir);
+
+    this->Fit();
+}
+
+}  // namespace dialogs

--- a/src/wx/dialogs/directories-config.h
+++ b/src/wx/dialogs/directories-config.h
@@ -1,0 +1,27 @@
+#ifndef VBAM_WX_DIALOGS_DIRECTORIES_CONFIG_H_
+#define VBAM_WX_DIALOGS_DIRECTORIES_CONFIG_H_
+
+#include <wx/dialog.h>
+
+#include "widgets/keep-on-top-styler.h"
+
+namespace dialogs {
+
+// Manages the directories configuration dialog.
+class DirectoriesConfig : public wxDialog {
+public:
+    static DirectoriesConfig* NewInstance(wxWindow* parent);
+    ~DirectoriesConfig() override = default;
+
+private:
+    // The constructor is private so initialization has to be done via the
+    // static method. This is because this class is destroyed when its
+    // owner, `parent` is destroyed. This prevents accidental deletion.
+    DirectoriesConfig(wxWindow* parent);
+
+    const widgets::KeepOnTopStyler keep_on_top_styler_;
+};
+
+}  // namespace dialogs
+
+#endif  // VBAM_WX_DIALOGS_DIRECTORIES_CONFIG_H_

--- a/src/wx/dialogs/game-boy-config.cpp
+++ b/src/wx/dialogs/game-boy-config.cpp
@@ -18,7 +18,6 @@
 #include "dialogs/validated-child.h"
 #include "widgets/group-check-box.h"
 #include "widgets/option-validator.h"
-#include "wx/object.h"
 
 namespace dialogs {
 

--- a/src/wx/gfxviewers.cpp
+++ b/src/wx/gfxviewers.cpp
@@ -1588,7 +1588,7 @@ public:
     {
         (void)ev; // unused params
         GameArea* panel = wxGetApp().frame->GetPanel();
-        wxString bmp_save_dir = wxGetApp().frame->GetGamePath(gopts.scrshot_dir);
+        wxString bmp_save_dir = wxGetApp().frame->GetGamePath(OPTION(kGenScreenshotDir));
         // no attempt is made here to translate the dialog type name
         // it's just a suggested name, anyway
         wxString def_name = panel->game_name() + wxT('-') + dname;
@@ -1731,7 +1731,7 @@ public:
     {
         (void)ev; // unused params
         GameArea* panel = wxGetApp().frame->GetPanel();
-        wxString bmp_save_dir = wxGetApp().frame->GetGamePath(gopts.scrshot_dir);
+        wxString bmp_save_dir = wxGetApp().frame->GetGamePath(OPTION(kGenScreenshotDir));
         // no attempt is made here to translate the dialog type name
         // it's just a suggested name, anyway
         wxString def_name = panel->game_name() + wxT('-') + dname;

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -28,6 +28,7 @@
 #include "config/option-proxy.h"
 #include "config/option.h"
 #include "config/user-input.h"
+#include "dialogs/directories-config.h"
 #include "dialogs/display-config.h"
 #include "dialogs/game-boy-config.h"
 #include "opts.h"
@@ -2418,12 +2419,6 @@ void MainFrame::BindAppIcon() {
     SetIcon(icon);
 }
 
-static void setCustomLabelForFilePicker(wxDirPickerCtrl* dp)
-{
-    wxButton *pButt = static_cast<wxButton*>(dp->GetPickerCtrl());
-    if (pButt) pButt->SetLabel(_("Browse"));
-}
-
 // If there is a menubar, store all special menuitems
 #define XRCITEM_I(id) menubar->FindItem(id, NULL)
 #define XRCITEM_D(s) XRCITEM_I(XRCID_D(s))
@@ -3317,30 +3312,7 @@ bool MainFrame::BindControls()
             getsl("GBASoundFiltering", gopts.gba_sound_filter);
             d->Fit();
         }
-        wxDirPickerCtrl* dp;
-#define getdp(n, o)                                     \
-    do {                                                \
-        dp = SafeXRCCTRL<wxDirPickerCtrl>(d, n);        \
-        dp->SetValidator(wxFileDirPickerValidator(&o)); \
-    } while (0)
-        d = LoadXRCDialog("DirectoriesConfig");
-        {
-            getdp("GBARoms", gopts.gba_rom_dir);
-            setCustomLabelForFilePicker(dp);
-            getdp("GBRoms", gopts.gb_rom_dir);
-            setCustomLabelForFilePicker(dp);
-            getdp("GBCRoms", gopts.gbc_rom_dir);
-            setCustomLabelForFilePicker(dp);
-            getdp("BatSaves", gopts.battery_dir);
-            setCustomLabelForFilePicker(dp);
-            getdp("StateSaves", gopts.state_dir);
-            setCustomLabelForFilePicker(dp);
-            getdp("Screenshots", gopts.scrshot_dir);
-            setCustomLabelForFilePicker(dp);
-            getdp("Recordings", gopts.recording_dir);
-            setCustomLabelForFilePicker(dp);
-            d->Fit();
-        }
+        dialogs::DirectoriesConfig::NewInstance(this);
         wxDialog* joyDialog = LoadXRCropertySheetDialog("JoypadConfig");
 
         for (int i = 0; i < 4; i++) {

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -29,8 +29,6 @@ extern struct opts_t {
     bool gb_lcd_filter = false;
     bool print_auto_page = true;
     bool print_screen_cap = false;
-    wxString gb_rom_dir;
-    wxString gbc_rom_dir;
 
     /// GBA
     wxString gba_bios;
@@ -44,17 +42,12 @@ extern struct opts_t {
     bool link_proto = false;
     int link_timeout = 500;
     int gba_link_type;
-    wxString gba_rom_dir;
 
     /// General
     bool autoload_state = false;
     bool autoload_cheats = false;
-    wxString battery_dir;
     bool recent_freeze = false;
-    wxString recording_dir;
     int rewind_interval = 0;
-    wxString scrshot_dir;
-    wxString state_dir;
     bool statusbar = false;
 
     /// Joypad

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -134,9 +134,9 @@ GameArea::GameArea()
 
 void GameArea::LoadGame(const wxString& name)
 {
-    rom_scene_rls = wxT("-");
-    rom_scene_rls_name = wxT("-");
-    rom_name = wxT("");
+    rom_scene_rls = "-";
+    rom_scene_rls_name = "-";
+    rom_name = "";
     // fex just crashes if file does not exist and it's compressed,
     // so check first
     wxFileName fnfn(name);
@@ -147,18 +147,21 @@ void GameArea::LoadGame(const wxString& name)
         wxString rp = fnfn.GetPath();
 
         // can't really decide which dir to use, so try GBA first, then GB
-        if (!wxGetApp().GetAbsolutePath(gopts.gba_rom_dir).empty()) {
-            fnfn.SetPath(wxGetApp().GetAbsolutePath(gopts.gba_rom_dir) + wxT('/') + rp);
+        const wxString& gba_rom_dir = OPTION(kGBAROMDir);
+        if (!wxGetApp().GetAbsolutePath(gba_rom_dir).empty()) {
+            fnfn.SetPath(wxGetApp().GetAbsolutePath(gba_rom_dir) + '/' + rp);
             badfile = !fnfn.IsFileReadable();
         }
 
-        if (badfile && !wxGetApp().GetAbsolutePath(gopts.gb_rom_dir).empty()) {
-            fnfn.SetPath(wxGetApp().GetAbsolutePath(gopts.gb_rom_dir) + wxT('/') + rp);
+        const wxString& gb_rom_dir = OPTION(kGBROMDir);
+        if (badfile && !wxGetApp().GetAbsolutePath(gb_rom_dir).empty()) {
+            fnfn.SetPath(wxGetApp().GetAbsolutePath(gb_rom_dir) + '/' + rp);
             badfile = !fnfn.IsFileReadable();
         }
 
-        if (badfile && !wxGetApp().GetAbsolutePath(gopts.gbc_rom_dir).empty()) {
-            fnfn.SetPath(wxGetApp().GetAbsolutePath(gopts.gbc_rom_dir) + wxT('/') + rp);
+        const wxString& gbc_rom_dir = OPTION(kGBGBCROMDir);
+        if (badfile && !wxGetApp().GetAbsolutePath(gbc_rom_dir).empty()) {
+            fnfn.SetPath(wxGetApp().GetAbsolutePath(gbc_rom_dir) + '/' + rp);
             badfile = !fnfn.IsFileReadable();
         }
     }
@@ -549,24 +552,24 @@ void GameArea::SetFrameTitle()
 
 void GameArea::recompute_dirs()
 {
-    batdir = gopts.battery_dir;
+    batdir = OPTION(kGenBatteryDir);
 
-    if (!batdir.size()) {
+    if (batdir.empty()) {
         batdir = loaded_game.GetPathWithSep();
     } else {
-        batdir = wxGetApp().GetAbsolutePath(gopts.battery_dir);
+        batdir = wxGetApp().GetAbsolutePath(batdir);
     }
 
     if (!wxIsWritable(batdir)) {
         batdir = wxGetApp().GetDataDir();
     }
 
-    statedir = gopts.state_dir;
+    statedir = OPTION(kGenStateDir);
 
-    if (!statedir.size()) {
+    if (statedir.empty()) {
         statedir = loaded_game.GetPathWithSep();
     } else {
-        statedir = wxGetApp().GetAbsolutePath(gopts.state_dir);
+        statedir = wxGetApp().GetAbsolutePath(statedir);
     }
 
     if (!wxIsWritable(statedir)) {

--- a/src/wx/sys.cpp
+++ b/src/wx/sys.cpp
@@ -547,7 +547,7 @@ void systemFrame()
 void systemScreenCapture(int num)
 {
     GameArea* panel = wxGetApp().frame->GetPanel();
-    wxFileName fn = wxFileName(wxGetApp().frame->GetGamePath(gopts.scrshot_dir), wxEmptyString);
+    wxFileName fn = wxFileName(wxGetApp().frame->GetGamePath(OPTION(kGenScreenshotDir)), wxEmptyString);
 
     const int capture_format = OPTION(kPrefCaptureFormat);
     do {
@@ -1104,7 +1104,7 @@ void systemGbPrint(uint8_t* data, int len, int pages, int feed, int pal, int con
     }
 
     if (gopts.print_screen_cap) {
-        wxFileName fn = wxFileName(wxGetApp().frame->GetGamePath(gopts.scrshot_dir), wxEmptyString);
+        wxFileName fn = wxFileName(wxGetApp().frame->GetGamePath(OPTION(kGenScreenshotDir)), wxEmptyString);
         int num = 1;
         const int capture_format = OPTION(kPrefCaptureFormat);
 

--- a/src/wx/viewsupt.cpp
+++ b/src/wx/viewsupt.cpp
@@ -1168,7 +1168,7 @@ void GfxViewer::SaveBMP(wxCommandEvent& ev)
 {
     (void)ev; // unused params
     GameArea* panel = wxGetApp().frame->GetPanel();
-    bmp_save_dir = wxGetApp().frame->GetGamePath(gopts.scrshot_dir);
+    bmp_save_dir = wxGetApp().frame->GetGamePath(OPTION(kGenScreenshotDir));
     // no attempt is made here to translate the dialog type name
     // it's just a suggested name, anyway
     wxString def_name = panel->game_name() + wxT('-') + dname;


### PR DESCRIPTION
* Moves most directory settings to g_owned_opts.
* Converts the DirectoriesConfig dialog to the new structure.
* Various includes clean-ups.

Breaking change: Loading a GB/GBC/GBA ROM when the ROM directory setting is unset for that platform will now populate the per-platform ROM directory setting.