### PR TITLE
Remove SDL sound driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ And the following development libraries:
 - [gettext](https://www.gnu.org/software/gettext/) and gettext-tools (optional, with ENABLE_NLS)
 - [SDL2](https://www.libsdl.org/) (required)
 - [SFML](https://www.sfml-dev.org/) (optional, for link)
-- [OpenAL](https://www.openal.org/) or [openal-soft](https://kcat.strangesoft.net/openal.html) (optional, a sound interface)
+- [OpenAL](https://www.openal.org/) or [openal-soft](https://kcat.strangesoft.net/openal.html) (required, a sound interface)
 - [wxWidgets](https://wxwidgets.org/) (required for GUI, 2.8 and non-stl builds are no longer supported)
 
 On Linux and similar, you also need the version of GTK your wxWidgets is linked

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -31,29 +31,15 @@ endif()
 
 option(ENABLE_FAUDIO "Enable FAudio sound output for the wxWidgets port" OFF)
 
-find_package(OpenAL)
+find_package(OpenAL REQUIRED)
 
-if(OPENAL_FOUND)
-	set(ENABLE_OPENAL_DEFAULT ON)
-else()
-	set(ENABLE_OPENAL_DEFAULT OFF)
+include_directories(${OPENAL_INCLUDE_DIR})
+
+if(OPENAL_STATIC OR (WIN32 AND ((NOT (MINGW AND MSYS)) OR CMAKE_TOOLCHAIN_FILE MATCHES mxe)))
+    add_definitions(-DAL_LIBTYPE_STATIC)
 endif()
 
-option(ENABLE_OPENAL "Enable OpenAL for the wxWidgets port" ${ENABLE_OPENAL_DEFAULT})
-
-if(ENABLE_OPENAL)
-	find_package(OpenAL REQUIRED)
-
-	include_directories(${OPENAL_INCLUDE_DIR})
-
-	if(OPENAL_STATIC OR (WIN32 AND ((NOT (MINGW AND MSYS)) OR CMAKE_TOOLCHAIN_FILE MATCHES mxe)))
-		add_definitions(-DAL_LIBTYPE_STATIC)
-	endif()
-
-        list(APPEND VBAM_LIBS ${OPENAL_LIBRARY})
-else()
-    add_definitions(-DNO_OAL)
-endif()
+list(APPEND VBAM_LIBS ${OPENAL_LIBRARY})
 
 if(APPLE)
     add_definitions(-DwxMAC_USE_CORE_GRAPHICS)
@@ -910,10 +896,8 @@ set(
 list(APPEND ALL_SRC_WX openal.cpp)
 list(APPEND ALL_HDR_WX openal.h)
 
-if(ENABLE_OPENAL)
-   list(APPEND SRC_WX openal.cpp)
-   list(APPEND HDR_WX openal.h)
-endif()
+list(APPEND SRC_WX openal.cpp)
+list(APPEND HDR_WX openal.h)
 
 list(APPEND ALL_SRC_WX xaudio2.cpp)
 

--- a/src/wx/config/internal/option-internal.cpp
+++ b/src/wx/config/internal/option-internal.cpp
@@ -712,7 +712,7 @@ RenderMethod StringToRenderMethod(const wxString& config_name,
     return iter->second;
 }
 
-int StringToAudioApi(const wxString& config_name, const wxString& input) {
+int StringToAudioApi(const wxString& config_name, const wxString& input_) {
     static std::map<wxString, AudioApi> kStringToAudioApi;
     if (kStringToAudioApi.empty()) {
         for (size_t i = 0; i < kNbAudioApis; i++) {
@@ -720,6 +720,17 @@ int StringToAudioApi(const wxString& config_name, const wxString& input) {
                                       static_cast<AudioApi>(i));
         }
         assert(kStringToAudioApi.size() == kNbAudioApis);
+    }
+
+    wxString input = input_;
+
+    // sdl has been removed, rewrite to new default
+    if (input == "sdl") {
+#ifdef __WXMSW__
+        input = "xaudio2";
+#else
+        input = "openal";
+#endif
     }
 
     const auto iter = kStringToAudioApi.find(input);

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -2696,6 +2696,8 @@ bool MainFrame::BindControls()
             NULL, &sound_config_handler);                 \
     } while (0)
             audapi_rb("SDL", AUD_SDL);
+            rb->Hide(); // currently disabled
+
             audapi_rb("OpenAL", AUD_OPENAL);
 #ifdef NO_OAL
             rb->Hide();

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -9,7 +9,7 @@
 #include "config/game-control.h"
 #include "config/shortcuts.h"
 #include "config/user-input.h"
-#include "wxutil.h"
+#include "wxhead.h"
 
 // Forward declaration.
 class wxFileHistory;
@@ -52,7 +52,11 @@ extern struct opts_t {
     int max_scale = 0;
 
     /// Sound
-    int audio_api = 0;
+#ifdef __WXMSW__
+    int audio_api = AUD_XAUDIO2;
+#else
+    int audio_api = AUD_OPENAL;
+#endif
     // 10 fixes stuttering on mac with openal, as opposed to 5
     // also should be better for modern hardware in general
     int audio_buffers = 10;

--- a/src/wx/wxhead.h
+++ b/src/wx/wxhead.h
@@ -59,6 +59,16 @@ using std::int32_t;
 
 #include "wxutil.h"
 
+// This enum must be kept in sync with the one in vbam-options-static.cpp.
+// TODO: These 2 enums should be unified and a validator created for this enum.
+enum audioapi {
+    AUD_SDL,
+    AUD_OPENAL,
+    AUD_DIRECTSOUND,
+    AUD_XAUDIO2,
+    AUD_FAUDIO
+};
+
 // wxrc helpers (for dynamic strings instead of constant)
 #define XRCID_D(str) wxXmlResource::GetXRCID(str)
 //#define XRCCTRL_D(win, id, type) (wxStaticCast((win).FindWindow(XRCID_D(id)), type))

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -426,16 +426,6 @@ enum showspeed {
     SS_DETAILED
 };
 
-// This enum must be kept in sync with the one in vbam-options-static.cpp.
-// TODO: These 2 enums should be unified and a validator created for this enum.
-enum audioapi {
-    AUD_SDL,
-    AUD_OPENAL,
-    AUD_DIRECTSOUND,
-    AUD_XAUDIO2,
-    AUD_FAUDIO
-};
-
 // an unfortunate legacy default; should have a non-digit preceding %d
 // the only reason to keep it is that user can set slotdir to old dir
 // otoh, we already make some name changes (double ext strip), and


### PR DESCRIPTION
Because of reported framerate issues with the SDL sound driver, remove it and make XAudio2 the default on Windows and OpenAL the default everywhere else.

Rewrite the "sdl" value from users' configs to the new default.

Make OpenAL a mandatory dependency as well.

Fix #709