### PR TITLE
Properly initialize wxAcceleratorTable

### DIFF
--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2302,7 +2302,7 @@ void MainFrame::set_global_accels()
             len++;
 
     if (len) {
-        wxAcceleratorEntryUnicode tab[1000];
+        wxAcceleratorEntry tab[1000];
 
         for (size_t i = 0, j = 0; i < accels.size(); i++)
             if (!accels[i].GetMenuItem())


### PR DESCRIPTION
The `wxAcceleratorTable` for the `GameArea` panel was initialized with an array of `wxAcceleratorEntryUnicode`, while the API calls for an array of `wxAcceleratorEntry`. This resulted in the array not being properly interpreted by the `wxAcceleratorEntry`. This fixes the issue by using `wxAcceleratorEntry` to instantiate the array.