### PR TITLE
Refactor accelerator / global shortcuts handling

### DIFF
--- a/po/wxvbam/wxvbam.pot
+++ b/po/wxvbam/wxvbam.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-05-03 20:32-0700\n"
+"POT-Creation-Date: 2023-05-11 16:43-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,60 +17,60 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: wxvbam.cpp:275
+#: wxvbam.cpp:283
 msgid "visualboyadvance-m"
 msgstr ""
 
-#: wxvbam.cpp:346 wxvbam.cpp:363
+#: wxvbam.cpp:354 wxvbam.cpp:371
 #, c-format
 msgid "Invalid configuration file provided: %s"
 msgstr ""
 
-#: wxvbam.cpp:502
+#: wxvbam.cpp:510
 msgid "Could not create main window"
 msgstr ""
 
-#: wxvbam.cpp:583
+#: wxvbam.cpp:591
 msgid "Save built-in XRC file and exit"
 msgstr ""
 
-#: wxvbam.cpp:586
+#: wxvbam.cpp:594
 msgid "Save built-in vba-over.ini and exit"
 msgstr ""
 
-#: wxvbam.cpp:589
+#: wxvbam.cpp:597
 msgid "Print configuration path and exit"
 msgstr ""
 
-#: wxvbam.cpp:592
+#: wxvbam.cpp:600
 msgid "Start in full-screen mode"
 msgstr ""
 
-#: wxvbam.cpp:595
+#: wxvbam.cpp:603
 msgid "Set a configuration file"
 msgstr ""
 
-#: wxvbam.cpp:599
+#: wxvbam.cpp:607
 msgid "Delete shared link state first, if it exists"
 msgstr ""
 
-#: wxvbam.cpp:606
+#: wxvbam.cpp:614
 msgid "List all settable options and exit"
 msgstr ""
 
-#: wxvbam.cpp:609
+#: wxvbam.cpp:617
 msgid "ROM file"
 msgstr ""
 
-#: wxvbam.cpp:611
+#: wxvbam.cpp:619
 msgid "<config>=<value>"
 msgstr ""
 
-#: wxvbam.cpp:642
+#: wxvbam.cpp:650
 msgid "Configuration / build error: can't find built-in xrc"
 msgstr ""
 
-#: wxvbam.cpp:650
+#: wxvbam.cpp:658
 #, c-format
 msgid ""
 "Wrote built-in configuration to %s.\n"
@@ -79,11 +79,11 @@ msgid ""
 "built-in:"
 msgstr ""
 
-#: wxvbam.cpp:664
+#: wxvbam.cpp:672
 msgid "Configuration is read from, in order:"
 msgstr ""
 
-#: wxvbam.cpp:678
+#: wxvbam.cpp:686
 #, c-format
 msgid ""
 "Wrote built-in override file to %s\n"
@@ -91,13 +91,13 @@ msgid ""
 "from search path:"
 msgstr ""
 
-#: wxvbam.cpp:684
+#: wxvbam.cpp:692
 msgid ""
 "\n"
 "\tbuilt-in"
 msgstr ""
 
-#: wxvbam.cpp:699
+#: wxvbam.cpp:707
 msgid ""
 "Options set from the command line are saved if any configuration changes are "
 "made in the user interface.\n"
@@ -106,213 +106,187 @@ msgid ""
 "\n"
 msgstr ""
 
-#: wxvbam.cpp:707
+#: wxvbam.cpp:715
 msgid ""
 "The commands available for the Keyboard/* option are:\n"
 "\n"
 msgstr ""
 
-#: wxvbam.cpp:718
+#: wxvbam.cpp:726
 msgid "Configuration file not found."
 msgstr ""
 
-#: wxvbam.cpp:749
+#: wxvbam.cpp:757
 msgid "Bad configuration option or multiple ROM files given:\n"
 msgstr ""
 
-#: guiinit.cpp:90
+#: guiinit.cpp:102
 msgid "Start!"
 msgstr ""
 
-#: guiinit.cpp:109 xrc/NetLink.xrc:99
+#: guiinit.cpp:121 xrc/NetLink.xrc:99
 msgid "Connect"
 msgstr ""
 
-#: guiinit.cpp:126
+#: guiinit.cpp:138
 msgid "You must enter a valid host name"
 msgstr ""
 
-#: guiinit.cpp:127
+#: guiinit.cpp:139
 msgid "Host name invalid"
 msgstr ""
 
-#: guiinit.cpp:145
+#: guiinit.cpp:157
 msgid "Waiting for clients..."
 msgstr ""
 
-#: guiinit.cpp:146
+#: guiinit.cpp:158
 #, c-format
 msgid "Server IP address is: %s\n"
 msgstr ""
 
-#: guiinit.cpp:148
+#: guiinit.cpp:160
 msgid "Waiting for connection..."
 msgstr ""
 
-#: guiinit.cpp:149
+#: guiinit.cpp:161
 #, c-format
 msgid "Connecting to %s\n"
 msgstr ""
 
-#: guiinit.cpp:182
+#: guiinit.cpp:194
 msgid ""
 "Error occurred.\n"
 "Please try again."
 msgstr ""
 
-#: guiinit.cpp:249 guiinit.cpp:302
+#: guiinit.cpp:261 guiinit.cpp:314
 msgid "Select cheat file"
 msgstr ""
 
-#: guiinit.cpp:250
+#: guiinit.cpp:262
 msgid "VBA cheat lists (*.clt)|*.clt|CHT cheat lists (*.cht)|*.cht"
 msgstr ""
 
-#: guiinit.cpp:269 panel.cpp:518
+#: guiinit.cpp:281 panel.cpp:516
 msgid "Loaded cheats"
 msgstr ""
 
-#: guiinit.cpp:303
+#: guiinit.cpp:315
 msgid "VBA cheat lists (*.clt)|*.clt"
 msgstr ""
 
-#: guiinit.cpp:321
+#: guiinit.cpp:333
 msgid "Saved cheats"
 msgstr ""
 
-#: guiinit.cpp:352 guiinit.cpp:371
+#: guiinit.cpp:364 guiinit.cpp:383
 msgid "Restore old values?"
 msgstr ""
 
-#: guiinit.cpp:353 guiinit.cpp:372
+#: guiinit.cpp:365 guiinit.cpp:384
 msgid "Removing cheats"
 msgstr ""
 
-#: guiinit.cpp:763 xrc/JoyPanel.xrc:364
+#: guiinit.cpp:775 xrc/JoyPanel.xrc:364
 msgid "Game Shark"
 msgstr ""
 
-#: guiinit.cpp:764 cmdevents.cpp:656
+#: guiinit.cpp:776 cmdevents.cpp:653
 msgid "Game Genie"
 msgstr ""
 
-#: guiinit.cpp:766
+#: guiinit.cpp:778
 msgid "Generic Code"
 msgstr ""
 
-#: guiinit.cpp:767
+#: guiinit.cpp:779
 msgid "Game Shark Advance"
 msgstr ""
 
-#: guiinit.cpp:768
+#: guiinit.cpp:780
 msgid "Code Breaker Advance"
 msgstr ""
 
-#: guiinit.cpp:769
+#: guiinit.cpp:781
 msgid "Flashcart CHT"
 msgstr ""
 
-#: guiinit.cpp:837 guiinit.cpp:1092
+#: guiinit.cpp:849 guiinit.cpp:1104
 msgid "Number cannot be empty"
 msgstr ""
 
-#: guiinit.cpp:887
+#: guiinit.cpp:899
 msgid "Search produced no results"
 msgstr ""
 
-#: guiinit.cpp:1050
+#: guiinit.cpp:1062
 msgid "8-bit "
 msgstr ""
 
-#: guiinit.cpp:1054
+#: guiinit.cpp:1066
 msgid "16-bit "
 msgstr ""
 
-#: guiinit.cpp:1058
+#: guiinit.cpp:1070
 msgid "32-bit "
 msgstr ""
 
-#: guiinit.cpp:1064
+#: guiinit.cpp:1076
 msgid "signed decimal"
 msgstr ""
 
-#: guiinit.cpp:1068
+#: guiinit.cpp:1080
 msgid "unsigned decimal"
 msgstr ""
 
-#: guiinit.cpp:1072
+#: guiinit.cpp:1084
 msgid "unsigned hexadecimal"
 msgstr ""
 
-#: guiinit.cpp:1473
+#: guiinit.cpp:1485
 #, c-format
 msgid "%d frames = %.2f ms"
 msgstr ""
 
-#: guiinit.cpp:1485
+#: guiinit.cpp:1497
 msgid "Default device"
 msgstr ""
 
-#: guiinit.cpp:1820
-msgid "This will clear all user-defined accelerators. Are you sure?"
-msgstr ""
-
-#: guiinit.cpp:1821
-msgid "Confirm"
-msgstr ""
-
-#: guiinit.cpp:2410
+#: guiinit.cpp:1950
 msgid "Main icon not found"
 msgstr ""
 
-#: guiinit.cpp:2428
+#: guiinit.cpp:1968
 msgid "Main display panel not found"
 msgstr ""
 
-#: guiinit.cpp:2594
-#, c-format
-msgid "Duplicate menu accelerator: %s for %s and %s; keeping first"
-msgstr ""
-
-#: guiinit.cpp:2608
-#, c-format
-msgid "Menu accelerator %s for %s overrides default for %s; keeping menu"
-msgstr ""
-
-#: guiinit.cpp:2747
+#: guiinit.cpp:2239
 #, c-format
 msgid "Invalid menu item %s; removing"
 msgstr ""
 
-#: guiinit.cpp:2946
+#: guiinit.cpp:2438
 msgid "Code"
 msgstr ""
 
-#: guiinit.cpp:2955
+#: guiinit.cpp:2447
 msgid "Description"
 msgstr ""
 
-#: guiinit.cpp:3029 xrc/CheatAdd.xrc:31
+#: guiinit.cpp:2521 xrc/CheatAdd.xrc:31
 msgid "Address"
 msgstr ""
 
-#: guiinit.cpp:3030
+#: guiinit.cpp:2522
 msgid "Old Value"
 msgstr ""
 
-#: guiinit.cpp:3031
+#: guiinit.cpp:2523
 msgid "New Value"
 msgstr ""
 
-#: guiinit.cpp:3387
-msgid "Menu commands"
-msgstr ""
-
-#: guiinit.cpp:3410
-msgid "Other commands"
-msgstr ""
-
-#: guiinit.cpp:3510
+#: guiinit.cpp:2897
 msgid "JoyBus host invalid; disabling"
 msgstr ""
 
@@ -321,7 +295,7 @@ msgid "Text files (*.txt;*.log)|*.txt;*.log|"
 msgstr ""
 
 #: viewers.cpp:563 viewers.cpp:773 gfxviewers.cpp:1603 gfxviewers.cpp:1746
-#: cmdevents.cpp:1127 cmdevents.cpp:1205 cmdevents.cpp:1275 cmdevents.cpp:1346
+#: cmdevents.cpp:1124 cmdevents.cpp:1202 cmdevents.cpp:1272 cmdevents.cpp:1343
 #: viewsupt.cpp:1183
 msgid "Select output file"
 msgstr ""
@@ -408,11 +382,11 @@ msgid ""
 "Table (*.act)|*.act"
 msgstr ""
 
-#: gfxviewers.cpp:1604 gfxviewers.cpp:1747 cmdevents.cpp:1128 viewsupt.cpp:1184
+#: gfxviewers.cpp:1604 gfxviewers.cpp:1747 cmdevents.cpp:1125 viewsupt.cpp:1184
 msgid "PNG images|*.png|BMP images|*.bmp"
 msgstr ""
 
-#: cmdevents.cpp:132
+#: cmdevents.cpp:129
 msgid ""
 "Game Boy Advance Files (*.agb;*.gba;*.bin;*.elf;*.mb;*.zip;*.7z;*.rar)|*.agb;"
 "*.gba;*.bin;*.elf;*.mb;*.agb.gz;*.gba.gz;*.bin.gz;*.elf.gz;*.mb.gz;*.agb.z;*."
@@ -422,379 +396,379 @@ msgid ""
 "*.7z;*.rar|"
 msgstr ""
 
-#: cmdevents.cpp:143
+#: cmdevents.cpp:140
 msgid "Open ROM file"
 msgstr ""
 
-#: cmdevents.cpp:164
+#: cmdevents.cpp:161
 msgid ""
 "Game Boy Files (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg;*.gb;*."
 "gbc;*.cgb;*.sgb;*.dmg.gz;*.gb.gz;*.gbc.gz;*.cgb.gz;*.sgb.gz;*.dmg.z;*.gb.z;*."
 "gbc.z;*.cgb.z;*.sgb.z;*.zip;*.7z;*.rar|"
 msgstr ""
 
-#: cmdevents.cpp:170
+#: cmdevents.cpp:167
 msgid "Open GB ROM file"
 msgstr ""
 
-#: cmdevents.cpp:191
+#: cmdevents.cpp:188
 msgid ""
 "Game Boy Color Files (*.dmg;*.gb;*.gbc;*.cgb;*.sgb;*.zip;*.7z;*.rar)|*.dmg;*."
 "gb;*.gbc;*.cgb;*.sgb;*.dmg.gz;*.gb.gz;*.gbc.gz;*.cgb.gz;*.sgb.gz;*.dmg.z;*."
 "gb.z;*.gbc.z;*.cgb.z;*.sgb.z;*.zip;*.7z;*.rar|"
 msgstr ""
 
-#: cmdevents.cpp:197
+#: cmdevents.cpp:194
 msgid "Open GBC ROM file"
 msgstr ""
 
-#: cmdevents.cpp:564 cmdevents.cpp:680 cmdevents.cpp:719 cmdevents.cpp:780
+#: cmdevents.cpp:561 cmdevents.cpp:677 cmdevents.cpp:716 cmdevents.cpp:777
 msgid "Unknown"
 msgstr ""
 
-#: cmdevents.cpp:572
+#: cmdevents.cpp:569
 msgid "ROM"
 msgstr ""
 
-#: cmdevents.cpp:576
+#: cmdevents.cpp:573
 msgid "ROM + MBC1"
 msgstr ""
 
-#: cmdevents.cpp:580
+#: cmdevents.cpp:577
 msgid "ROM + MBC1 + RAM"
 msgstr ""
 
-#: cmdevents.cpp:584
+#: cmdevents.cpp:581
 msgid "ROM + MBC1 + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:588
