### PR TITLE
Create the config directory at first launch

### DIFF
--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2608,7 +2608,7 @@ EVT_HANDLER(SpeedOn, "Enable faster network protocol by default")
 
 EVT_HANDLER(LinkProto, "Local host IPC")
 {
-    GetMenuOptionConfig("LinkProto", config::OptionID::kGBALinkHost);
+    GetMenuOptionConfig("LinkProto", config::OptionID::kGBALinkProto);
 }
 
 EVT_HANDLER(LinkConfigure, "Link options...")

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -406,6 +406,11 @@ bool wxvbamApp::OnInit() {
                                        config_file_.GetFullPath(),
                                        wxEmptyString, wxCONFIG_USE_LOCAL_FILE));
 
+    // wx does not create the directories by itself so do it here, if needed.
+    if (!wxDirExists(config_file_.GetPath())) {
+       config_file_.Mkdir(wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+    }
+
     // Load the default options.
     load_opts(!config_file_.Exists());
 


### PR DESCRIPTION
First launch would fail because wx does not create the configuration directory by itself if it does not exist.
This also fixes an incorrect menu option.