### PR TITLE
[bios] Fix lz77 and add BIOS_SndDriverVsyncOn

### DIFF
--- a/src/gba/GBA.cpp
+++ b/src/gba/GBA.cpp
@@ -2083,8 +2083,8 @@ void CPUSoftwareInterrupt(int comment)
     case 0x02:
 #ifdef GBA_LOGGING
         if (systemVerbose & VERBOSE_SWI) {
-            /*log("Halt: (VCOUNT = %2d)\n",
-          VCOUNT);*/
+            log("Halt: (VCOUNT = %2d)\n",
+                VCOUNT);
         }
 #endif
         holdState = true;
@@ -2094,8 +2094,8 @@ void CPUSoftwareInterrupt(int comment)
     case 0x03:
 #ifdef GBA_LOGGING
         if (systemVerbose & VERBOSE_SWI) {
-            /*log("Stop: (VCOUNT = %2d)\n",
-          VCOUNT);*/
+            log("Stop: (VCOUNT = %2d)\n",
+                VCOUNT);
         }
 #endif
         holdState = true;
@@ -2271,11 +2271,14 @@ void CPUSoftwareInterrupt(int comment)
     case 0x1E:
         BIOS_SndChannelClear();
         break;
+    case 0x1F:
+        BIOS_MidiKey2Freq();
+        break;
     case 0x28:
         BIOS_SndDriverVSyncOff();
         break;
-    case 0x1F:
-        BIOS_MidiKey2Freq();
+    case 0x29:
+        BIOS_SndDriverVSyncOn();
         break;
     case 0xE0:
     case 0xE1:

--- a/src/gba/bios.h
+++ b/src/gba/bios.h
@@ -30,6 +30,7 @@ extern void BIOS_SndDriverMode();
 extern void BIOS_SndDriverMain();
 extern void BIOS_SndDriverVSync();
 extern void BIOS_SndDriverVSyncOff();
+extern void BIOS_SndDriverVSyncOn();
 extern void BIOS_SndChannelClear();
 
 #endif // BIOS_H


### PR DESCRIPTION
The lz77 uncompresssion software BIOS implementation was exiting early when uncompressing data, if the overall length was larger than advertised in the function parameter. However, real GBA BIOS does read further than the advertised length, so we do here too. This fixes Advance Wars title screen.

This also adds a SoundDriverVSyncOn implementation, silencing an error for some Shrek games, though they still cannot properly boot with an emulated BIOS.

Fixes #789