+#: cmdevents.cpp:585
 msgid "ROM + MBC2"
 msgstr ""
 
-#: cmdevents.cpp:592
+#: cmdevents.cpp:589
 msgid "ROM + MBC2 + BATT"
 msgstr ""
 
-#: cmdevents.cpp:596
+#: cmdevents.cpp:593
 msgid "ROM + MMM01"
 msgstr ""
 
-#: cmdevents.cpp:600
+#: cmdevents.cpp:597
 msgid "ROM + MMM01 + RAM"
 msgstr ""
 
-#: cmdevents.cpp:604
+#: cmdevents.cpp:601
 msgid "ROM + MMM01 + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:608
+#: cmdevents.cpp:605
 msgid "ROM + MBC3 + TIMER + BATT"
 msgstr ""
 
-#: cmdevents.cpp:612
+#: cmdevents.cpp:609
 msgid "ROM + MBC3 + TIMER + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:616
+#: cmdevents.cpp:613
 msgid "ROM + MBC3"
 msgstr ""
 
-#: cmdevents.cpp:620
+#: cmdevents.cpp:617
 msgid "ROM + MBC3 + RAM"
 msgstr ""
 
-#: cmdevents.cpp:624
+#: cmdevents.cpp:621
 msgid "ROM + MBC3 + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:628
+#: cmdevents.cpp:625
 msgid "ROM + MBC5"
 msgstr ""
 
-#: cmdevents.cpp:632
+#: cmdevents.cpp:629
 msgid "ROM + MBC5 + RAM"
 msgstr ""
 
-#: cmdevents.cpp:636
+#: cmdevents.cpp:633
 msgid "ROM + MBC5 + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:640
+#: cmdevents.cpp:637
 msgid "ROM + MBC5 + RUMBLE"
 msgstr ""
 
-#: cmdevents.cpp:644
+#: cmdevents.cpp:641
 msgid "ROM + MBC5 + RUMBLE + RAM"
 msgstr ""
 
-#: cmdevents.cpp:648
+#: cmdevents.cpp:645
 msgid "ROM + MBC5 + RUMBLE + RAM + BATT"
 msgstr ""
 
-#: cmdevents.cpp:652
+#: cmdevents.cpp:649
 msgid "ROM + MBC7 + BATT"
 msgstr ""
 
-#: cmdevents.cpp:660
+#: cmdevents.cpp:657
 msgid "Game Shark 3.0"
 msgstr ""
 
-#: cmdevents.cpp:664
+#: cmdevents.cpp:661
 msgid "ROM + POCKET CAMERA"
 msgstr ""
 
-#: cmdevents.cpp:668
+#: cmdevents.cpp:665
 msgid "ROM + BANDAI TAMA5"
 msgstr ""
 
-#: cmdevents.cpp:672
+#: cmdevents.cpp:669
 msgid "ROM + HuC-3"
 msgstr ""
 
-#: cmdevents.cpp:676
+#: cmdevents.cpp:673
 msgid "ROM + HuC-1"
 msgstr ""
 
-#: cmdevents.cpp:726 dialogs/display-config.cpp:341 xrc/DisplayConfig.xrc:85
+#: cmdevents.cpp:723 dialogs/display-config.cpp:341 xrc/DisplayConfig.xrc:85
 #: xrc/DisplayConfig.xrc:135 xrc/DisplayConfig.xrc:221
 #: xrc/GameBoyAdvanceConfig.xrc:32 xrc/GameBoyAdvanceConfig.xrc:204
 #: xrc/SoundConfig.xrc:219 xrc/SoundConfig.xrc:309
 msgid "None"
 msgstr ""
 
-#: cmdevents.cpp:816 cmdevents.cpp:838
+#: cmdevents.cpp:813 cmdevents.cpp:835
 msgid "Select Dot Code file"
 msgstr ""
 
-#: cmdevents.cpp:818 cmdevents.cpp:840
+#: cmdevents.cpp:815 cmdevents.cpp:837
 msgid "e-Reader Dot Code (*.bin;*.raw)|*.bin;*.raw"
 msgstr ""
 
-#: cmdevents.cpp:859 cmdevents.cpp:1054
+#: cmdevents.cpp:856 cmdevents.cpp:1051
 msgid "Select battery file"
 msgstr ""
 
-#: cmdevents.cpp:860 cmdevents.cpp:1055
+#: cmdevents.cpp:857 cmdevents.cpp:1052
 msgid "Battery file (*.sav)|*.sav|Flash save (*.dat)|*.dat"
 msgstr ""
 
-#: cmdevents.cpp:868
+#: cmdevents.cpp:865
 msgid ""
 "Importing a battery file will erase any saved games (permanently after the "
 "next write). Do you want to continue?"
 msgstr ""
 
-#: cmdevents.cpp:869 cmdevents.cpp:897 cmdevents.cpp:1017
+#: cmdevents.cpp:866 cmdevents.cpp:894 cmdevents.cpp:1014
 msgid "Confirm import"
 msgstr ""
 
-#: cmdevents.cpp:875 panel.cpp:461
+#: cmdevents.cpp:872 panel.cpp:459
 #, c-format
 msgid "Loaded battery %s"
 msgstr ""
 
-#: cmdevents.cpp:877
+#: cmdevents.cpp:874
 #, c-format
 msgid "Error loading battery %s"
 msgstr ""
 
-#: cmdevents.cpp:886
+#: cmdevents.cpp:883
 msgid "Select code file"
 msgstr ""
 
-#: cmdevents.cpp:887
+#: cmdevents.cpp:884
 msgid "Game Shark Code File (*.spc;*.xpc)|*.spc;*.xpc"
 msgstr ""
 
-#: cmdevents.cpp:887
+#: cmdevents.cpp:884
 msgid "Game Shark Code File (*.gcf)|*.gcf"
 msgstr ""
 
-#: cmdevents.cpp:896
+#: cmdevents.cpp:893
 msgid ""
 "Importing a code file will replace any loaded cheats. Do you want to "
 "continue?"
 msgstr ""
 
-#: cmdevents.cpp:913
+#: cmdevents.cpp:910
 #, c-format
 msgid "Cannot open file %s"
 msgstr ""
 
-#: cmdevents.cpp:923
+#: cmdevents.cpp:920
 #, c-format
 msgid "Unsupported code file %s"
 msgstr ""
 
-#: cmdevents.cpp:993
+#: cmdevents.cpp:990
 #, c-format
 msgid "Loaded code file %s"
 msgstr ""
 
-#: cmdevents.cpp:995
+#: cmdevents.cpp:992
 #, c-format
 msgid "Error loading code file %s"
 msgstr ""
 
-#: cmdevents.cpp:1006 cmdevents.cpp:1082
+#: cmdevents.cpp:1003 cmdevents.cpp:1079
 msgid "Select snapshot file"
 msgstr ""
 
-#: cmdevents.cpp:1007
+#: cmdevents.cpp:1004
 msgid ""
 "Game Shark & PAC Snapshots (*.sps;*.xps)|*.sps;*.xps|Game Shark SP Snapshots "
 "(*.gsv)|*.gsv"
 msgstr ""
 
-#: cmdevents.cpp:1007
+#: cmdevents.cpp:1004
 msgid "Game Boy Snapshot (*.gbs)|*.gbs"
 msgstr ""
 
-#: cmdevents.cpp:1016
+#: cmdevents.cpp:1013
 msgid ""
 "Importing a snapshot file will erase any saved games (permanently after the "
 "next write). Do you want to continue?"
 msgstr ""
 
-#: cmdevents.cpp:1041
+#: cmdevents.cpp:1038
 #, c-format
 msgid "Loaded snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1043
+#: cmdevents.cpp:1040
 #, c-format
 msgid "Error loading snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1066
+#: cmdevents.cpp:1063
 #, c-format
 msgid "Wrote battery %s"
 msgstr ""
 
-#: cmdevents.cpp:1068 panel.cpp:773
+#: cmdevents.cpp:1065 panel.cpp:771
 #, c-format
 msgid "Error writing battery %s"
 msgstr ""
 
-#: cmdevents.cpp:1076
+#: cmdevents.cpp:1073
 msgid "EEPROM saves cannot be exported"
 msgstr ""
 
-#: cmdevents.cpp:1083
+#: cmdevents.cpp:1080
 msgid "Game Shark Snapshot (*.sps)|*.sps"
 msgstr ""
 
-#: cmdevents.cpp:1097
+#: cmdevents.cpp:1094
 msgid "Exported from Visual Boy Advance-M"
 msgstr ""
 
-#: cmdevents.cpp:1109
+#: cmdevents.cpp:1106
 #, c-format
 msgid "Saved snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1111
+#: cmdevents.cpp:1108
 #, c-format
 msgid "Error saving snapshot file %s"
 msgstr ""
 
-#: cmdevents.cpp:1152 sys.cpp:574
+#: cmdevents.cpp:1149 sys.cpp:574
 #, c-format
 msgid "Wrote snapshot %s"
 msgstr ""
 
-#: cmdevents.cpp:1173 cmdevents.cpp:1243 cmdevents.cpp:1314 cmdevents.cpp:1380
+#: cmdevents.cpp:1170 cmdevents.cpp:1240 cmdevents.cpp:1311 cmdevents.cpp:1377
 msgid " files ("
 msgstr ""
 
-#: cmdevents.cpp:1413
+#: cmdevents.cpp:1410
 msgid "Select file"
 msgstr ""
 
-#: cmdevents.cpp:1717 cmdevents.cpp:1810
+#: cmdevents.cpp:1714 cmdevents.cpp:1807
 msgid "Select state file"
 msgstr ""
 
-#: cmdevents.cpp:1718 cmdevents.cpp:1811
+#: cmdevents.cpp:1715 cmdevents.cpp:1808
 msgid "Visual Boy Advance saved game files|*.sgm"
 msgstr ""
 
-#: cmdevents.cpp:1841 cmdevents.cpp:1851 cmdevents.cpp:1862
+#: cmdevents.cpp:1838 cmdevents.cpp:1848 cmdevents.cpp:1859
 #, c-format
 msgid "Current state slot #%d"
 msgstr ""
 
-#: cmdevents.cpp:1927
+#: cmdevents.cpp:1924
 msgid "Cannot use Colorizer Hack when Game Boy BIOS File is enabled."
 msgstr ""
 
-#: cmdevents.cpp:2138
+#: cmdevents.cpp:2135
 msgid "Sound enabled"
 msgstr ""
 
-#: cmdevents.cpp:2138
+#: cmdevents.cpp:2135
 msgid "Sound disabled"
 msgstr ""
 
-#: cmdevents.cpp:2151 cmdevents.cpp:2165
+#: cmdevents.cpp:2148 cmdevents.cpp:2162
 #, c-format
 msgid "Volume: %d %%"
 msgstr ""
 
-#: cmdevents.cpp:2234
+#: cmdevents.cpp:2231
 msgid "Set to 0 for pseudo tty"
 msgstr ""
 
-#: cmdevents.cpp:2236
+#: cmdevents.cpp:2233
 msgid "Port to wait for connection:"
 msgstr ""
 
-#: cmdevents.cpp:2237
+#: cmdevents.cpp:2234
 msgid "GDB Connection"
 msgstr ""
 
-#: cmdevents.cpp:2289
+#: cmdevents.cpp:2286
 #, c-format
 msgid "Waiting for connection at %s"
 msgstr ""
 
-#: cmdevents.cpp:2296
+#: cmdevents.cpp:2293
 #, c-format
 msgid "Waiting for connection on port %d"
 msgstr ""
 
-#: cmdevents.cpp:2299
+#: cmdevents.cpp:2296
 msgid "Waiting for GDB..."
 msgstr ""
 
-#: cmdevents.cpp:2672 panel.cpp:261 panel.cpp:373
+#: cmdevents.cpp:2669 panel.cpp:259 panel.cpp:371
 msgid "Could not initialize the sound driver!"
 msgstr ""
 
-#: cmdevents.cpp:2735
+#: cmdevents.cpp:2734
 msgid ""
 "YOUR CONFIGURATION WILL BE DELETED!\n"
 "\n"
 "Are you sure?"
 msgstr ""
 
-#: cmdevents.cpp:2736
+#: cmdevents.cpp:2735
 msgid "FACTORY RESET"
 msgstr ""
 
-#: cmdevents.cpp:2771
+#: cmdevents.cpp:2770
 msgid "Nintendo Game Boy / Color / Advance emulator."
 msgstr ""
 
-#: cmdevents.cpp:2772
+#: cmdevents.cpp:2771
 msgid ""
 "Copyright (C) 1999-2003 Forgotten\n"
 "Copyright (C) 2004-2006 VBA development team\n"
 "Copyright (C) 2007-2020 VBA-M development team"
 msgstr ""
 
-#: cmdevents.cpp:2774
+#: cmdevents.cpp:2773
 msgid ""
 "This program is free software: you can redistribute it and / or modify\n"
 "it under the terms of the GNU General Public License as published by\n"
@@ -810,15 +784,15 @@ msgid ""
 "along with this program. If not, see http://www.gnu.org/licenses ."
 msgstr ""
 
-#: cmdevents.cpp:2959
+#: cmdevents.cpp:2958
 msgid "Cannot use Game Boy BIOS when Colorizer Hack is enabled."
 msgstr ""
 
-#: cmdevents.cpp:3013
+#: cmdevents.cpp:3012
 msgid "LAN link is already active. Disable link mode to disconnect."
 msgstr ""
 
-#: cmdevents.cpp:3019
+#: cmdevents.cpp:3018
 msgid "Network is not supported in local mode."
 msgstr ""
 
@@ -850,23 +824,23 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
-#: opts.cpp:381
+#: opts.cpp:290
 msgid ""
 "The INI file was written for a more recent version of VBA-M. Some INI option "
 "values may have been reset."
 msgstr ""
 
-#: opts.cpp:548 opts.cpp:568 opts.cpp:810
+#: opts.cpp:457 opts.cpp:477 opts.cpp:651
 #, c-format
 msgid "Invalid key binding %s for %s"
 msgstr ""
 
-#: opts.cpp:732 opts.cpp:741 opts.cpp:750 opts.cpp:759 config/option.cpp:492
+#: opts.cpp:587 opts.cpp:596 opts.cpp:605 opts.cpp:614 config/option.cpp:492
 #, c-format
 msgid "Invalid value %s for option %s"
 msgstr ""
 
-#: opts.cpp:832
+#: opts.cpp:673
 #, c-format
 msgid "Unknown option %s with value %s"
 msgstr ""
