### PR TITLE
Discord streaming is now fixed for opengl, hoozah!.

### DIFF
--- a/src/wx/drawing.h
+++ b/src/wx/drawing.h
@@ -38,6 +38,7 @@ protected:
     void DrawArea(wxWindowDC& dc);
     void OnSize(wxSizeEvent& ev);
     void AdjustViewport();
+    void RefreshGL();
 #ifndef wxGL_IMPLICIT_CONTEXT
     wxGLContext* ctx;
 #endif

--- a/src/wx/drawing.h
+++ b/src/wx/drawing.h
@@ -41,6 +41,7 @@ protected:
 #ifndef wxGL_IMPLICIT_CONTEXT
     wxGLContext* ctx;
 #endif
+    bool SetCurrent();
     void DrawingPanelInit();
     GLuint texid, vlist;
     int texsize;

--- a/src/wx/drawing.h
+++ b/src/wx/drawing.h
@@ -39,13 +39,10 @@ protected:
     void OnSize(wxSizeEvent& ev);
     void AdjustViewport();
     void RefreshGL();
-
-    // Add a new method to reset the OpenGL context
-    void ResetContext();
-
 #ifndef wxGL_IMPLICIT_CONTEXT
     wxGLContext* ctx;
 #endif
+    bool SetContext();
     void DrawingPanelInit();
     GLuint texid, vlist;
     int texsize;

--- a/src/wx/drawing.h
+++ b/src/wx/drawing.h
@@ -39,10 +39,13 @@ protected:
     void OnSize(wxSizeEvent& ev);
     void AdjustViewport();
     void RefreshGL();
+
+    // Add a new method to reset the OpenGL context
+    void ResetContext();
+
 #ifndef wxGL_IMPLICIT_CONTEXT
     wxGLContext* ctx;
 #endif
-    bool SetCurrent();
     void DrawingPanelInit();
     GLuint texid, vlist;
     int texsize;

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2224,10 +2224,7 @@ GLDrawingPanel::~GLDrawingPanel()
     // it's also unsafe if panel no longer displayed
     if (did_init)
     {
-        SetCurrent(*ctx);
-#else
-        SetCurrent();
-#endif
+        SetContext();
         glDeleteLists(vlist, 1);
         glDeleteTextures(1, &texid);
     }
@@ -2237,17 +2234,6 @@ GLDrawingPanel::~GLDrawingPanel()
 #endif
 }
 
-void GLDrawingPanel::ResetContext()
-{
-#ifndef wxGL_IMPLICIT_CONTEXT
-    // Check if the current context is valid
-    if (ctx && ctx->IsOK())
-        return;
-
-    // Delete the old context
-    if (ctx) {
-        delete ctx;
-        ctx = nullptr;
 void GLDrawingPanel::DrawingPanelInit()
 {
     SetContext();

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2183,6 +2183,15 @@ static int glopts[] = {
     WX_GL_RGBA, WX_GL_DOUBLEBUFFER, 0
 };
 
+bool GLDrawingPanel::SetCurrent()
+{
+#ifndef wxGL_IMPLICIT_CONTEXT
+    return wxGLCanvas::SetCurrent(*ctx);
+#else
+    return wxGLContext::SetCurrent(*this);
+#endif
+}
+
 GLDrawingPanel::GLDrawingPanel(wxWindow* parent, int _width, int _height)
     : DrawingPanelBase(_width, _height)
     , wxglc(parent, wxID_ANY, glopts, wxPoint(0, 0), parent->GetClientSize(),
@@ -2191,8 +2200,8 @@ GLDrawingPanel::GLDrawingPanel(wxWindow* parent, int _width, int _height)
     widgets::RequestHighResolutionOpenGlSurfaceForWindow(this);
 #ifndef wxGL_IMPLICIT_CONTEXT
     ctx = new wxGLContext(this);
-    SetCurrent(*ctx);
 #endif
+    SetCurrent();
     if (!did_init) DrawingPanelInit();
 }
 
@@ -2202,11 +2211,7 @@ GLDrawingPanel::~GLDrawingPanel()
     // it's also unsafe if panel no longer displayed
     if (did_init)
     {
-#ifndef wxGL_IMPLICIT_CONTEXT
-        SetCurrent(*ctx);
-#else
         SetCurrent();
-#endif
         glDeleteLists(vlist, 1);
         glDeleteTextures(1, &texid);
     }
@@ -2218,11 +2223,7 @@ GLDrawingPanel::~GLDrawingPanel()
 
 void GLDrawingPanel::DrawingPanelInit()
 {
-#ifndef wxGL_IMPLICIT_CONTEXT
-    SetCurrent(*ctx);
-#else
     SetCurrent();
-#endif
 
     DrawingPanelBase::DrawingPanelInit();
 
@@ -2360,6 +2361,7 @@ void GLDrawingPanel::DrawingPanelInit()
 
 void GLDrawingPanel::OnSize(wxSizeEvent& ev)
 {
+    SetCurrent();
     AdjustViewport();
 
     // Temporary hack to backport 800d6ed69b from wxWidgets until 3.2.2 is released.
@@ -2371,11 +2373,7 @@ void GLDrawingPanel::OnSize(wxSizeEvent& ev)
 
 void GLDrawingPanel::AdjustViewport()
 {
-#ifndef wxGL_IMPLICIT_CONTEXT
-    SetCurrent(*ctx);
-#else
     SetCurrent();
-#endif
 
     int x, y;
     widgets::GetRealPixelClientSize(this, &x, &y);
@@ -2392,11 +2390,7 @@ void GLDrawingPanel::AdjustViewport()
 void GLDrawingPanel::DrawArea(wxWindowDC& dc)
 {
     (void)dc; // unused params
-#ifndef wxGL_IMPLICIT_CONTEXT
-    SetCurrent(*ctx);
-#else
     SetCurrent();
-#endif
 
     if (!did_init)
         DrawingPanelInit();

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2220,6 +2220,10 @@ GLDrawingPanel::~GLDrawingPanel()
 void GLDrawingPanel::ResetContext()
 {
 #ifndef wxGL_IMPLICIT_CONTEXT
+    // Check if the current context is valid
+    if (ctx && ctx->IsOK())
+        return;
+
     // Delete the old context
     if (ctx) {
         delete ctx;
@@ -2425,12 +2429,7 @@ void GLDrawingPanel::RefreshGL()
 void GLDrawingPanel::DrawArea(wxWindowDC& dc)
 {
     (void)dc; // unused params
-#ifndef wxGL_IMPLICIT_CONTEXT
-    SetCurrent(*ctx);
-#else
-    SetCurrent();
-#endif
-
+    ResetContext();
     RefreshGL();
 
     if (!did_init)

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -2387,10 +2387,24 @@ void GLDrawingPanel::AdjustViewport()
 #endif
 }
 
+void GLDrawingPanel::RefreshGL()
+{
+#ifndef wxGL_IMPLICIT_CONTEXT
+    SetCurrent(*ctx);
+#else
+    SetCurrent();
+#endif
+
+    // Rebind any textures or other OpenGL resources here
+    glBindTexture(GL_TEXTURE_2D, texid);
+}
+
 void GLDrawingPanel::DrawArea(wxWindowDC& dc)
 {
     (void)dc; // unused params
     SetCurrent();
+
+    RefreshGL();
 
     if (!did_init)
         DrawingPanelInit();


### PR DESCRIPTION
we just needed to rebind the textures after discord forced itself on us.

Fixes duplicates #840 #843 
Closes #643, #767 

This also adapters the setcurrent changes to SetContext with the ResetContext system for the case where the opengl context is ever lost.