### PR TITLE
merges the behaviour of steelo's initial simplified save data code, with the multi-size mbc7 code, adds missing Save State handling.

### DIFF
--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -3063,6 +3063,9 @@ void gbReset()
     gbDataMBC5.mapperROMBank = 1;
     gbDataMBC5.isRumbleCartridge = g_gbCartData.has_rumble();
 
+    memset(&gbDataMBC7, 0, sizeof(gbDataMBC7));
+    gbDataMBC7.mapperROMBank = 1;
+
     memset(&gbDataHuC1, 0, sizeof(gbDataHuC1));
     gbDataHuC1.mapperROMBank = 1;
 
@@ -3291,6 +3294,7 @@ static bool gbWriteSaveState(gzFile gzFile)
     utilGzWrite(gzFile, &gbDataMBC2, sizeof(gbDataMBC2));
     utilGzWrite(gzFile, &gbDataMBC3, sizeof(gbDataMBC3));
     utilGzWrite(gzFile, &gbDataMBC5, sizeof(gbDataMBC5));
+    utilGzWrite(gzFile, &gbDataMBC7, sizeof(gbDataMBC7));
     utilGzWrite(gzFile, &gbDataHuC1, sizeof(gbDataHuC1));
     utilGzWrite(gzFile, &gbDataHuC3, sizeof(gbDataHuC3));
     utilGzWrite(gzFile, &gbDataTAMA5, sizeof(gbDataTAMA5));
@@ -3453,6 +3457,7 @@ static bool gbReadSaveState(gzFile gzFile)
     utilGzRead(gzFile, &gbDataMBC2, sizeof(gbDataMBC2));
     utilGzRead(gzFile, &gbDataMBC3, sizeof(gbDataMBC3));
     utilGzRead(gzFile, &gbDataMBC5, sizeof(gbDataMBC5));
+    utilGzRead(gzFile, &gbDataMBC7, sizeof(gbDataMBC7));
     utilGzRead(gzFile, &gbDataHuC1, sizeof(gbDataHuC1));
     utilGzRead(gzFile, &gbDataHuC3, sizeof(gbDataHuC3));
     if (version >= 11) {
@@ -4973,6 +4978,7 @@ unsigned int gbWriteSaveState(uint8_t* data)
     utilWriteMem(data, &gbDataMBC2, sizeof(gbDataMBC2));
     utilWriteMem(data, &gbDataMBC3, sizeof(gbDataMBC3));
     utilWriteMem(data, &gbDataMBC5, sizeof(gbDataMBC5));
+    utilWriteMem(data, &gbDataMBC7, sizeof(gbDataMBC7));
     utilWriteMem(data, &gbDataHuC1, sizeof(gbDataHuC1));
     utilWriteMem(data, &gbDataHuC3, sizeof(gbDataHuC3));
     if (g_gbCartData.mapper_type() == gbCartData::MapperType::kHuC3)
@@ -5099,6 +5105,7 @@ bool gbReadSaveState(const uint8_t* data)
     utilReadMem(&gbDataMBC2, data, sizeof(gbDataMBC2));
     utilReadMem(&gbDataMBC3, data, sizeof(gbDataMBC3));
     utilReadMem(&gbDataMBC5, data, sizeof(gbDataMBC5));
+    utilReadMem(&gbDataMBC7, data, sizeof(gbDataMBC7));
     utilReadMem(&gbDataHuC1, data, sizeof(gbDataHuC1));
     utilReadMem(&gbDataHuC3, data, sizeof(gbDataHuC3));
     if (g_gbCartData.mapper_type() == gbCartData::MapperType::kHuC3)

--- a/src/gb/GB.cpp
+++ b/src/gb/GB.cpp
@@ -450,6 +450,11 @@ bool gbInitializeRom(size_t romSize) {
                                             &ResetMBC3RTC});
                 }
                 break;
+         case gbCartData::MapperType::kMbc7:
+                // For MBC7, we don't save the RAM data from the same location.
+                g_vbamIoVecs.clear();
+                g_vbamIoVecs.push_back({ &gbMemory[0xa000], ramSize});
+                break;				
             case gbCartData::MapperType::kTama5:
                 g_vbamIoVecs.push_back({gbTAMA5ram, kTama5RamSize});
                 g_vbamIoVecs.push_back({&gbDataTAMA5.mapperSeconds,
@@ -466,7 +471,6 @@ bool gbInitializeRom(size_t romSize) {
             case gbCartData::MapperType::kMbc2:
             case gbCartData::MapperType::kMbc5:
             case gbCartData::MapperType::kMbc6:
-            case gbCartData::MapperType::kMbc7:
             case gbCartData::MapperType::kHuC1:
             case gbCartData::MapperType::kMmm01:
             case gbCartData::MapperType::kPocketCamera:
@@ -3163,6 +3167,8 @@ bool gbReadGSASnapshot(const char* fileName)
             case gbCartData::MapperType::kMbc3:
             case gbCartData::MapperType::kMbc5:
             case gbCartData::MapperType::kMbc7:
+                FREAD_UNCHECKED(&gbMemory[0xa000], 1, g_gbCartData.ram_size(), file);
+                break;		
             case gbCartData::MapperType::kHuC1:
                 FREAD_UNCHECKED(gbRam, 1, g_gbCartData.ram_size(), file);
                 break;

--- a/src/gb/gbMemory.h
+++ b/src/gb/gbMemory.h
@@ -157,6 +157,7 @@ extern mapperMBC1 gbDataMBC1;
 extern mapperMBC2 gbDataMBC2;
 extern mapperMBC3 gbDataMBC3;
 extern mapperMBC5 gbDataMBC5;
+extern mapperMBC7 gbDataMBC7;
 extern mapperHuC1 gbDataHuC1;
 extern mapperHuC3 gbDataHuC3;
 extern mapperHuC3RTC gbRTCHuC3;


### PR DESCRIPTION
Fixes #1173

This does not resolve the unveiled issue where gbReset causes MBC7 saves to be corrupted.

This is a breaking change, previously made states for Kirby Tilt-N-Tumble and Command Master will not be loadable.