### PR TITLE
Add toggle: SDL GameController mode for joysticks

### DIFF
--- a/src/wx/config/internal/option-internal.cpp
+++ b/src/wx/config/internal/option-internal.cpp
@@ -211,6 +211,7 @@ std::array<Option, kNbOptions>& Option::All() {
 
         /// Joypad
         uint32_t default_stick = 1;
+        bool sdl_game_controller_mode = true;
 
         /// Geometry
         bool fullscreen = false;
@@ -293,6 +294,7 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kJoy),
         Option(OptionID::kJoyAutofireThrottle, &gopts.autofire_rate, 1, 1000),
         Option(OptionID::kJoyDefault, &g_owned_opts.default_stick, 1, 4),
+        Option(OptionID::kSDLGameControllerMode, &g_owned_opts.sdl_game_controller_mode),
 
         /// Keyboard
         Option(OptionID::kKeyboard),
@@ -478,6 +480,8 @@ const std::array<OptionData, kNbOptions + 1> kAllOptionsData = {
                _("The autofire toggle period, in frames (1/60 s)")},
     OptionData{"Joypad/Default", "",
                _("The number of the stick to use in single-player mode")},
+    OptionData{"Joypad/SDLGameControllerMode", "SDLGameControllerMode",
+               _("Whether to enable SDL GameController mode")},
 
     /// Keyboard
     OptionData{"Keyboard/*", "",

--- a/src/wx/config/option-id.h
+++ b/src/wx/config/option-id.h
@@ -61,6 +61,7 @@ enum class OptionID {
     kJoy,
     kJoyAutofireThrottle,
     kJoyDefault,
+    kSDLGameControllerMode,
 
     /// Keyboard
     kKeyboard,

--- a/src/wx/config/option-proxy.h
+++ b/src/wx/config/option-proxy.h
@@ -65,6 +65,7 @@ static constexpr std::array<Option::Type, kNbOptions> kOptionsTypes = {
     /*kJoy*/ Option::Type::kNone,
     /*kJoyAutofireThrottle*/ Option::Type::kInt,
     /*kJoyDefault*/ Option::Type::kUnsigned,
+    /*kSDLGameControllerMode*/ Option::Type::kBool,
 
     /// Keyboard
     /*kKeyboard*/ Option::Type::kNone,

--- a/src/wx/dialogs/joypad-config.h
+++ b/src/wx/dialogs/joypad-config.h
@@ -25,6 +25,12 @@ private:
     // Clears all Joypad controls.
     void ClearJoypad(wxWindow* panel);
 
+    // Clears all Joypad controls for all Joypads.
+    void ClearAllJoypads();
+    
+    // Toggle SDL GameController mode for all joysticks.
+    void ToggleSDLGameControllerMode();
+
     const widgets::KeepOnTopStyler keep_on_top_styler_;
 };
 

--- a/src/wx/widgets/sdljoy.cpp
+++ b/src/wx/widgets/sdljoy.cpp
@@ -3,6 +3,8 @@
 #include <wx/timer.h>
 #include <SDL.h>
 
+#include "wx/config/option-proxy.h"
+#include "wx/config/option.h"
 #include "wx/wxvbam.h"
 
 namespace {
@@ -171,7 +173,7 @@ wxSDLJoyState::wxSDLJoyState(int sdl_index)
 
 wxSDLJoyState::wxSDLJoyState(wxJoystick joystick) : wx_joystick_(joystick) {
     int sdl_index = wx_joystick_.sdl_index_;
-    if (SDL_IsGameController(sdl_index)) {
+    if (OPTION(kSDLGameControllerMode) && SDL_IsGameController(sdl_index)) {
         game_controller_ = SDL_GameControllerOpen(sdl_index);
         if (game_controller_)
             sdl_joystick_ = SDL_GameControllerGetJoystick(game_controller_);

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -314,6 +314,8 @@ public:
     }
 
     void PollJoysticks() { joy.Poll(); }
+    
+    void PollAllJoysticks() { joy.PollAllJoysticks(); }
 
     // Poll joysticks with timer.
     void StartJoyPollTimer();

--- a/src/wx/xrc/JoypadConfig.xrc
+++ b/src/wx/xrc/JoypadConfig.xrc
@@ -5,6 +5,12 @@
     <object class="wxBoxSizer">
     <orient>wxVERTICAL</orient>
     <object class="sizeritem">
+      <flag>wxALIGN_CENTRE_HORIZONTAL</flag>
+      <object class="wxCheckBox" name="SDLGameControllerMode">
+        <label>SDL GameController Mode</label>
+      </object>
+    </object>
+    <object class="sizeritem">
     <object class="wxNotebook">
     <object class="notebookpage">
       <object_ref name="joy1" ref="JoyPanel">


### PR DESCRIPTION
Add a toggle for SDL GameController Mode in the game key configuration dialog, default enabled.

On check or uncheck, change the option and reinitialize joysticks, not using GameController mode if it is disabled.