### PR TITLE
build: fix gentoo dependency namespaces

### DIFF
--- a/installdeps
+++ b/installdeps
@@ -1095,15 +1095,24 @@ gentoo_installdeps() {
     wx_slot=$(equery -qC list -p -F '$slot' x11-libs/wxGTK | grep gtk3 | sort -rV | head -1)
 
     ebuilds="\
-      sys-devel/gcc      sys-devel/make     dev-util/cmake          dev-util/ccache sys-devel/binutils \
-      media-libs/libsdl2 media-libs/libsfml x11-libs/wxGTK:$wx_slot sys-libs/zlib   dev-util/pkgconf \
-      dev-lang/nasm      dev-util/ninja"
+      sys-devel/gcc \
+      dev-build/make \
+      dev-build/cmake \
+      dev-util/ccache \
+      sys-devel/binutils \
+      media-libs/libsdl2 \
+      media-libs/libsfml \
+      x11-libs/wxGTK:$wx_slot \
+      sys-libs/zlib \
+      dev-util/pkgconf \
+      dev-lang/nasm \
+      dev-build/ninja"
 
     [ -n "$ENABLE_OPENAL" ] && ebuilds="$ebuilds media-libs/openal"
 
     [ -n "$ENABLE_FFMPEG" ] && ebuilds="$ebuilds media-video/ffmpeg"
 
-    check sudo emerge -vn $ebuilds
+    check sudo emerge -vna $ebuilds
 
     build_instructions
 }


### PR DESCRIPTION
Change sys-devel to dev-build to match current gentoo package naming convention. Also add --ask flag to prompt for confirmation before merging packages.