### PR TITLE
Disable mirroring for ROMs > 32MB

### DIFF
--- a/src/common/sizes.h
+++ b/src/common/sizes.h
@@ -20,6 +20,8 @@ constexpr size_t k1MiB = 2 * k512KiB;
 constexpr size_t k2MiB = 2 * k1MiB;
 constexpr size_t k4MiB = 2 * k2MiB;
 constexpr size_t k8MiB = 2 * k4MiB;
+constexpr size_t k16MiB = 2 * k8MiB;
+constexpr size_t k32MiB = 2 * k16MiB;
 
 // Game Boy BIOS Sizes.
 constexpr size_t kGBBiosSize = k256B;

--- a/src/gba/GBA.cpp
+++ b/src/gba/GBA.cpp
@@ -12,6 +12,7 @@
 #include "../System.h"
 #include "../Util.h"
 #include "../common/Port.h"
+#include "../common/sizes.h"
 #include "Cheats.h"
 #include "EEprom.h"
 #include "Flash.h"
@@ -1688,6 +1689,9 @@ int CPULoadRomData(const char* data, int size)
 
 void doMirroring(bool b)
 {
+    if (romSize > k32MiB)
+        return;
+
     int romSizeRounded = romSize;
     romSizeRounded--;
     romSizeRounded |= romSizeRounded >> 1;


### PR DESCRIPTION
In doMirroring() do nothing if the ROM size is greater than 32MB. This fixes these ROMs automatically working without disabling mirroring in settings.

Fix #1046