@@ -946,177 +920,177 @@ msgstr ""
 msgid "Error setting up server socket (%d)"
 msgstr ""
 
-#: panel.cpp:184
+#: panel.cpp:183
 #, c-format
 msgid "%s is not a valid ROM file"
 msgstr ""
 
-#: panel.cpp:185 panel.cpp:246 panel.cpp:311
+#: panel.cpp:184 panel.cpp:244 panel.cpp:309
 msgid "Problem loading file"
 msgstr ""
 
-#: panel.cpp:245
+#: panel.cpp:243
 #, c-format
 msgid "Unable to load Game Boy ROM %s"
 msgstr ""
 
-#: panel.cpp:273
+#: panel.cpp:271
 msgid ""
 "Cannot use Game Boy BIOS file when Colorizer Hack is enabled, disabling Game "
 "Boy BIOS file."
 msgstr ""
 
-#: panel.cpp:287 panel.cpp:387
+#: panel.cpp:285 panel.cpp:385
 #, c-format
 msgid "Could not load BIOS %s"
 msgstr ""
 
-#: panel.cpp:310
+#: panel.cpp:308
 #, c-format
 msgid "Unable to load Game Boy Advance ROM %s"
 msgstr ""
 
-#: panel.cpp:555
+#: panel.cpp:553
 msgid " player "
 msgstr ""
 
-#: panel.cpp:721
+#: panel.cpp:719
 #, c-format
 msgid "Loaded state %s"
 msgstr ""
 
-#: panel.cpp:721
+#: panel.cpp:719
 #, c-format
 msgid "Error loading state %s"
 msgstr ""
 
-#: panel.cpp:745
+#: panel.cpp:743
 #, c-format
 msgid "Saved state %s"
 msgstr ""
 
-#: panel.cpp:745
+#: panel.cpp:743
 #, c-format
 msgid "Error saving state %s"
 msgstr ""
 
-#: panel.cpp:949
+#: panel.cpp:947
 #, c-format
 msgid "Fullscreen mode %d x %d - %d @ %d not supported; looking for another"
 msgstr ""
 
-#: panel.cpp:987
+#: panel.cpp:985
 #, c-format
 msgid "Fullscreen mode %d x %d - %d @ %d not supported"
 msgstr ""
 
-#: panel.cpp:992
+#: panel.cpp:990
 #, c-format
 msgid "Valid mode: %d x %d - %d @ %d"
 msgstr ""
 
-#: panel.cpp:1000
+#: panel.cpp:998
 #, c-format
 msgid "Chose mode %d x %d - %d @ %d"
 msgstr ""
 
-#: panel.cpp:1004
+#: panel.cpp:1002
 #, c-format
 msgid "Failed to change mode to %d x %d - %d @ %d"
 msgstr ""
 
-#: panel.cpp:1095
+#: panel.cpp:1093
 msgid "Not a valid Game Boy Advance cartridge"
 msgstr ""
 
-#: panel.cpp:1258
+#: panel.cpp:1256
 msgid "No memory for rewinding"
 msgstr ""
 
-#: panel.cpp:1268
+#: panel.cpp:1266
 msgid "Error writing rewind state"
 msgstr ""
 
-#: panel.cpp:2286
+#: panel.cpp:2284
 msgid "Enabling EGL VSync."
 msgstr ""
 
-#: panel.cpp:2288
+#: panel.cpp:2286
 msgid "Disabling EGL VSync."
 msgstr ""
 
-#: panel.cpp:2295
+#: panel.cpp:2293
 msgid "Enabling GLX VSync."
 msgstr ""
 
-#: panel.cpp:2297
+#: panel.cpp:2295
 msgid "Disabling GLX VSync."
 msgstr ""
 
-#: panel.cpp:2315
+#: panel.cpp:2313
 msgid "Failed to set glXSwapIntervalEXT"
 msgstr ""
 
-#: panel.cpp:2324
+#: panel.cpp:2322
 msgid "Failed to set glXSwapIntervalSGI"
 msgstr ""
 
-#: panel.cpp:2333
+#: panel.cpp:2331
 msgid "Failed to set glXSwapIntervalMESA"
 msgstr ""
 
-#: panel.cpp:2340
+#: panel.cpp:2338
 msgid "No support for wglGetExtensionsStringEXT"
 msgstr ""
 
-#: panel.cpp:2343
+#: panel.cpp:2341
 msgid "No support for WGL_EXT_swap_control"
 msgstr ""
 
-#: panel.cpp:2352
+#: panel.cpp:2350
 msgid "Failed to set wglSwapIntervalEXT"
 msgstr ""
 
-#: panel.cpp:2358
+#: panel.cpp:2356
 msgid "No VSYNC available on this platform"
 msgstr ""
 
-#: panel.cpp:2458
+#: panel.cpp:2456
 msgid "memory allocation error"
 msgstr ""
 
-#: panel.cpp:2461
+#: panel.cpp:2459
 msgid "error initializing codec"
 msgstr ""
 
-#: panel.cpp:2464
+#: panel.cpp:2462
 msgid "error writing to output file"
 msgstr ""
 
-#: panel.cpp:2467
+#: panel.cpp:2465
 msgid "can't guess output format from file name"
 msgstr ""
 
-#: panel.cpp:2472
+#: panel.cpp:2470
 msgid "programming error; aborting!"
 msgstr ""
 
-#: panel.cpp:2484 panel.cpp:2513
+#: panel.cpp:2482 panel.cpp:2511
 #, c-format
 msgid "Unable to begin recording to %s (%s)"
 msgstr ""
 
-#: panel.cpp:2541
+#: panel.cpp:2539
 #, c-format
 msgid "Error in audio / video recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2547
+#: panel.cpp:2545
 #, c-format
 msgid "Error in audio recording (%s); aborting"
 msgstr ""
 
-#: panel.cpp:2557
+#: panel.cpp:2555
 #, c-format
 msgid "Error in video recording (%s); aborting"
 msgstr ""
@@ -1133,174 +1107,174 @@ msgstr ""
 msgid "B:"
 msgstr ""
 
-#: config/internal/option-internal.cpp:375
+#: config/internal/option-internal.cpp:376
 msgid "Use bilinear filter with 3d renderer"
 msgstr ""
 
-#: config/internal/option-internal.cpp:376
+#: config/internal/option-internal.cpp:377
 msgid "Full-screen filter to apply"
 msgstr ""
 
-#: config/internal/option-internal.cpp:377
+#: config/internal/option-internal.cpp:378
 msgid "Filter plugin library"
 msgstr ""
 
-#: config/internal/option-internal.cpp:378
+#: config/internal/option-internal.cpp:379
 msgid "Interframe blending function"
 msgstr ""
 
-#: config/internal/option-internal.cpp:379
+#: config/internal/option-internal.cpp:380
 msgid "Keep window on top"
 msgstr ""
 
-#: config/internal/option-internal.cpp:381
+#: config/internal/option-internal.cpp:382
 msgid "Maximum number of threads to run filters in"
 msgstr ""
 
-#: config/internal/option-internal.cpp:383
+#: config/internal/option-internal.cpp:384
 msgid "Render method; if unsupported, simple method will be used"
 msgstr ""
 
-#: config/internal/option-internal.cpp:384
+#: config/internal/option-internal.cpp:385
 msgid "Default scale factor"
 msgstr ""
 
-#: config/internal/option-internal.cpp:386
+#: config/internal/option-internal.cpp:387
 msgid "Retain aspect ratio when resizing"
 msgstr ""
 
-#: config/internal/option-internal.cpp:390
+#: config/internal/option-internal.cpp:391
 msgid "BIOS file to use for Game Boy, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:392
+#: config/internal/option-internal.cpp:393
 msgid "Game Boy color enhancement, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:394
+#: config/internal/option-internal.cpp:395
 msgid "Enable DX Colorization Hacks"
 msgstr ""
 
-#: config/internal/option-internal.cpp:396
-#: config/internal/option-internal.cpp:422
+#: config/internal/option-internal.cpp:397
+#: config/internal/option-internal.cpp:423
 msgid "Apply LCD filter, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:398
+#: config/internal/option-internal.cpp:399
 msgid "BIOS file to use for Game Boy Color, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:400
+#: config/internal/option-internal.cpp:401
 msgid ""
 "The default palette, as 8 comma-separated 4-digit hex integers (rgb555)."
 msgstr ""
 
-#: config/internal/option-internal.cpp:403
+#: config/internal/option-internal.cpp:404
 msgid ""
 "The first user palette, as 8 comma-separated 4-digit hex integers (rgb555)."
 msgstr ""
 
-#: config/internal/option-internal.cpp:406
+#: config/internal/option-internal.cpp:407
 msgid ""
 "The second user palette, as 8 comma-separated 4-digit hex integers (rgb555)."
 msgstr ""
 
-#: config/internal/option-internal.cpp:409
+#: config/internal/option-internal.cpp:410
 msgid "Automatically gather a full page before printing"
 msgstr ""
 
-#: config/internal/option-internal.cpp:411
+#: config/internal/option-internal.cpp:412
 msgid "Automatically save printouts as screen captures with -print suffix"
 msgstr ""
 
-#: config/internal/option-internal.cpp:413
-#: config/internal/option-internal.cpp:443
+#: config/internal/option-internal.cpp:414
+#: config/internal/option-internal.cpp:444
 msgid "Directory to look for ROM files"
 msgstr ""
 
-#: config/internal/option-internal.cpp:415
+#: config/internal/option-internal.cpp:416
 msgid "Directory to look for Game Boy Color ROM files"
 msgstr ""
 
-#: config/internal/option-internal.cpp:418
+#: config/internal/option-internal.cpp:419
 msgid "BIOS file to use, if enabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:428
+#: config/internal/option-internal.cpp:429
 msgid "Enable link at boot"
 msgstr ""
 
-#: config/internal/option-internal.cpp:433
+#: config/internal/option-internal.cpp:434
 msgid "Enable faster network protocol by default"
 msgstr ""
 
-#: config/internal/option-internal.cpp:435
+#: config/internal/option-internal.cpp:436
 msgid "Default network link client host"
 msgstr ""
 
-#: config/internal/option-internal.cpp:436
+#: config/internal/option-internal.cpp:437
 msgid "Default network link server IP to bind"
 msgstr ""
 
-#: config/internal/option-internal.cpp:438
+#: config/internal/option-internal.cpp:439
 msgid "Default network link port (server and client)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:439
+#: config/internal/option-internal.cpp:440
 msgid "Default network protocol"
 msgstr ""
 
-#: config/internal/option-internal.cpp:440
+#: config/internal/option-internal.cpp:441
 msgid "Link timeout (ms)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:441
+#: config/internal/option-internal.cpp:442
 msgid "Link cable type"
 msgstr ""
 
-#: config/internal/option-internal.cpp:447
+#: config/internal/option-internal.cpp:448
 msgid "Automatically load last saved state"
 msgstr ""
 
-#: config/internal/option-internal.cpp:449
+#: config/internal/option-internal.cpp:450
 msgid ""
 "Directory to store game save files (relative paths are relative to ROM; "
 "blank is config dir)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:451
+#: config/internal/option-internal.cpp:452
 msgid "Freeze recent load list"
 msgstr ""
 
-#: config/internal/option-internal.cpp:453
+#: config/internal/option-internal.cpp:454
 msgid ""
 "Directory to store A / V and game recordings (relative paths are relative to "
 "ROM)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:456
+#: config/internal/option-internal.cpp:457
 msgid "Number of seconds between rewind snapshots (0 to disable)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:458
+#: config/internal/option-internal.cpp:459
 msgid "Directory to store screenshots (relative paths are relative to ROM)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:461
+#: config/internal/option-internal.cpp:462
 msgid ""
 "Directory to store saved state files (relative paths are relative to "
 "BatteryDir)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:463
+#: config/internal/option-internal.cpp:464
 msgid "Enable status bar"
 msgstr ""
 
-#: config/internal/option-internal.cpp:464
+#: config/internal/option-internal.cpp:465
 msgid "INI file version (DO NOT MODIFY)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:468
+#: config/internal/option-internal.cpp:469
 msgid ""
 "The parameter Joypad/<n>/<button> contains a comma-separated list of key "
 "names which map to joypad #<n> button <button>. Button is one of Up, Down, "
@@ -1308,254 +1282,254 @@ msgid ""
 "MotionRight, AutoA, AutoB, Speed, Capture, GS"
 msgstr ""
 
-#: config/internal/option-internal.cpp:474
+#: config/internal/option-internal.cpp:475
 msgid "The autofire toggle period, in frames (1/60 s)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:476
+#: config/internal/option-internal.cpp:477
 msgid "The number of the stick to use in single-player mode"
 msgstr ""
 
-#: config/internal/option-internal.cpp:480
+#: config/internal/option-internal.cpp:481
 msgid ""
 "The parameter Keyboard/<cmd> contains a comma-separated list of key names (e."
 "g. Alt-Shift-F1).  When the named key is pressed, the command <cmd> is "
 "executed."
 msgstr ""
 
-#: config/internal/option-internal.cpp:486
+#: config/internal/option-internal.cpp:487
 msgid "Enable AGB debug print"
 msgstr ""
 
-#: config/internal/option-internal.cpp:488
+#: config/internal/option-internal.cpp:489
 msgid "Auto skip frames"
 msgstr ""
 
-#: config/internal/option-internal.cpp:490
+#: config/internal/option-internal.cpp:491
 msgid "Apply IPS / UPS / IPF patches if found"
 msgstr ""
 
-#: config/internal/option-internal.cpp:492
+#: config/internal/option-internal.cpp:493
 msgid "Automatically save and load cheat list"
 msgstr ""
 
-#: config/internal/option-internal.cpp:496
+#: config/internal/option-internal.cpp:497
 msgid "Automatically enable border for Super Game Boy games"
 msgstr ""
 
-#: config/internal/option-internal.cpp:498
+#: config/internal/option-internal.cpp:499
 msgid "Always enable border"
 msgstr ""
 
-#: config/internal/option-internal.cpp:500
+#: config/internal/option-internal.cpp:501
 msgid "Screen capture file format"
 msgstr ""
 
-#: config/internal/option-internal.cpp:501
+#: config/internal/option-internal.cpp:502
 msgid "Enable cheats"
 msgstr ""
 
-#: config/internal/option-internal.cpp:503
+#: config/internal/option-internal.cpp:504
 msgid "Disable on-screen status messages"
 msgstr ""
 
