### PR TITLE
Remove global variables for ROM data

### DIFF
--- a/src/gb/gb.h
+++ b/src/gb/gb.h
@@ -63,9 +63,6 @@ void setColorizerHack(bool value);
 bool allowColorizerHack(void);
 
 extern int gbHardware;
-extern int gbRomType; // gets type from header 0x147
-extern int gbBattery; // enabled when gbRamSize != 0
-extern int gbRTCPresent;  // gbROM has RTC support
 
 extern gbCartData g_gbCartData;
 extern struct EmulatedSystem GBSystem;

--- a/src/gb/gbGlobals.cpp
+++ b/src/gb/gbGlobals.cpp
@@ -3,11 +3,6 @@
 
 uint8_t* gbMemoryMap[16];
 
-int gbRomSizeMask = 0;
-int gbRomSize = 0;
-int gbRamSizeMask = 0;
-int gbRamSize = 0;
-
 uint8_t* gbMemory = nullptr;
 uint8_t* gbVram = nullptr;
 uint8_t* gbRom = nullptr;
@@ -22,9 +17,6 @@ uint8_t gbObp0[4] = { 0, 1, 2, 3 };
 uint8_t gbObp1[4] = { 0, 1, 2, 3 };
 int gbWindowLine = -1;
 
-bool genericflashcardEnable = false;
-int gbCgbMode = 0;
-
 uint16_t gbColorFilter[32768];
 uint32_t gbEmulatorType = 0;
 uint32_t gbPaletteOption = 0;
@@ -34,6 +26,8 @@ int gbBorderColumnSkip = 0;
 int gbDmaTicks = 0;
 bool gbBorderAutomatic = false;
 bool gbBorderOn = false;
+bool gbCgbMode = false;
+bool gbSgbMode = false;
 bool gbColorOption = false;
 
 uint8_t (*gbSerialFunction)(uint8_t) = NULL;

--- a/src/gb/gbGlobals.h
+++ b/src/gb/gbGlobals.h
@@ -3,11 +3,6 @@
 
 #include "../common/Types.h"
 
-extern int gbRomSizeMask;
-extern int gbRomSize;
-extern int gbRamSize;
-extern int gbRamSizeMask;
-
 extern uint8_t* bios;
 
 extern uint8_t* gbRom;
@@ -24,8 +19,8 @@ extern int gbFrameSkip;
 extern uint16_t gbColorFilter[32768];
 extern uint32_t gbEmulatorType;
 extern uint32_t gbPaletteOption;
-extern int gbCgbMode;
-extern int gbSgbMode;
+extern bool gbCgbMode;
+extern bool gbSgbMode;
 extern int gbWindowLine;
 extern int gbSpeed;
 extern uint8_t gbBgp[4];
@@ -58,7 +53,6 @@ extern uint8_t register_VBK;
 extern uint8_t oldRegister_WY;
 
 extern int emulating;
-extern bool genericflashcardEnable;
 
 extern int gbBorderLineSkip;
 extern int gbBorderRowSkip;

--- a/src/gb/gbSGB.cpp
+++ b/src/gb/gbSGB.cpp
@@ -20,7 +20,6 @@ uint8_t* gbSgbBorder = NULL;
 
 int gbSgbCGBSupport = 0;
 int gbSgbMask = 0;
-int gbSgbMode = 0;
 int gbSgbPacketState = GBSGB_NONE;
 int gbSgbBit = 0;
 int gbSgbPacketTimeout = 0;
@@ -328,7 +327,7 @@ void gbSgbPicture()
 
     if (gbSgbMode && gbCgbMode && gbSgbCGBSupport > 4) {
         gbSgbCGBSupport = 0;
-        gbSgbMode = 0;
+        gbSgbMode = false;
         gbSgbMask = 0;
         gbSgbRenderBorder();
         gbReset();
@@ -672,7 +671,7 @@ void gbSgbChrTransfer()
 
     if (gbSgbMode && gbCgbMode && gbSgbCGBSupport == 7) {
         gbSgbCGBSupport = 0;
-        gbSgbMode = 0;
+        gbSgbMode = false;
         gbSgbMask = 0;
         gbSgbRenderBorder();
         gbReset();

--- a/src/gb/gbSGB.h
+++ b/src/gb/gbSGB.h
@@ -17,7 +17,6 @@ void gbSgbReadGame(gzFile, int version);
 #endif
 
 extern uint8_t gbSgbATF[20 * 18];
-extern int gbSgbMode;
 extern int gbSgbMask;
 extern int gbSgbMultiplayer;
 extern uint8_t gbSgbNextController;

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -751,21 +751,9 @@ EVT_HANDLER_MASK(RomInformation, "ROM information...", CMDEN_GB | CMDEN_GBA)
         setblab("DestCode", gbRom[0x14a]);
         setblab("LicCode", gbRom[0x14b]);
         setblab("Version", gbRom[0x14c]);
-        uint8_t crc = 25;
-
-        for (int i = 0x134; i < 0x14d; i++)
-            crc += gbRom[i];
-
-        crc = 256 - crc;
-        s.Printf(wxT("%02x (%02x)"), crc, gbRom[0x14d]);
+        s.Printf(wxT("%02x (%02x)"), g_gbCartData.actual_header_checksum(), g_gbCartData.header_checksum());
         setlab("CRC");
-        uint16_t crc16 = 0;
-
-        for (int i = 0; i < gbRomSize; i++)
-            crc16 += gbRom[i];
-
-        crc16 -= gbRom[0x14e] + gbRom[0x14f];
-        s.Printf(wxT("%04x (%04x)"), crc16, gbRom[0x14e] * 256 + gbRom[0x14f]);
+        s.Printf(wxT("%04x (%04x)"), g_gbCartData.actual_global_checksum(), g_gbCartData.global_checksum());
         setlab("Checksum");
         dlg->Fit();
         ShowModal(dlg);

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -946,9 +946,9 @@ public:
                 else
                     block->data = &gbMemory[0xa000];
 
-                block->saved = (uint8_t*)malloc(gbRamSize);
-                block->size = gbRamSize;
-                block->bits = (uint8_t*)malloc(gbRamSize >> 3);
+                block->saved = (uint8_t*)malloc(g_gbCartData.ram_size());
+                block->size = g_gbCartData.ram_size();
+                block->bits = (uint8_t*)malloc(g_gbCartData.ram_size() >> 3);
 
                 if (gbCgbMode) {
                     block++;


### PR DESCRIPTION
These can be accessed via the global gbCartData object. In addition, this cleans up gbMemory to remove dead code that was used as a workaround for ROM hacks.