### PR TITLE
Link: Fix menu not refreshing correctly

### DIFF
--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2630,6 +2630,7 @@ EVT_HANDLER(LinkProto, "Local host IPC")
 {
 #ifndef NO_LINK
     GetMenuOptionConfig("LinkProto", config::OptionID::kGBALinkProto);
+    EnableNetworkMenu();
 #endif
 }
 
@@ -2643,7 +2644,6 @@ EVT_HANDLER(LinkConfigure, "Link options...")
 
     SetLinkTimeout(gopts.link_timeout);
     update_opts();
-    EnableNetworkMenu();
 #endif
 }
 


### PR DESCRIPTION
Start Network Link is not allowed while Local mode is selected, but state change of Local mode was ignored until an option which triggers EnableNetworkMenu() was selected.

Removed EnableNetworkMenu() from the Configuration option because it doesn't change anything related to Link menu state.