-#: config/internal/option-internal.cpp:504
+#: config/internal/option-internal.cpp:505
 msgid "Type of system to emulate"
 msgstr ""
 
-#: config/internal/option-internal.cpp:506
+#: config/internal/option-internal.cpp:507
 msgid "Flash size 0 = 64 KB 1 = 128 KB"
 msgstr ""
 
-#: config/internal/option-internal.cpp:508
+#: config/internal/option-internal.cpp:509
 msgid "Skip frames. Values are 0-9 or -1 to skip automatically based on time."
 msgstr ""
 
-#: config/internal/option-internal.cpp:510
+#: config/internal/option-internal.cpp:511
 msgid "The palette to use"
 msgstr ""
 
-#: config/internal/option-internal.cpp:512
+#: config/internal/option-internal.cpp:513
 msgid "Enable printer emulation"
 msgstr ""
 
-#: config/internal/option-internal.cpp:514
+#: config/internal/option-internal.cpp:515
 msgid "Break into GDB after loading the game."
 msgstr ""
 
-#: config/internal/option-internal.cpp:516
+#: config/internal/option-internal.cpp:517
 msgid "Port to connect GDB to"
 msgstr ""
 
-#: config/internal/option-internal.cpp:519
+#: config/internal/option-internal.cpp:520
 msgid "Number of players in network"
 msgstr ""
 
-#: config/internal/option-internal.cpp:522
+#: config/internal/option-internal.cpp:523
 msgid "Maximum scale factor (0 = no limit)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:524
+#: config/internal/option-internal.cpp:525
 msgid "Pause game when main window loses focus"
 msgstr ""
 
-#: config/internal/option-internal.cpp:526
+#: config/internal/option-internal.cpp:527
 msgid "Enable RTC (vba-over.ini override is rtcEnabled"
 msgstr ""
 
-#: config/internal/option-internal.cpp:528
+#: config/internal/option-internal.cpp:529
 msgid "Native save (\"battery\") hardware type"
 msgstr ""
 
-#: config/internal/option-internal.cpp:529
+#: config/internal/option-internal.cpp:530
 msgid "Show speed indicator"
 msgstr ""
 
-#: config/internal/option-internal.cpp:531
+#: config/internal/option-internal.cpp:532
 msgid "Draw on-screen messages transparently"
 msgstr ""
 
-#: config/internal/option-internal.cpp:533
+#: config/internal/option-internal.cpp:534
 msgid "Skip BIOS initialization"
 msgstr ""
 
-#: config/internal/option-internal.cpp:535
+#: config/internal/option-internal.cpp:536
 msgid "Do not overwrite cheat list when loading state"
 msgstr ""
 
-#: config/internal/option-internal.cpp:537
+#: config/internal/option-internal.cpp:538
 msgid "Do not overwrite native (battery) save when loading state"
 msgstr ""
 
-#: config/internal/option-internal.cpp:539
+#: config/internal/option-internal.cpp:540
 msgid "Throttle game speed, even when accelerated (0-450 %, 0 = no throttle)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:542
+#: config/internal/option-internal.cpp:543
 msgid "Set throttle for speedup key (0-3000 %, 0 = no throttle)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:544
+#: config/internal/option-internal.cpp:545
 msgid "Number of frames to skip with speedup (instead of speedup throttle)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:547
+#: config/internal/option-internal.cpp:548
 msgid "Use frame skip for speedup throttle"
 msgstr ""
 
-#: config/internal/option-internal.cpp:549
+#: config/internal/option-internal.cpp:550
 msgid "Use the specified BIOS file for Game Boy"
 msgstr ""
 
-#: config/internal/option-internal.cpp:551
+#: config/internal/option-internal.cpp:552
 msgid "Use the specified BIOS file"
 msgstr ""
 
-#: config/internal/option-internal.cpp:553
+#: config/internal/option-internal.cpp:554
 msgid "Use the specified BIOS file for Game Boy Color"
 msgstr ""
 
-#: config/internal/option-internal.cpp:554
+#: config/internal/option-internal.cpp:555
 msgid "Wait for vertical sync"
 msgstr ""
 
-#: config/internal/option-internal.cpp:558
+#: config/internal/option-internal.cpp:559
 msgid "Enter fullscreen mode at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:559
+#: config/internal/option-internal.cpp:560
 msgid "Window maximized"
 msgstr ""
 
-#: config/internal/option-internal.cpp:561
+#: config/internal/option-internal.cpp:562
 msgid "Window height at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:562
+#: config/internal/option-internal.cpp:563
 msgid "Window width at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:563
+#: config/internal/option-internal.cpp:564
 msgid "Window axis X position at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:564
+#: config/internal/option-internal.cpp:565
 msgid "Window axis Y position at startup"
 msgstr ""
 
-#: config/internal/option-internal.cpp:569
+#: config/internal/option-internal.cpp:570
 msgid "Capture key events while on background"
 msgstr ""
 
-#: config/internal/option-internal.cpp:572
+#: config/internal/option-internal.cpp:573
 msgid "Capture joy events while on background"
 msgstr ""
 
-#: config/internal/option-internal.cpp:573
+#: config/internal/option-internal.cpp:574
 msgid "Hide menu bar when mouse is inactive"
 msgstr ""
 
-#: config/internal/option-internal.cpp:574
+#: config/internal/option-internal.cpp:575
 msgid "Suspend screensaver when game is running"
 msgstr ""
 
-#: config/internal/option-internal.cpp:578
+#: config/internal/option-internal.cpp:579
 msgid "Sound API; if unsupported, default API will be used"
 msgstr ""
 
-#: config/internal/option-internal.cpp:580
+#: config/internal/option-internal.cpp:581
 msgid "Device ID of chosen audio device for chosen driver"
 msgstr ""
 
-#: config/internal/option-internal.cpp:581
+#: config/internal/option-internal.cpp:582
 msgid "Number of sound buffers"
 msgstr ""
 
-#: config/internal/option-internal.cpp:582
+#: config/internal/option-internal.cpp:583
 msgid "Bit mask of sound channels to enable"
 msgstr ""
 
-#: config/internal/option-internal.cpp:584
+#: config/internal/option-internal.cpp:585
 msgid "Game Boy Advance sound filtering (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:586
+#: config/internal/option-internal.cpp:587
 msgid "Game Boy Advance sound interpolation"
 msgstr ""
 
-#: config/internal/option-internal.cpp:588
+#: config/internal/option-internal.cpp:589
 msgid "Game Boy sound declicking"
 msgstr ""
 
-#: config/internal/option-internal.cpp:589
+#: config/internal/option-internal.cpp:590
 msgid "Game Boy echo effect (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:591
+#: config/internal/option-internal.cpp:592
 msgid "Enable Game Boy sound effects"
 msgstr ""
 
-#: config/internal/option-internal.cpp:592
+#: config/internal/option-internal.cpp:593
 msgid "Game Boy stereo effect (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:594
+#: config/internal/option-internal.cpp:595
 msgid "Game Boy surround sound effect (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:595
+#: config/internal/option-internal.cpp:596
 msgid "Sound sample rate (kHz)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:596
+#: config/internal/option-internal.cpp:597
 msgid "Sound volume (%)"
 msgstr ""
 
-#: config/internal/option-internal.cpp:662
-#: config/internal/option-internal.cpp:682
-#: config/internal/option-internal.cpp:703
-#: config/internal/option-internal.cpp:723
-#: config/internal/option-internal.cpp:743
+#: config/internal/option-internal.cpp:663
+#: config/internal/option-internal.cpp:683
+#: config/internal/option-internal.cpp:704
+#: config/internal/option-internal.cpp:724
+#: config/internal/option-internal.cpp:744
 #, c-format
 msgid "Invalid value %s for option %s; valid values are %s"
 msgstr ""
@@ -1575,111 +1549,111 @@ msgstr ""
 msgid "Invalid value %d for option %s; valid values are %s"
 msgstr ""
 
-#: config/user-input.cpp:24
+#: config/user-input.cpp:23
 msgid "Backspace"
 msgstr ""
 
-#: config/user-input.cpp:25
+#: config/user-input.cpp:24
 msgid "Delete"
 msgstr ""
 
-#: config/user-input.cpp:26
+#: config/user-input.cpp:25
 msgid "Page Up"
 msgstr ""
 
-#: config/user-input.cpp:27
+#: config/user-input.cpp:26
 msgid "Page Down"
 msgstr ""
 
-#: config/user-input.cpp:28
+#: config/user-input.cpp:27
 msgid "Num Lock"
 msgstr ""
 
-#: config/user-input.cpp:29
+#: config/user-input.cpp:28
 msgid "Scroll Lock"
 msgstr ""
 
-#: config/user-input.cpp:32
+#: config/user-input.cpp:31
 msgid "Num Space"
 msgstr ""
 
-#: config/user-input.cpp:33
+#: config/user-input.cpp:32
 msgid "Num Tab"
 msgstr ""
 
-#: config/user-input.cpp:34
+#: config/user-input.cpp:33
 msgid "Num Enter"
 msgstr ""
 
-#: config/user-input.cpp:35
+#: config/user-input.cpp:34
 msgid "Num Home"
 msgstr ""
 
-#: config/user-input.cpp:36
+#: config/user-input.cpp:35
 msgid "Num left"
 msgstr ""
 
-#: config/user-input.cpp:37
+#: config/user-input.cpp:36
 msgid "Num Up"
 msgstr ""
 
-#: config/user-input.cpp:38
+#: config/user-input.cpp:37
 msgid "Num Right"
 msgstr ""
 
-#: config/user-input.cpp:39
+#: config/user-input.cpp:38
 msgid "Num Down"
 msgstr ""
 
-#: config/user-input.cpp:40
+#: config/user-input.cpp:39
 msgid "Num PageUp"
 msgstr ""
 
-#: config/user-input.cpp:41
+#: config/user-input.cpp:40
 msgid "Num PageDown"
 msgstr ""
 
-#: config/user-input.cpp:42
+#: config/user-input.cpp:41
 msgid "Num End"
 msgstr ""
 
-#: config/user-input.cpp:43
+#: config/user-input.cpp:42
 msgid "Num Begin"
 msgstr ""
 
-#: config/user-input.cpp:44
+#: config/user-input.cpp:43
 msgid "Num Insert"
 msgstr ""
 
-#: config/user-input.cpp:45
+#: config/user-input.cpp:44
 msgid "Num Delete"
 msgstr ""
 
-#: config/user-input.cpp:46
+#: config/user-input.cpp:45
 msgid "Num ="
 msgstr ""
 
-#: config/user-input.cpp:47
+#: config/user-input.cpp:46
 msgid "Num *"
 msgstr ""
 
-#: config/user-input.cpp:48
+#: config/user-input.cpp:47
 msgid "Num +"
 msgstr ""
 
-#: config/user-input.cpp:49
+#: config/user-input.cpp:48
 msgid "Num ,"
 msgstr ""
 
-#: config/user-input.cpp:50
+#: config/user-input.cpp:49
 msgid "Num -"
 msgstr ""
 
-#: config/user-input.cpp:51
+#: config/user-input.cpp:50
 msgid "Num ."
 msgstr ""
 
-#: config/user-input.cpp:52
+#: config/user-input.cpp:51
 msgid "Num /"
 msgstr ""
 
@@ -1711,40 +1685,57 @@ msgstr ""
 msgid "Play/Pause"
 msgstr ""
 
-#: config/user-input.cpp:93
+#: config/user-input.cpp:94
 msgid "Alt+"
 msgstr ""
 
-#: config/user-input.cpp:96
+#: config/user-input.cpp:97
 msgid "Ctrl+"
 msgstr ""
 
-#: config/user-input.cpp:100
+#: config/user-input.cpp:101
 msgid "Rawctrl+"
 msgstr ""
 
-#: config/user-input.cpp:104
+#: config/user-input.cpp:105
 msgid "Shift+"
 msgstr ""
 
-#: config/user-input.cpp:107
+#: config/user-input.cpp:108
 msgid "Meta+"
 msgstr ""
 
-#: config/user-input.cpp:134
+#: config/user-input.cpp:135
 msgid "Alt"
 msgstr ""
 
-#: config/user-input.cpp:135
+#: config/user-input.cpp:136
 msgid "Shift"
 msgstr ""
 
-#: config/user-input.cpp:137 config/user-input.cpp:140
+#: config/user-input.cpp:138 config/user-input.cpp:141
 msgid "Ctrl"
 msgstr ""
 
-#: config/user-input.cpp:138
+#: config/user-input.cpp:139
 msgid "Cmd"
