### PR TITLE
build: fix LTO on Linux

### DIFF
--- a/cmake/Toolchain-gcc-clang.cmake
+++ b/cmake/Toolchain-gcc-clang.cmake
@@ -2,12 +2,14 @@ if(X86_32 OR X86_64)
     add_compile_options(-mfpmath=sse -msse2)
 endif()
 
-if(X86_64)
-    # Require and optimize for Core2 level support, tune for generic.
-    add_compile_options(-march=core2 -mtune=generic)
-elseif(X86_32)
-    # Optimize for pentium-mmx and tune for generic for older builds.
-    add_compile_options(-march=pentium-mmx -mtune=generic)
+if(UPSTREAM_RELEASE)
+    if(X86_64)
+        # Require and optimize for Core2 level support, tune for generic.
+        add_compile_options(-march=core2 -mtune=generic)
+    elseif(X86_32)
+        # Optimize for pentium-mmx and tune for generic for older builds.
+        add_compile_options(-march=pentium-mmx -mtune=generic)
+    endif()
 endif()
 
 # Common flags.
@@ -54,5 +56,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 endif()
 
 if(VBAM_STATIC)
-    add_link_options("-static-libgcc" "-static-libstdc++" "-Wl,-Bstatic" "-lstdc++" "-lpthread")
+    add_link_options(-static-libgcc -static-libstdc++ -Wl,-Bstatic -lstdc++ -lpthread)
 endif()
+
+# To support LTO, this must always fail.
+add_compile_options(-Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing)
+add_link_options(   -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing)

--- a/src/sdl/expr-lex.cpp
+++ b/src/sdl/expr-lex.cpp
@@ -151,7 +151,7 @@ typedef unsigned int flex_uint32_t;
 
 #ifndef YY_TYPEDEF_YY_BUFFER_STATE
 #define YY_TYPEDEF_YY_BUFFER_STATE
-typedef struct yy_buffer_state* YY_BUFFER_STATE;
+typedef struct yy_buffer_state_sdl* YY_BUFFER_STATE;
 #endif
 
 extern int yyleng;
@@ -184,7 +184,7 @@ typedef size_t yy_size_t;
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
 #define YY_STRUCT_YY_BUFFER_STATE
-struct yy_buffer_state {
+struct yy_buffer_state_sdl {
     FILE* yy_input_file;
 
     char* yy_ch_buf; /* input buffer */
@@ -1218,7 +1218,7 @@ YY_BUFFER_STATE yy_create_buffer(FILE* file, int size)
 {
     YY_BUFFER_STATE b;
 
-    b = (YY_BUFFER_STATE)yyalloc(sizeof(struct yy_buffer_state));
+    b = (YY_BUFFER_STATE)yyalloc(sizeof(struct yy_buffer_state_sdl));
     if (!b)
         YY_FATAL_ERROR("out of dynamic memory in yy_create_buffer()");
 
@@ -1381,11 +1381,11 @@ static void yyensure_buffer_stack(void)
 		 * immediate realloc on the next call.
          */
         num_to_alloc = 1;
-        (yy_buffer_stack) = (struct yy_buffer_state**)yyalloc(num_to_alloc * sizeof(struct yy_buffer_state*));
+        (yy_buffer_stack) = (struct yy_buffer_state_sdl**)yyalloc(num_to_alloc * sizeof(struct yy_buffer_state_sdl*));
         if (!(yy_buffer_stack))
             YY_FATAL_ERROR("out of dynamic memory in yyensure_buffer_stack()");
 
-        memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
+        memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state_sdl*));
 
         (yy_buffer_stack_max) = num_to_alloc;
         (yy_buffer_stack_top) = 0;
@@ -1398,13 +1398,13 @@ static void yyensure_buffer_stack(void)
         int grow_size = 8 /* arbitrary grow size */;
 
         num_to_alloc = (yy_buffer_stack_max) + grow_size;
-        (yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc((yy_buffer_stack),
-            num_to_alloc * sizeof(struct yy_buffer_state*));
+        (yy_buffer_stack) = (struct yy_buffer_state_sdl**)yyrealloc((yy_buffer_stack),
+            num_to_alloc * sizeof(struct yy_buffer_state_sdl*));
         if (!(yy_buffer_stack))
             YY_FATAL_ERROR("out of dynamic memory in yyensure_buffer_stack()");
 
         /* zero only the new slots.*/
-        memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state*));
+        memset((yy_buffer_stack) + (yy_buffer_stack_max), 0, grow_size * sizeof(struct yy_buffer_state_sdl*));
         (yy_buffer_stack_max) = num_to_alloc;
     }
 }
@@ -1423,7 +1423,7 @@ YY_BUFFER_STATE yy_scan_buffer(char* base, yy_size_t size)
         /* They forgot to leave room for the EOB's. */
         return 0;
 
-    b = (YY_BUFFER_STATE)yyalloc(sizeof(struct yy_buffer_state));
+    b = (YY_BUFFER_STATE)yyalloc(sizeof(struct yy_buffer_state_sdl));
     if (!b)
         YY_FATAL_ERROR("out of dynamic memory in yy_scan_buffer()");
 


### PR DESCRIPTION
Add -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing to compile and link options for gcc/clang always.

Rename struct yy_buffer_state in src/sdl/expr-lex.cpp to struct yy_buffer_state_sdl because it breaks when linking the SDL binary with -Werror=odr.

Fix #1260