+msgstr ""
+
+#: dialogs/accel-config.cpp:156
+msgid "Menu commands"
+msgstr ""
+
+#: dialogs/accel-config.cpp:269
+msgid "This will clear all user-defined accelerators. Are you sure?"
+msgstr ""
+
+#: dialogs/accel-config.cpp:269 dialogs/accel-config.cpp:309
+msgid "Confirm"
+msgstr ""
+
+#: dialogs/accel-config.cpp:306
+#, c-format
+msgid "This will unassign \"%s\" from \"%s\". Are you sure?"
 msgstr ""
 
 #: dialogs/directories-config.cpp:50

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -762,9 +762,12 @@ set(
     wxutil.cpp
     config/game-control.cpp
     config/internal/option-internal.cpp
+    config/internal/shortcuts-internal.cpp
     config/option-observer.cpp
     config/option.cpp
+    config/shortcuts.cpp
     config/user-input.cpp
+    dialogs/accel-config.cpp
     dialogs/directories-config.cpp
     dialogs/display-config.cpp
     dialogs/game-boy-config.cpp
@@ -808,11 +811,14 @@ set(
     wxutil.h
     config/game-control.h
     config/internal/option-internal.h
+    config/internal/shortcuts-internal.h
     config/option-id.h
     config/option-observer.h
     config/option-proxy.h
     config/option.h
+    config/shortcuts.h
     config/user-input.h
+    dialogs/accel-config.h
     dialogs/directories-config.h
     dialogs/display-config.h
     dialogs/game-boy-config.h

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2710,8 +2710,10 @@ EVT_HANDLER(Customize, "Customize UI...")
 
     if (!joy_timer) frame->StartJoyPollTimer();
 
-    if (ShowModal(dlg) == wxID_OK)
-        update_opts();
+    if (ShowModal(dlg) == wxID_OK) {
+        update_shortcut_opts();
+        ResetMenuAccelerators();
+    }
 
     if (!joy_timer) frame->StopJoyPollTimer();
 

--- a/src/wx/config/internal/shortcuts-internal.cpp
+++ b/src/wx/config/internal/shortcuts-internal.cpp
@@ -1,0 +1,107 @@
+#include "config/shortcuts.h"
+
+#include <wx/xrc/xmlres.h>
+
+#define VBAM_SHORTCUTS_INTERNAL_INCLUDE
+#include "config/internal/shortcuts-internal.h"
+#undef VBAM_SHORTCUTS_INTERNAL_INCLUDE
+
+namespace config {
+namespace internal {
+
+const std::unordered_map<int, UserInput>& DefaultShortcuts() {
+    static const std::unordered_map<int, UserInput> kDefaultShortcuts = {
+        {XRCID("CheatsList"), UserInput('C', wxMOD_CMD)},
+        {XRCID("NextFrame"), UserInput('N', wxMOD_CMD)},
+        // this was annoying people A LOT #334
+        //{wxID_EXIT, UserInput(WXK_ESCAPE, wxMOD_NONE)},
+        // this was annoying people #298
+        //{wxID_EXIT, UserInput('X', wxMOD_CMD)},
+
+        {wxID_EXIT, UserInput('Q', wxMOD_CMD)},
+        {wxID_CLOSE, UserInput('W', wxMOD_CMD)},
+        // load most recent is more commonly used than load state
+        // {XRCID("Load"), UserInput('L', wxMOD_CMD)},
+        {XRCID("LoadGameRecent"), UserInput('L', wxMOD_CMD)},
+        {XRCID("LoadGame01"), UserInput(WXK_F1, wxMOD_NONE)},
+        {XRCID("LoadGame02"), UserInput(WXK_F2, wxMOD_NONE)},
+        {XRCID("LoadGame03"), UserInput(WXK_F3, wxMOD_NONE)},
+        {XRCID("LoadGame04"), UserInput(WXK_F4, wxMOD_NONE)},
+        {XRCID("LoadGame05"), UserInput(WXK_F5, wxMOD_NONE)},
+        {XRCID("LoadGame06"), UserInput(WXK_F6, wxMOD_NONE)},
+        {XRCID("LoadGame07"), UserInput(WXK_F7, wxMOD_NONE)},
+        {XRCID("LoadGame08"), UserInput(WXK_F8, wxMOD_NONE)},
+        {XRCID("LoadGame09"), UserInput(WXK_F9, wxMOD_NONE)},
+        {XRCID("LoadGame10"), UserInput(WXK_F10, wxMOD_NONE)},
+        {XRCID("Pause"), UserInput(WXK_PAUSE, wxMOD_NONE)},
+        {XRCID("Pause"), UserInput('P', wxMOD_CMD)},
+        {XRCID("Reset"), UserInput('R', wxMOD_CMD)},
+        // add shortcuts for original size multiplier #415
+        {XRCID("SetSize1x"), UserInput('1', wxMOD_NONE)},
+        {XRCID("SetSize2x"), UserInput('2', wxMOD_NONE)},
+        {XRCID("SetSize3x"), UserInput('3', wxMOD_NONE)},
+        {XRCID("SetSize4x"), UserInput('4', wxMOD_NONE)},
+        {XRCID("SetSize5x"), UserInput('5', wxMOD_NONE)},
+        {XRCID("SetSize6x"), UserInput('6', wxMOD_NONE)},
+        // save oldest is more commonly used than save other
+        // {XRCID("Save"), UserInput('S', wxMOD_CMD)},
+        {XRCID("SaveGameOldest"), UserInput('S', wxMOD_CMD)},
+        {XRCID("SaveGame01"), UserInput(WXK_F1, wxMOD_SHIFT)},
+        {XRCID("SaveGame02"), UserInput(WXK_F2, wxMOD_SHIFT)},
+        {XRCID("SaveGame03"), UserInput(WXK_F3, wxMOD_SHIFT)},
+        {XRCID("SaveGame04"), UserInput(WXK_F4, wxMOD_SHIFT)},
+        {XRCID("SaveGame05"), UserInput(WXK_F5, wxMOD_SHIFT)},
+        {XRCID("SaveGame06"), UserInput(WXK_F6, wxMOD_SHIFT)},
+        {XRCID("SaveGame07"), UserInput(WXK_F7, wxMOD_SHIFT)},
+        {XRCID("SaveGame08"), UserInput(WXK_F8, wxMOD_SHIFT)},
+        {XRCID("SaveGame09"), UserInput(WXK_F9, wxMOD_SHIFT)},
+        {XRCID("SaveGame10"), UserInput(WXK_F10, wxMOD_SHIFT)},
+        // I prefer the SDL ESC key binding
+        // {XRCID("ToggleFullscreen"), UserInput(WXK_ESCAPE, wxMOD_NONE)},
+        // alt-enter is more standard anyway
+        {XRCID("ToggleFullscreen"), UserInput(WXK_RETURN, wxMOD_ALT)},
+        {XRCID("JoypadAutofireA"), UserInput('1', wxMOD_ALT)},
+        {XRCID("JoypadAutofireB"), UserInput('2', wxMOD_ALT)},
+        {XRCID("JoypadAutofireL"), UserInput('3', wxMOD_ALT)},
+        {XRCID("JoypadAutofireR"), UserInput('4', wxMOD_ALT)},
+        {XRCID("VideoLayersBG0"), UserInput('1', wxMOD_CMD)},
+        {XRCID("VideoLayersBG1"), UserInput('2', wxMOD_CMD)},
+        {XRCID("VideoLayersBG2"), UserInput('3', wxMOD_CMD)},
+        {XRCID("VideoLayersBG3"), UserInput('4', wxMOD_CMD)},
+        {XRCID("VideoLayersOBJ"), UserInput('5', wxMOD_CMD)},
+        {XRCID("VideoLayersWIN0"), UserInput('6', wxMOD_CMD)},
+        {XRCID("VideoLayersWIN1"), UserInput('7', wxMOD_CMD)},
+        {XRCID("VideoLayersOBJWIN"), UserInput('8', wxMOD_CMD)},
+        {XRCID("Rewind"), UserInput('B', wxMOD_CMD)},
+        // following are not in standard menus
+        // FILExx are filled in when recent menu is filled
+        {wxID_FILE1, UserInput(WXK_F1, wxMOD_CMD)},
+        {wxID_FILE2, UserInput(WXK_F2, wxMOD_CMD)},
+        {wxID_FILE3, UserInput(WXK_F3, wxMOD_CMD)},
+        {wxID_FILE4, UserInput(WXK_F4, wxMOD_CMD)},
+        {wxID_FILE5, UserInput(WXK_F5, wxMOD_CMD)},
+        {wxID_FILE6, UserInput(WXK_F6, wxMOD_CMD)},
+        {wxID_FILE7, UserInput(WXK_F7, wxMOD_CMD)},
+        {wxID_FILE8, UserInput(WXK_F8, wxMOD_CMD)},
+        {wxID_FILE9, UserInput(WXK_F9, wxMOD_CMD)},
+        {wxID_FILE10, UserInput(WXK_F10, wxMOD_CMD)},
+        {XRCID("VideoLayersReset"), UserInput('0', wxMOD_CMD)},
+        {XRCID("ChangeFilter"), UserInput('G', wxMOD_CMD)},
+        {XRCID("ChangeIFB"), UserInput('I', wxMOD_CMD)},
+        {XRCID("IncreaseVolume"), UserInput(WXK_NUMPAD_ADD, wxMOD_NONE)},
+        {XRCID("DecreaseVolume"), UserInput(WXK_NUMPAD_SUBTRACT, wxMOD_NONE)},
+        {XRCID("ToggleSound"), UserInput(WXK_NUMPAD_ENTER, wxMOD_NONE)},
+    };
+    return kDefaultShortcuts;
+}
+
+UserInput DefaultShortcutForCommand(int command) {
+    const auto& iter = DefaultShortcuts().find(command);
+    if (iter != DefaultShortcuts().end()) {
+        return iter->second;
+    }
+    return UserInput();
+}
+
+}  // namespace internal
+}  // namespace config

--- a/src/wx/config/internal/shortcuts-internal.h
+++ b/src/wx/config/internal/shortcuts-internal.h
@@ -1,0 +1,21 @@
+#ifndef VBAM_SHORTCUTS_INTERNAL_INCLUDE
+#error "Do not include "config/internal/shortcuts-internal.h" outside of the implementation."
+#endif
+
+#include <set>
+#include <unordered_map>
+
+#include "config/user-input.h"
+
+namespace config {
+namespace internal {
+
+// Returns the map of commands to their default shortcut.
+const std::unordered_map<int, UserInput>& DefaultShortcuts();
+
+// Returns the default shortcut for the given `command`.
+// Returns an Invalid UserInput if there is no default shortcut for `command`.
+UserInput DefaultShortcutForCommand(int command);
+
+}  // namespace internal
+}  // namespace config

--- a/src/wx/config/shortcuts.cpp
+++ b/src/wx/config/shortcuts.cpp
@@ -1,0 +1,183 @@
+#include "config/shortcuts.h"
+
+#include <wx/string.h>
+#include <wx/translation.h>
+#include <wx/xrc/xmlres.h>
+
+#include "config/user-input.h"
+
+#define VBAM_SHORTCUTS_INTERNAL_INCLUDE
+#include "config/internal/shortcuts-internal.h"
+#undef VBAM_SHORTCUTS_INTERNAL_INCLUDE
+
+namespace config {
+
+namespace {
+
+int NoopCommand() {
+    static const int noop = XRCID("NOOP");
+    return noop;
+}
+
+}  // namespace
+
+Shortcuts::Shortcuts() {
+    // Set up default shortcuts.
+    for (const auto& iter : internal::DefaultShortcuts()) {
+        AssignInputToCommand(iter.second, iter.first);
+    }
+}
+
+Shortcuts::Shortcuts(const std::unordered_map<int, std::set<UserInput>>& command_to_inputs,
+                     const std::map<UserInput, int>& input_to_command,
+                     const std::map<UserInput, int>& disabled_defaults)
+    : command_to_inputs_(command_to_inputs.begin(), command_to_inputs.end()),
+      input_to_command_(input_to_command.begin(), input_to_command.end()),
+      disabled_defaults_(disabled_defaults.begin(), disabled_defaults.end()) {}
+
+std::vector<std::pair<int, wxString>> Shortcuts::GetConfiguration() const {
+    std::vector<std::pair<int, wxString>> config;
+    config.reserve(command_to_inputs_.size() + 1);
+
+    if (!disabled_defaults_.empty()) {
+        std::set<UserInput> noop_inputs;
+        for (const auto& iter : disabled_defaults_) {
+            noop_inputs.insert(iter.first);
+        }
+        config.push_back(std::make_pair(NoopCommand(), UserInput::SpanToConfigString(noop_inputs)));
+    }
+
+    for (const auto& iter : command_to_inputs_) {
+        std::set<UserInput> inputs;
+        for (const auto& input : iter.second) {
+            if (internal::DefaultShortcutForCommand(iter.first) != input) {
+                // Not a default input.
+                inputs.insert(input);
+            }
+        }
+        if (!inputs.empty()) {
+            config.push_back(std::make_pair(iter.first, UserInput::SpanToConfigString(inputs)));
+        }
+    }
+
+    return config;
+}
+
+std::set<UserInput> Shortcuts::InputsForCommand(int command) const {
+    if (command == NoopCommand()) {
+        std::set<UserInput> noop_inputs;
+        for (const auto& iter : disabled_defaults_) {
+            noop_inputs.insert(iter.first);
+        }
+        return noop_inputs;
+    }
+
+    auto iter = command_to_inputs_.find(command);
+    if (iter == command_to_inputs_.end()) {
+        return {};
+    }
+    return iter->second;
+}
+
+int Shortcuts::CommandForInput(const UserInput& input) const {
+    const auto iter = input_to_command_.find(input);
+    if (iter == input_to_command_.end()) {
+        return 0;
+    }
+    return iter->second;
+}
+
+std::set<wxJoystick> Shortcuts::Joysticks() const {
+    std::set<wxJoystick> output;
+    for (const auto& iter : command_to_inputs_) {
+        for (const UserInput& user_input : iter.second) {
+            output.insert(user_input.joystick());
+        }
+    }
+    return output;
+}
+
+Shortcuts Shortcuts::Clone() const {
+    return Shortcuts(this->command_to_inputs_, this->input_to_command_, this->disabled_defaults_);
+}
+
+void Shortcuts::AssignInputToCommand(const UserInput& input, int command) {
+    if (command == NoopCommand()) {
+        // "Assigning to Noop" means unassinging the default binding.
+        UnassignDefaultBinding(input);
+        return;
+    }
+
+    // Remove the existing binding if it exists.
+    auto iter = input_to_command_.find(input);
+    if (iter != input_to_command_.end()) {
+        UnassignInput(input);
+    }
+
+    auto disabled_iter = disabled_defaults_.find(input);
+    if (disabled_iter != disabled_defaults_.end()) {
+        int original_command = disabled_iter->second;
+        if (original_command == command) {
+            // Restoring a disabled input. Remove from the disabled set.
+            disabled_defaults_.erase(disabled_iter);
+        }
+        // Then, just continue normally.
+    }
+
+    command_to_inputs_[command].emplace(input);
+    input_to_command_[input] = command;
+}
+
+void Shortcuts::UnassignInput(const UserInput& input) {
+    assert(input);
+
+    auto iter = input_to_command_.find(input);
+    if (iter == input_to_command_.end()) {
+        // Input not found, nothing to do.
+        return;
+    }
+
+    if (internal::DefaultShortcutForCommand(iter->second) == input) {
+        // Unassigning a default binding has some special handling.
+        UnassignDefaultBinding(input);
+        return;
+    }
+
+    // Otherwise, just remove it from the 2 maps.
+    auto command_iter = command_to_inputs_.find(iter->second);
+    assert(command_iter != command_to_inputs_.end());
+
+    command_iter->second.erase(input);
+    if (command_iter->second.empty()) {
+        // Remove empty set.
+        command_to_inputs_.erase(command_iter);
+    }
+    input_to_command_.erase(iter);
+}
+
+void Shortcuts::UnassignDefaultBinding(const UserInput& input) {
+    auto input_iter = input_to_command_.find(input);
+    if (input_iter == input_to_command_.end()) {
+        // This can happen if the INI file provided by the user has an invalid
+        // option. In this case, just silently ignore it.
+        return;
+    }
+
+    if (internal::DefaultShortcutForCommand(input_iter->second) != input) {
+        // As above, we have already removed the default binding, ignore it.
+        return;
+    }
+
+    auto command_iter = command_to_inputs_.find(input_iter->second);
+    assert(command_iter != command_to_inputs_.end());
+
+    command_iter->second.erase(input);
+    if (command_iter->second.empty()) {
+        command_to_inputs_.erase(command_iter);
+    }
+
+    disabled_defaults_[input] = input_iter->second;
+    input_to_command_.erase(input_iter);
+}
+
+}  // namespace config

--- a/src/wx/config/shortcuts.h
+++ b/src/wx/config/shortcuts.h
@@ -1,0 +1,86 @@
+#ifndef VBAM_WX_CONFIG_SHORTCUTS_H_
+#define VBAM_WX_CONFIG_SHORTCUTS_H_
+
+#include <map>
+#include <set>
+#include <vector>
+#include <unordered_map>
+#include <utility>
+
+#include "config/user-input.h"
+
+// by default, only 9 recent items
+#define wxID_FILE10 (wxID_FILE9 + 1)
+
+namespace config {
+
+// Represents a set of shortcuts from a user input (keyboard or joypad) to a
+// command. Internally, this class keeps track of all the necessary data for
+// resolving a user input to a command at runtime and for updating the INI file.
+class Shortcuts {
+public:
+    Shortcuts();
+    ~Shortcuts() = default;
+
+    Shortcuts(Shortcuts&&) noexcept = default;
+    Shortcuts& operator=(Shortcuts&&) noexcept = default;
+
+    // Disable copy and copy assignment operator.
+    // Clone() is provided only for the configuration window, this class
+    // should otherwise be treated as move-only.
+    Shortcuts(const Shortcuts&) = delete;
+    Shortcuts& operator=(const Shortcuts&) = delete;
+
+    // Returns the configuration for the INI file.
+    // Internally, there are global default system inputs that are immediately
+    // available on first run. For the configuration saved in the [Keyboard]
+    // section of the vbam.ini file, we only keep track of the following:
+    // - Disabled default input. These appear under [Keyboard/NOOP].
+    // - User-added custom bindings. These appear under [Keyboard/CommandName].
+    std::vector<std::pair<int, wxString>> GetConfiguration() const;
+
+    // Returns the list of input currently configured for `command`.
+    std::set<UserInput> InputsForCommand(int command) const;
+
+    // Returns the command currently assigned to `input` or nullptr if none.
+    int CommandForInput(const UserInput& input) const;
+
+    // Returns the set of joysticks used by shortcuts.
+    std::set<wxJoystick> Joysticks() const;
+
+    // Returns a copy of this object. This can be an expensive operation and
+    // should only be used to modify the currently active shortcuts
+    // configuration.
+    Shortcuts Clone() const;
+
+    // Assigns `input` to `command`. Silently unassigns `input` if it is already
+    // assigned to another command.
+    void AssignInputToCommand(const UserInput& input, int command);
+
+    // Removes `input` assignment. No-op if `input` is not assigned. `input`
+    // must be a valid UserInput.
+    void UnassignInput(const UserInput& input);
+
+private:
+    // Faster constructor for explitit copy.
+    Shortcuts(const std::unordered_map<int, std::set<UserInput>>& command_to_inputs,
+              const std::map<UserInput, int>& input_to_command,
+              const std::map<UserInput, int>& disabled_defaults);
+
+    // Helper method to unassign a binding used by the default configuration.
+    // This requires special handling since the INI configuration is a diff
+    // between the default bindings and the user configuration.
+    void UnassignDefaultBinding(const UserInput& input);
+
+    // Map of command to their associated input set.
+    std::unordered_map<int, std::set<UserInput>> command_to_inputs_;
+    // Reverse map of the above. An input can only map to a single command.
+    std::map<UserInput, int> input_to_command_;
+    // Disabled default inputs. This is used to easily retrieve the
+    // configuration to save in the INI file.
+    std::map<UserInput, int> disabled_defaults_;
+};
+
+}  // namespace config
+
+#endif  // VBAM_WX_CONFIG_SHORTCUTS_H_

--- a/src/wx/dialogs/accel-config.cpp
+++ b/src/wx/dialogs/accel-config.cpp
@@ -1,0 +1,364 @@
+#include "dialogs/accel-config.h"
+
+#include <wx/ctrlsub.h>
+#include <wx/event.h>
+#include <wx/listbox.h>
+#include <wx/menu.h>
+#include <wx/msgdlg.h>
+#include <wx/xrc/xmlres.h>
+
+#include "config/shortcuts.h"
+#include "config/user-input.h"
+#include "dialogs/validated-child.h"
+#include "opts.h"
+#include "widgets/user-input-ctrl.h"
+#include "wxvbam.h"
+
+namespace dialogs {
+
+namespace {
+
+// Client data holding a config::UserInput.
+class UserInputClientData : public wxClientData {
+public:
+    explicit UserInputClientData(const config::UserInput& user_input) : user_input_(user_input) {}
+    explicit UserInputClientData(config::UserInput&& user_input)
+        : user_input_(std::move(user_input)) {}
+    ~UserInputClientData() override = default;
+
+    const config::UserInput& user_input() const { return user_input_; }
+
+private:
+    const config::UserInput user_input_;
+};
+
+// Holds a Command reference and the corresponding string used for current
+// assignment reference for fast access at configuration time. Owned by
+// the corresponding wxTreeItem.
+class CommandTreeItemData : public wxTreeItemData {
+public:
+    CommandTreeItemData(int command, wxString assigned_string, wxString message_string)
+        : wxTreeItemData(),
+          command_(command),
+          assigned_string_(std::move(assigned_string)),
+          message_string_(std::move(message_string)) {}
+    ~CommandTreeItemData() override = default;
+
+    int command() const { return command_; }
+    const wxString& assigned_string() const { return assigned_string_; };
+    const wxString& message_string() const { return message_string_; };
+
+private:
+    const int command_;
+    const wxString assigned_string_;
+    const wxString message_string_;
+};
+
+wxString AppendString(const wxString& prefix, int level, const wxString& command_name) {
+    return prefix + wxString(' ', 2 * level) + command_name;
+}
+
+wxString AppendMenuItem(const wxString& prefix, int level, const wxMenuItem* menu_item) {
+    return AppendString(prefix, level,
+                        menu_item->GetItemLabelText() + (menu_item->IsSubMenu() ? "\n" : ""));
+}
+
+void AppendItemToTree(std::unordered_map<int, wxTreeItemId>* command_to_item_id,
+                      wxTreeCtrl* tree,
+                      const wxTreeItemId& parent,
+                      int command,
+                      const wxString& prefix,
+                      int level) {
+    int i = 0;
+    for (; i < ncmds; i++) {
+        if (command == cmdtab[i].cmd_id) {
+            break;
+        }
+    }
+    assert(i < ncmds);
+
+    const wxTreeItemId tree_item_id =
+        tree->AppendItem(parent,
+                         /*text=*/cmdtab[i].name,
+                         /*image=*/-1,
+                         /*selImage=*/-1,
+                         /*data=*/
+                         new CommandTreeItemData(
+                             command, AppendString(prefix, level, cmdtab[i].name), cmdtab[i].name));
+    command_to_item_id->emplace(command, tree_item_id);
+}
+
+// Built the initial tree control from the menu.
+void PopulateTreeWithMenu(std::unordered_map<int, wxTreeItemId>* command_to_item_id,
+                          wxTreeCtrl* tree,
+                          const wxTreeItemId& parent,
+                          wxMenu* menu,
+                          const wxMenu* recents,
+                          const wxString& prefix,
+                          int level = 1) {
+    for (auto menu_item : menu->GetMenuItems()) {
+        if (menu_item->IsSeparator()) {
+            tree->AppendItem(parent, "-----");
+        } else if (menu_item->IsSubMenu()) {
+            if (menu_item->GetSubMenu() == recents) {
+                // This has to be done manually because not all recents are always populated.
+                const wxTreeItemId recents_parent =
+                    tree->AppendItem(parent, menu_item->GetItemLabelText());
+                const wxString recents_prefix = AppendMenuItem(prefix, level, menu_item);
+                for (int i = wxID_FILE1; i <= wxID_FILE10; i++) {
+                    AppendItemToTree(command_to_item_id, tree, recents_parent, i, recents_prefix,
+                                     level + 1);
+                }
+            } else {
+                const wxTreeItemId sub_parent =
+                    tree->AppendItem(parent, menu_item->GetItemLabelText());
+                PopulateTreeWithMenu(command_to_item_id, tree, sub_parent, menu_item->GetSubMenu(),
+                                     recents, AppendMenuItem(prefix, level, menu_item), level + 1);
+            }
+        } else {
+            AppendItemToTree(command_to_item_id, tree, parent, menu_item->GetId(), prefix, level);
+        }
+    }
+}
+
+}  // namespace
+
+// static
+AccelConfig* AccelConfig::NewInstance(wxWindow* parent, wxMenuBar* menu, wxMenu* recents) {
+    assert(parent);
+    assert(menu);
+    assert(recents);
+    return new AccelConfig(parent, menu, recents);
+}
+
+AccelConfig::AccelConfig(wxWindow* parent, wxMenuBar* menu, wxMenu* recents)
+    : wxDialog(), keep_on_top_styler_(this) {
+    assert(parent);
+    assert(menu);
+
+    // Load the dialog XML.
+    const bool success = wxXmlResource::Get()->LoadDialog(this, parent, "AccelConfig");
+    assert(success);
+
+    // Loads the various dialog elements.
+    tree_ = GetValidatedChild<wxTreeCtrl>(this, "Commands");
+    current_keys_ = GetValidatedChild<wxListBox>(this, "Current");
+    assign_button_ = GetValidatedChild(this, "Assign");
+    remove_button_ = GetValidatedChild(this, "Remove");
+    key_input_ = GetValidatedChild<widgets::UserInputCtrl>(this, "Shortcut");
+    currently_assigned_label_ = GetValidatedChild<wxControl>(this, "AlreadyThere");
+
+    // Configure the key input.
+    key_input_->MoveBeforeInTabOrder(assign_button_);
+
+    // Populate the tree from the menu.
+    wxTreeItemId root_id = tree_->AddRoot("root");
+    wxTreeItemId menu_id = tree_->AppendItem(root_id, _("Menu commands"));
+    for (size_t i = 0; i < menu->GetMenuCount(); i++) {
+        wxTreeItemId id = tree_->AppendItem(menu_id, menu->GetMenuLabelText(i));
+        PopulateTreeWithMenu(&command_to_item_id_, tree_, id, menu->GetMenu(i), recents,
+                             menu->GetMenuLabelText(i) + '\n');
+    }
+    tree_->ExpandAll();
+    tree_->SelectItem(menu_id);
+
+    // Set the initial tree size.
+    wxSize size = tree_->GetBestSize();
+    size.SetHeight(std::min(200, size.GetHeight()));
+    tree_->SetSize(size);
+    size.SetWidth(-1);  // maybe allow it to become bigger
+    tree_->SetSizeHints(size, size);
+
+    int w, h;
+    current_keys_->GetTextExtent("CTRL-ALT-SHIFT-ENTER", &w, &h);
+    size.Set(w, h);
+    current_keys_->SetMinSize(size);
+
+    // Compute max size for currently_assigned_label_.
+    size.Set(0, 0);
+    for (const auto& iter : command_to_item_id_) {
+        const CommandTreeItemData* item_data =
+            static_cast<const CommandTreeItemData*>(tree_->GetItemData(iter.second));
+        assert(item_data);
+
+        currently_assigned_label_->GetTextExtent(item_data->assigned_string(), &w, &h);
+        size.SetWidth(std::max(w, size.GetWidth()));
+        size.SetHeight(std::max(h, size.GetHeight()));
+    }
+    currently_assigned_label_->SetMinSize(size);
+    currently_assigned_label_->SetSizeHints(size);
+
+    // Finally, bind the events.
+    Bind(wxEVT_SHOW, &AccelConfig::OnDialogShown, this, GetId());
+    Bind(wxEVT_TREE_SEL_CHANGING, &AccelConfig::OnCommandSelected, this, tree_->GetId());
+    Bind(wxEVT_TREE_SEL_CHANGED, &AccelConfig::OnCommandSelected, this, tree_->GetId());
+    Bind(wxEVT_LISTBOX, &AccelConfig::OnKeySelected, this, current_keys_->GetId());
+    Bind(wxEVT_BUTTON, &AccelConfig::OnValidate, this, wxID_OK);
+    Bind(wxEVT_BUTTON, &AccelConfig::OnAssignBinding, this, assign_button_->GetId());
+    Bind(wxEVT_BUTTON, &AccelConfig::OnRemoveBinding, this, remove_button_->GetId());
+    Bind(wxEVT_BUTTON, &AccelConfig::OnResetAll, this, XRCID("ResetAll"));
+    Bind(wxEVT_TEXT, &AccelConfig::OnKeyInput, this, key_input_->GetId());
+
+    // And fit everything nicely.
+    Fit();
+}
+
+void AccelConfig::OnDialogShown(wxShowEvent& ev) {
+    // Let the event propagate.
+    ev.Skip();
+
+    if (!ev.IsShown()) {
+        return;
+    }
+
+    // Reset the dialog.
+    current_keys_->Clear();
+    tree_->Unselect();
+    tree_->ExpandAll();
+    key_input_->Clear();
+    assign_button_->Enable(false);
+    remove_button_->Enable(false);
+    currently_assigned_label_->SetLabel("");
+
+    config_shortcuts_ = gopts.shortcuts.Clone();
+}
+
+void AccelConfig::OnValidate(wxCommandEvent& ev) {
+    gopts.shortcuts = std::move(config_shortcuts_);
+    ev.Skip();
+}
+
+void AccelConfig::OnCommandSelected(wxTreeEvent& ev) {
+    const CommandTreeItemData* command_tree_data =
+        static_cast<const CommandTreeItemData*>(tree_->GetItemData(ev.GetItem()));
+
+    if (!command_tree_data) {
+        selected_command_ = 0;
+        PopulateCurrentKeys();
+        ev.Veto();
+        return;
+    }
+
+    if (ev.GetEventType() == wxEVT_COMMAND_TREE_SEL_CHANGING) {
+        ev.Skip();
+        return;
+    }
+
+    selected_command_ = command_tree_data->command();
+    PopulateCurrentKeys();
+}
+
+void AccelConfig::OnKeySelected(wxCommandEvent&) {
+    remove_button_->Enable(current_keys_->GetSelection() != wxNOT_FOUND);
+}
+
+void AccelConfig::OnRemoveBinding(wxCommandEvent&) {
+    const int selection = current_keys_->GetSelection();
+    if (selection == wxNOT_FOUND) {
+        return;
+    }
+
+    config_shortcuts_.UnassignInput(
+        static_cast<UserInputClientData*>(current_keys_->GetClientObject(selection))->user_input());
+    PopulateCurrentKeys();
+}
+
+void AccelConfig::OnResetAll(wxCommandEvent&) {
+    const int confirmation = wxMessageBox(
+        _("This will clear all user-defined accelerators. Are you sure?"), _("Confirm"), wxYES_NO);
+    if (confirmation != wxYES) {
+        return;
+    }
+
+    config_shortcuts_ = config::Shortcuts();
+    tree_->Unselect();
+    key_input_->Clear();
+    PopulateCurrentKeys();
+}
+
+void AccelConfig::OnAssignBinding(wxCommandEvent&) {
+    const wxTreeItemId selected_id = tree_->GetSelection();
+    const config::UserInput user_input = key_input_->SingleInput();
+    if (!selected_id.IsOk() || !user_input) {
+        return;
+    }
+
+    const CommandTreeItemData* data =
+        static_cast<CommandTreeItemData*>(tree_->GetItemData(selected_id));
+    if (!data) {
+        return;
+    }
+
+    const int old_command = config_shortcuts_.CommandForInput(user_input);
+    if (old_command != 0) {
+        const auto iter = command_to_item_id_.find(old_command);
+        assert(iter != command_to_item_id_.end());
+        const CommandTreeItemData* old_command_item_data =
+            static_cast<const CommandTreeItemData*>(tree_->GetItemData(iter->second));
+        assert(old_command_item_data);
+
+        // Require user confirmation to override.
+        const int confirmation =
+            wxMessageBox(wxString::Format(_("This will unassign \"%s\" from \"%s\". Are you sure?"),
+                                          user_input.ToLocalizedString(),
+                                          old_command_item_data->message_string()),
+                         _("Confirm"), wxYES_NO);
+        if (confirmation != wxYES) {
+            return;
+        }
+    }
+
+    config_shortcuts_.AssignInputToCommand(user_input, data->command());
+    PopulateCurrentKeys();
+}
+
+void AccelConfig::OnKeyInput(wxCommandEvent&) {
+    const config::UserInput user_input = key_input_->SingleInput();
+    if (!user_input) {
+        currently_assigned_label_->SetLabel(wxEmptyString);
+        assign_button_->Enable(false);
+        return;
+    }
+
+    const int command = config_shortcuts_.CommandForInput(user_input);
+    if (command == 0) {
+        // No existing assignment.
+        currently_assigned_label_->SetLabel(wxEmptyString);
+    } else {
+        // Existing assignment, inform the user.
+        const auto iter = command_to_item_id_.find(command);
+        assert(iter != command_to_item_id_.end());
+        currently_assigned_label_->SetLabel(
+            static_cast<CommandTreeItemData*>(tree_->GetItemData(iter->second))->assigned_string());
+    }
+
+    assign_button_->Enable(true);
+}
+
+void AccelConfig::PopulateCurrentKeys() {
+    const int previous_selection = current_keys_->GetSelection();
+    current_keys_->Clear();
+
+    if (selected_command_ == 0) {
+        return;
+    }
+
+    // Populate `current_keys`.
+    int new_keys_count = 0;
+    for (const auto& user_input : config_shortcuts_.InputsForCommand(selected_command_)) {
+        current_keys_->Append(user_input.ToLocalizedString(), new UserInputClientData(user_input));
+        new_keys_count++;
+    }
+
+    // Reset the selection accordingly.
+    if (previous_selection == wxNOT_FOUND || new_keys_count == 0) {
+        current_keys_->SetSelection(wxNOT_FOUND);
+        remove_button_->Enable(false);
+    } else {
+        current_keys_->SetSelection(std::min(previous_selection, new_keys_count - 1));
+        remove_button_->Enable(true);
+    }
+
+}
+
+}  // namespace dialogs

--- a/src/wx/dialogs/accel-config.h
+++ b/src/wx/dialogs/accel-config.h
@@ -1,0 +1,83 @@
+#ifndef VBAM_WX_DIALOGS_ACCEL_CONFIG_H_
+#define VBAM_WX_DIALOGS_ACCEL_CONFIG_H_
+
+#include <unordered_map>
+
+#include <wx/dialog.h>
+#include <wx/treectrl.h>
+
+#include "config/shortcuts.h"
+#include "widgets/keep-on-top-styler.h"
+
+// Forward declarations.
+class wxControl;
+class wxListBox;
+class wxMenu;
+class wxMenuBar;
+class wxWindow;
+
+namespace widgets {
+class UserInputCtrl;
+}
+
+namespace dialogs {
+
+// Manages the shortcuts editor dialog.
+class AccelConfig : public wxDialog {
+public:
+    static AccelConfig* NewInstance(wxWindow* parent, wxMenuBar* menu_bar, wxMenu* recents);
+
+    ~AccelConfig() override = default;
+
+private:
+    // The constructor is private so initialization has to be done via the
+    // static method. This is because this class is destroyed when its
+    // owner, `parent` is destroyed. This prevents accidental deletion.
+    AccelConfig(wxWindow* parent, wxMenuBar* menu_bar, wxMenu* recents);
+
+    // Re-initializes the configuration.
+    void OnDialogShown(wxShowEvent& ev);
+
+    // On OK, saves the global shortcuts.
+    void OnValidate(wxCommandEvent& ev);
+
+    // Fills in the key list.
+    void OnCommandSelected(wxTreeEvent& ev);
+
+    // after selecting a key in key list, enable Remove button
+    void OnKeySelected(wxCommandEvent& ev);
+
+    // remove selected binding
+    void OnRemoveBinding(wxCommandEvent& ev);
+
+    // wipe out all user bindings
+    void OnResetAll(wxCommandEvent& ev);
+
+    // remove old key binding, add new key binding, and update GUI
+    void OnAssignBinding(wxCommandEvent& ev);
+
+    // update curas and maybe enable asb
+    // Called when the input text box is updated. Finds current binding.
+    void OnKeyInput(wxCommandEvent& ev);
+
+    // Helper method to populate `current_keys_` whenever the configuration or
+    // selection has changed.
+    void PopulateCurrentKeys();
+
+    wxTreeCtrl* tree_;
+    wxListBox* current_keys_;
+    wxWindow* assign_button_;
+    wxWindow* remove_button_;
+    widgets::UserInputCtrl* key_input_;
+    wxControl* currently_assigned_label_;
+    std::unordered_map<int, wxTreeItemId> command_to_item_id_;
+
+    config::Shortcuts config_shortcuts_;
+    int selected_command_ = 0;
+
+    const widgets::KeepOnTopStyler keep_on_top_styler_;
+};
+
+}  // namespace dialogs
+
+#endif  // VBAM_WX_DIALOGS_ACCEL_CONFIG_H_

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -110,98 +110,6 @@ uint32_t LoadUnsignedOption(wxConfigBase* cfg,
 
 opts_t gopts;
 
-// having the standard menu accels here means they will work even without menus
-const wxAcceleratorEntryUnicode default_accels[] = {
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'C', XRCID("CheatsList")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'N', XRCID("NextFrame")),
-    // some ports add ctrl-q anyway, so may as well make it official
-    // maybe make alt-f4 universal as well...
-    // FIXME: ctrl-Q does not work on wxMSW
-    // FIXME: esc does not work on wxMSW
-
-    // this was annoying people A LOT #334
-    //wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_ESCAPE, wxID_EXIT),
-
-    // this was annoying people #298
-    //wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'X', wxID_EXIT),
-
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'Q', wxID_EXIT),
-    // FIXME: ctrl-W does not work on wxMSW
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'W', wxID_CLOSE),
-    // load most recent is more commonly used than load other
-    //wxAcceleratorEntry(wxMOD_CMD, 'L', XRCID("Load")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'L', XRCID("LoadGameRecent")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_F1, XRCID("LoadGame01")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_F2, XRCID("LoadGame02")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_F3, XRCID("LoadGame03")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_F4, XRCID("LoadGame04")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_F5, XRCID("LoadGame05")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_F6, XRCID("LoadGame06")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_F7, XRCID("LoadGame07")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_F8, XRCID("LoadGame08")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_F9, XRCID("LoadGame09")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_F10, XRCID("LoadGame10")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_PAUSE, XRCID("Pause")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'P', XRCID("Pause")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'R', XRCID("Reset")),
-    // add shortcuts for original size multiplier #415
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, '1', XRCID("SetSize1x")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, '2', XRCID("SetSize2x")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, '3', XRCID("SetSize3x")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, '4', XRCID("SetSize4x")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, '5', XRCID("SetSize5x")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, '6', XRCID("SetSize6x")),
-    // save oldest is more commonly used than save other
-    //wxAcceleratorEntry(wxMOD_CMD, 'S', XRCID("Save")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'S', XRCID("SaveGameOldest")),
-    wxAcceleratorEntryUnicode(0, wxMOD_SHIFT, WXK_F1, XRCID("SaveGame01")),
-    wxAcceleratorEntryUnicode(0, wxMOD_SHIFT, WXK_F2, XRCID("SaveGame02")),
-    wxAcceleratorEntryUnicode(0, wxMOD_SHIFT, WXK_F3, XRCID("SaveGame03")),
-    wxAcceleratorEntryUnicode(0, wxMOD_SHIFT, WXK_F4, XRCID("SaveGame04")),
-    wxAcceleratorEntryUnicode(0, wxMOD_SHIFT, WXK_F5, XRCID("SaveGame05")),
-    wxAcceleratorEntryUnicode(0, wxMOD_SHIFT, WXK_F6, XRCID("SaveGame06")),
-    wxAcceleratorEntryUnicode(0, wxMOD_SHIFT, WXK_F7, XRCID("SaveGame07")),
-    wxAcceleratorEntryUnicode(0, wxMOD_SHIFT, WXK_F8, XRCID("SaveGame08")),
-    wxAcceleratorEntryUnicode(0, wxMOD_SHIFT, WXK_F9, XRCID("SaveGame09")),
-    wxAcceleratorEntryUnicode(0, wxMOD_SHIFT, WXK_F10, XRCID("SaveGame10")),
-    // I prefer the SDL ESC key binding
-    //wxAcceleratorEntry(wxMOD_NONE, WXK_ESCAPE, XRCID("ToggleFullscreen"),
-    // alt-enter is more standard anyway
-    wxAcceleratorEntryUnicode(0, wxMOD_ALT, WXK_RETURN, XRCID("ToggleFullscreen")),
-    wxAcceleratorEntryUnicode(0, wxMOD_ALT, '1', XRCID("JoypadAutofireA")),
-    wxAcceleratorEntryUnicode(0, wxMOD_ALT, '2', XRCID("JoypadAutofireB")),
-    wxAcceleratorEntryUnicode(0, wxMOD_ALT, '3', XRCID("JoypadAutofireL")),
-    wxAcceleratorEntryUnicode(0, wxMOD_ALT, '4', XRCID("JoypadAutofireR")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, '1', XRCID("VideoLayersBG0")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, '2', XRCID("VideoLayersBG1")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, '3', XRCID("VideoLayersBG2")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, '4', XRCID("VideoLayersBG3")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, '5', XRCID("VideoLayersOBJ")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, '6', XRCID("VideoLayersWIN0")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, '7', XRCID("VideoLayersWIN1")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, '8', XRCID("VideoLayersOBJWIN")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'B', XRCID("Rewind")),
-    // following are not in standard menus
-    // FILExx are filled in when recent menu is filled
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, WXK_F1, wxID_FILE1),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, WXK_F2, wxID_FILE2),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, WXK_F3, wxID_FILE3),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, WXK_F4, wxID_FILE4),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, WXK_F5, wxID_FILE5),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, WXK_F6, wxID_FILE6),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, WXK_F7, wxID_FILE7),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, WXK_F8, wxID_FILE8),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, WXK_F9, wxID_FILE9),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, WXK_F10, wxID_FILE10),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, '0', XRCID("VideoLayersReset")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'G', XRCID("ChangeFilter")),
-    wxAcceleratorEntryUnicode(0, wxMOD_CMD, 'I', XRCID("ChangeIFB")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_NUMPAD_ADD, XRCID("IncreaseVolume")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_NUMPAD_SUBTRACT, XRCID("DecreaseVolume")),
-    wxAcceleratorEntryUnicode(0, wxMOD_NONE, WXK_NUMPAD_ENTER, XRCID("ToggleSound"))
-};
-const int num_def_accels = sizeof(default_accels) / sizeof(default_accels[0]);
-
 const std::map<config::GameControl, std::set<config::UserInput>> kDefaultBindings = {
     { config::GameControl(0, config::GameKey::Up), {
         WJKB('W'),
@@ -335,8 +243,6 @@ const std::map<config::GameControl, std::set<config::UserInput>> kDefaultBinding
     { config::GameControl(3, config::GameKey::Capture), {}},
     { config::GameControl(3, config::GameKey::Gameshark), {}},
 };
-
-wxAcceleratorEntry_v sys_accels;
 
 // This constructor only works with globally allocated gopts.
 opts_t::opts_t()
@@ -570,11 +476,9 @@ void load_opts(bool first_time_launch) {
             if (inputs.empty()) {
                 wxLogWarning(_("Invalid key binding %s for %s"), s.c_str(), kbopt.c_str());
             } else {
-                wxAcceleratorEntry_v val;
                 for (const auto& input : inputs) {
-                    val.push_back(wxAcceleratorEntryUnicode(input, cmdtab[i].cmd_id));
+                    gopts.shortcuts.AssignInputToCommand(input, cmdtab[i].cmd_id);
                 }
-                gopts.accels.insert(gopts.accels.end(), val.begin(), val.end());
             }
         }
     }
@@ -651,72 +555,31 @@ void update_opts() {
         config::GameControlState::Instance().OnGameBindingsChanged();
     }
 
-    // for keyboard, first remove any commands that aren't bound at all
-    if (cfg->HasGroup(wxT("/Keyboard"))) {
-        cfg->SetPath(wxT("/Keyboard"));
-        wxString s;
-        long entry_idx;
-        wxArrayString item_del;
+    cfg->SetPath("/");
+    cfg->Flush();
+}
 
-        for (bool cont = cfg->GetFirstEntry(s, entry_idx); cont;
-             cont = cfg->GetNextEntry(s, entry_idx)) {
-            const cmditem dummy = new_cmditem(s);
-            cmditem* cmd = std::lower_bound(&cmdtab[0], &cmdtab[ncmds], dummy, cmditem_lt);
-            size_t i;
+void update_shortcut_opts() {
+    wxConfigBase* cfg = wxConfigBase::Get();
 
-            for (i = 0; i < gopts.accels.size(); i++)
-                if (gopts.accels[i].GetCommand() == cmd->cmd_id)
-                    break;
-
-            if (i == gopts.accels.size())
-                item_del.push_back(s);
-        }
-
-        for (size_t i = 0; i < item_del.size(); i++)
-            cfg->DeleteEntry(item_del[i]);
-    }
-
-    // then, add/update the commands that are bound
-    // even if only ordering changed, a write will be triggered.
-    // nothing to worry about...
-    if (gopts.accels.size())
-        cfg->SetPath(wxT("/Keyboard"));
-
-    int cmd_id = -1;
-    for (wxAcceleratorEntry_v::iterator i = gopts.accels.begin();
-         i < gopts.accels.end(); ++i) {
-        if (cmd_id == i->GetCommand()) continue;
-        cmd_id = i->GetCommand();
-        int cmd;
-
+    // For shortcuts, it's easier to delete everything and start over.
+    cfg->DeleteGroup("/Keyboard");
+    cfg->SetPath("/Keyboard");
+    for (const auto& iter : gopts.shortcuts.GetConfiguration()) {
+        int cmd = 0;
         for (cmd = 0; cmd < ncmds; cmd++)
-            if (cmdtab[cmd].cmd_id == cmd_id)
+            if (cmdtab[cmd].cmd_id == iter.first)
                 break;
-
-        // NOOP overwrittes commands removed by the user
-        wxString command = cmdtab[cmd].cmd;
-        if (cmdtab[cmd].cmd_id == XRCID("NOOP"))
-            command = wxT("NOOP");
-
-        wxAcceleratorEntry_v::iterator j;
-
-        for (j = i + 1; j < gopts.accels.end(); ++j)
-            if (j->GetCommand() != cmd_id)
-                break;
-
-        wxAcceleratorEntry_v nv(i, j);
-        std::set<config::UserInput> user_inputs;
-        for (const auto& accel : nv) {
-            user_inputs.insert(config::UserInput(accel.GetKeyCode(), accel.GetFlags(), accel.GetJoystick()));
+        if (cmd == ncmds) {
+            // Command not found. This should never happen.
+            assert(false);
+            continue;
         }
-        wxString nvs = config::UserInput::SpanToConfigString(user_inputs);
 
-        if (nvs != cfg->Read(command))
-            cfg->Write(command, nvs);
+        cfg->Write(cmdtab[cmd].cmd, iter.second);
     }
 
-    cfg->SetPath(wxT("/"));
-    // recent items are updated separately
+    cfg->SetPath("/");
     cfg->Flush();
 }
 
@@ -793,28 +656,14 @@ void opt_set(const wxString& name, const wxString& val) {
             return;
         }
 
-        for (auto i = gopts.accels.begin(); i < gopts.accels.end(); ++i)
-            if (i->GetCommand() == cmd->cmd_id) {
-                auto j = i;
-                for (; j < gopts.accels.end(); ++j)
-                    if (j->GetCommand() != cmd->cmd_id)
-                        break;
-                gopts.accels.erase(i, j);
-                break;
-            }
-
         if (!val.empty()) {
-            auto inputs = config::UserInput::FromConfigString(val);
-            wxAcceleratorEntry_v aval;
-            for (const auto& input : inputs) {
-                aval.push_back(wxAcceleratorEntryUnicode(input, cmd->cmd_id));
-            }
-            if (!aval.size()) {
+            const auto inputs = config::UserInput::FromConfigString(val);
+            if (inputs.empty()) {
                 wxLogWarning(_("Invalid key binding %s for %s"), val.c_str(), name.c_str());
-                return;
             }
-
-            gopts.accels.insert(gopts.accels.end(), aval.begin(), aval.end());
+            for (const auto& input : inputs) {
+                gopts.shortcuts.AssignInputToCommand(input, cmd->cmd_id);
+            }
         }
 
         return;

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -7,6 +7,7 @@
 #include <wx/vidmode.h>
 
 #include "config/game-control.h"
+#include "config/shortcuts.h"
 #include "config/user-input.h"
 #include "wxutil.h"
 
@@ -44,7 +45,7 @@ extern struct opts_t {
     int default_stick = 1;
 
     /// Keyboard
-    wxAcceleratorEntry_v accels;
+    config::Shortcuts shortcuts;
 
     /// Core
     int gdb_port = 55555;
@@ -77,9 +78,6 @@ extern struct opts_t {
     // wxWidgets-generated options (opaque)
 } gopts;
 
-extern const wxAcceleratorEntryUnicode default_accels[];
-extern const int num_def_accels;
-
 // call to load config (once)
 // will write defaults for options not present and delete bad opts
 // will also initialize opts[] array translations
@@ -87,6 +85,8 @@ void load_opts(bool first_time_launch);
 // call whenever opt vars change
 // will detect changes and write config if necessary
 void update_opts();
+// Updates the shortcut options.
+void update_shortcut_opts();
 // returns true if option name correct; prints error if val invalid
 void opt_set(const wxString& name, const wxString& val);
 

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -191,7 +191,7 @@ void GameArea::LoadGame(const wxString& name)
 
         if (!OPTION(kGenFreezeRecent)) {
             gopts.recent->AddFileToHistory(name);
-            wxGetApp().frame->SetRecentAccels();
+            wxGetApp().frame->ResetRecentAccelerators();
             cfg->SetPath("/Recent");
             gopts.recent->Save(*cfg);
             cfg->SetPath("/");

--- a/src/wx/widgets/user-input-ctrl.cpp
+++ b/src/wx/widgets/user-input-ctrl.cpp
@@ -67,6 +67,14 @@ void UserInputCtrl::SetInputs(const std::set<config::UserInput>& inputs) {
     UpdateText();
 }
 
+config::UserInput UserInputCtrl::SingleInput() const {
+    assert(!is_multikey_);
+    if (inputs_.empty()) {
+        return config::UserInput();
+    }
+    return *inputs_.begin();
+}
+
 void UserInputCtrl::Clear() {
     inputs_.clear();
     UpdateText();

--- a/src/wx/widgets/user-input-ctrl.h
+++ b/src/wx/widgets/user-input-ctrl.h
@@ -47,6 +47,11 @@ public:
     // Sets this control inputs.
     void SetInputs(const std::set<config::UserInput>& inputs);
 
+    // Helper method to return the single input for no multikey UserInputCtrls.
+    // Asserts if `is_multikey_` is true.
+    // Returns an invalid UserInput if no input is currently set.
+    config::UserInput SingleInput() const;
+
     // Returns the inputs set in this control.
     const std::set<config::UserInput>& inputs() const { return inputs_; }
 

--- a/src/wx/wxhead.h
+++ b/src/wx/wxhead.h
@@ -59,41 +59,6 @@ using std::int32_t;
 
 #include "wxutil.h"
 
-static inline void DoSetAccel(wxMenuItem* mi, wxAcceleratorEntryUnicode* acc)
-{
-    // cannot use SDL keybinding as text without wx assertion error
-    if (acc && acc->GetJoystick() != 0) return;
-
-    wxString lab = mi->GetItemLabel();
-    size_t tab = lab.find(wxT('\t'));
-
-    // following short circuit returns are to avoid UI update on no change
-    if (tab == wxString::npos && !acc)
-        return;
-
-    wxString accs;
-
-    if (acc) {
-        // actually, use keyedit's ToString(), as it is more reliable
-        // and doesn't generate wx assertions
-        // accs = acc->ToString();
-        accs = config::UserInput(acc->GetKeyCode(), acc->GetFlags()).ToLocalizedString();
-    }
-
-    if (tab != wxString::npos && accs == lab.substr(tab + 1))
-        return;
-
-    if (tab != wxString::npos)
-        lab.resize(tab);
-
-    if (acc) {
-        lab.append(wxT('\t'));
-        lab.append(accs);
-    }
-
-    mi->SetItemLabel(lab);
-}
-
 // wxrc helpers (for dynamic strings instead of constant)
 #define XRCID_D(str) wxXmlResource::GetXRCID(str)
 //#define XRCCTRL_D(win, id, type) (wxStaticCast((win).FindWindow(XRCID_D(id)), type))
@@ -117,8 +82,5 @@ static inline const wxCharBuffer UTF8(wxString str)
 {
     return str.mb_str(wxConvUTF8);
 }
-
-// by default, only 9 recent items
-#define wxID_FILE10 (wxID_FILE9 + 1)
 
 #endif /* WX_WXHEAD_H */

--- a/src/wx/wxutil.cpp
+++ b/src/wx/wxutil.cpp
@@ -1,5 +1,4 @@
 #include "wxutil.h"
-#include "../common/contains.h"
 
 int getKeyboardKeyCode(const wxKeyEvent& event) {
     int uc = event.GetUnicodeKey();
@@ -19,28 +18,4 @@ int getKeyboardKeyCode(const wxKeyEvent& event) {
     } else {
         return event.GetKeyCode();
     }
-}
-
-wxAcceleratorEntryUnicode::wxAcceleratorEntryUnicode(wxAcceleratorEntry* accel)
-    : wxAcceleratorEntryUnicode(0,
-                                accel->GetFlags(),
-                                accel->GetKeyCode(),
-                                accel->GetCommand(),
-                                accel->GetMenuItem()) {}
-
-wxAcceleratorEntryUnicode::wxAcceleratorEntryUnicode(const config::UserInput& input,
-                                                     int cmd,
-                                                     wxMenuItem* item)
-    : wxAcceleratorEntryUnicode(input.joy(), input.mod(), input.key(), cmd, item) {}
-
-wxAcceleratorEntryUnicode::wxAcceleratorEntryUnicode(int joy,
-                                                     int flags,
-                                                     int keyCode,
-                                                     int cmd,
-                                                     wxMenuItem* item)
-    : wxAcceleratorEntry(flags, keyCode, cmd, item), joystick(joy) {}
-
-void wxAcceleratorEntryUnicode::Set(int joy, int flags, int keyCode, int cmd, wxMenuItem* item) {
-    joystick = joy;
-    wxAcceleratorEntry::Set(flags, keyCode, cmd, item);
 }

--- a/src/wx/wxutil.h
+++ b/src/wx/wxutil.h
@@ -1,36 +1,8 @@
 #ifndef _WX_UTIL_H
 #define _WX_UTIL_H
 
-#include <vector>
-
-#include <wx/accel.h>
 #include <wx/event.h>
 
-#include "config/user-input.h"
-
 int getKeyboardKeyCode(const wxKeyEvent& event);
-
-class wxAcceleratorEntryUnicode : public wxAcceleratorEntry
-{
-  public:
-    wxAcceleratorEntryUnicode(wxAcceleratorEntry *accel);
-    wxAcceleratorEntryUnicode(const config::UserInput& input,
-                              int cmd = 0,
-                              wxMenuItem* item = nullptr);
-    wxAcceleratorEntryUnicode(int joy = 0,
-                              int flags = 0,
-                              int keyCode = 0,
-                              int cmd = 0,
-                              wxMenuItem* item = nullptr);
-
-    void Set(int joy, int flags, int keyCode, int cmd, wxMenuItem* item = nullptr);
-
-    int GetJoystick() const { return joystick; };
-
-private:
-    int joystick;
-};
-
-typedef std::vector<wxAcceleratorEntryUnicode> wxAcceleratorEntry_v;
 
 #endif

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -95,12 +95,6 @@ public:
 #endif
     // without this, global accels don't always work
     int FilterEvent(wxEvent&);
-    wxAcceleratorEntry_v accels;
-
-    wxAcceleratorEntry_v GetAccels()
-    {
-        return accels;
-    }
 
     // vba-over.ini
     wxFileConfig* overrides = nullptr;
@@ -262,15 +256,11 @@ public:
     int oldest_state_slot(); // or empty slot if available
     int newest_state_slot(); // or 0 if none
 
-    // system-defined accelerators
-    wxAcceleratorEntry_v sys_accels;
-    // adjust recent menu with accelerators
-    void SetRecentAccels();
-    // merge sys accels with user-defined accels (user overrides sys)
-    wxAcceleratorEntry_v get_accels(wxAcceleratorEntry_v user_accels);
-    // update menu and global accelerator table with sys+user accel defs
-    // probably not the quickest way to add/remove individual accels
-    void set_global_accels();
+    // Resets the Recent menu accelerators. Needs to be called every time the
+    // Recent menu is updated.
+    void ResetRecentAccelerators();
+    // Resets all menu accelerators.
+    void ResetMenuAccelerators();
 
     // 2.8 has no HasFocus(), and FindFocus() doesn't work right
     bool HasFocus() const
@@ -357,7 +347,6 @@ private:
     checkable_mi_array_t checkable_mi;
     // recent menu item accels
     wxMenu* recent;
-    wxAcceleratorEntryUnicode recent_accel[10];
     // joystick reader
     wxJoyPoller joy;
     JoystickPoller* jpoll = nullptr;

--- a/src/wx/xrc/AccelConfig.xrc
+++ b/src/wx/xrc/AccelConfig.xrc
@@ -3,7 +3,7 @@
   <object class="wxDialog" name="AccelConfig">
     <title>Key Shortcuts</title>
     <object class="wxBoxSizer">
-      <orient>wxVERTICAL</orient>
+      <flag>wxEXPAND</flag>
       <object class="sizeritem">
         <object class="wxFlexGridSizer">
           <object class="sizeritem">


### PR DESCRIPTION
* Removes wxAcceleratorEntryUnicode and assorted arrays in favor of a new class, `config::Shortcuts`, which handles UserInput assignment to commands and resolution at runtime. `config::Shortcuts` also handles the INI user configuration in a backwards-compatible way. Runtime resolution of UserInput to command is also now logarithmic rather than linear.
* The same shortcut can no longer be assigned to 2 different commands, which fixes #158.
* Moves the `AccelConfig` dialog to its own dedicated class.