### PR TITLE
[Dialogs] Move SoundConfig dialog to its own class

### DIFF
--- a/doc/DevInfo.txt
+++ b/doc/DevInfo.txt
@@ -2,8 +2,6 @@
 Developer Information File
 ==========================
 
-
-
 Known preprocessor switches:
 - SDL: Defined for the SDL version
 - GBA_LOGGING: Enables logging for the GBA core
@@ -13,46 +11,18 @@ Known preprocessor switches:
 - RGB555: Use 16bit colors with 5bit green instead of 6bit green in hq3x/4x filters (C++ version)
 - NO_OGL: Exclude OpenGL code
 - NO_D3D: Exclude Direct3D code
-- NO_XAUDIO2: Exclude XAudio2 code (the XAudio2 interface is DirectSound's successor)
+- VBAM_ENABLE_XAUDIO2: Enable XAudio2 code (the XAudio2 interface is DirectSound's successor)
+- VBAM_ENABLE_FAUDIO: Enable FAudio code (the FAudio interface is an open source multiplatform re-implementation of XAudio2)
 - NO_LINK: Exclude linking code (joybus, multilink, ...)
-- WIN64: This macro is only defined for 64 bit builds
-
-
-
-Download locations:
-NASM:         http://nasm.us/
-DirectX SDK:  http://msdn.microsoft.com/en-us/xna/aa937788.aspx
-OpenAL SDK:   http://connect.creativelabs.com/openal/default.aspx
-OpenGL files: http://www.opengl.org/registry/
-zlib:         http://zlib.net/
-libpng:       http://libpng.org/pub/png/libpng.html
-
-You can find pre-built versions of zlib & libpng at:
-http://spacy51.sp.funpic.de/VBA-M/libs/
-Just extract them somewhere and point Visual C++ 2008 to the include & lib folders.
-They are built with the static C runtime (this is what the release builds use).
-
-
 
 ###########################
 #  --- Build Systems  --- #
 ###########################
 
-===Win32/MFC===
-This is the full-featured Windows build using the MFC GUI.
-The project files are located in /project/vc2008_mfc (VBA2008.sln) and /project/vs2010_mfc (VBA2010.sln).
-Anyone distributing builds should be using MSVC 2010 SP1, the unpatched release has a bug where it applies SSE2 updates to mov and other instructions resulting in illegal instruction errors on cpu's only supporting SSE.
-You also have to install Microsoft's DirectX SDK for Direct3D, DirectInput & XAudio2.
-If you want to enable OpenAL sound output, install the OpenAL SDK. If you do not want it, add NO_OAL to the VBA-M project's preprocessor definitions.
-SubWCRev.exe is used to append the svn versioning to the output executable, this as of TortoiseSVN 1.7, is only available by installing TortoiseSVN.
-All other dependencies for MSVC builds may be found in the ../dependencies directory (above /trunk).
-Normally, Windows users will want to checkout the root of the repository instead of just the trunk directory. Afterwards, simply opening the .sln of choice, setting preprocessor definitions, and hitting build is all that's required.
-
-===*nix/GTK===
+===src/sdl===
 This is the standard build configuration on non-Windows.
 Running cmake will inform you of any packages you need to install.
 
-===*/wxw===
-The wxWidgets interface is an in-development frontend meant to be more cross-platform friendly than MFC and GTK.
+===src/wx===
+The wxWidgets interface is an in-development frontend meant to be more cross-platform friendly than MFC and SDL.
 Running cmake will inform you of any packages you need to install.
-NOTE: In addition to what cmake currently checks for, you will also need the wxrc tool and libgdiplus.

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -39,6 +39,8 @@ set(VBAM_WX_COMMON
     dialogs/gb-rom-info.h
     dialogs/joypad-config.cpp
     dialogs/joypad-config.h
+    dialogs/sound-config.cpp
+    dialogs/sound-config.h
     dialogs/validated-child.h
     drawing.h
     extra-translations.cpp
@@ -87,11 +89,11 @@ set(VBAM_WX_COMMON
     x11keymap.h
     xrc/visualboyadvance-m.xpm
     # Generated files.
-    ${VBAM_GENERATED_DIR}/wx//builtin-xrc.h
-    ${VBAM_GENERATED_DIR}/wx//builtin-over.h
-    ${VBAM_GENERATED_DIR}/wx//cmdhandlers.h
-    ${VBAM_GENERATED_DIR}/wx//cmd-evtable.h
-    ${VBAM_GENERATED_DIR}/wx//cmdtab.cpp
+    ${VBAM_GENERATED_DIR}/wx/builtin-xrc.h
+    ${VBAM_GENERATED_DIR}/wx/builtin-over.h
+    ${VBAM_GENERATED_DIR}/wx/cmdhandlers.h
+    ${VBAM_GENERATED_DIR}/wx/cmd-evtable.h
+    ${VBAM_GENERATED_DIR}/wx/cmdtab.cpp
 )
 
 if(NOT ZIP_PROGRAM)
@@ -182,19 +184,19 @@ add_executable(
 )
 
 target_sources(visualboyadvance-m PRIVATE ${VBAM_WX_COMMON} ${VBAM_ICON_PATH})
-target_include_directories(visualboyadvance-m PRIVATE ${NONSTD_INCLUDE_DIR})
+target_include_directories(visualboyadvance-m PRIVATE ${NONSTD_INCLUDE_DIR} ${SDL2_INCLUDE_DIRS})
 
 target_link_libraries(
     visualboyadvance-m
     nonstd-lib
     vbam-core
-    vbam-components-audio-sdl
     vbam-components-draw-text
     vbam-components-filters
     vbam-components-filters-agb
     vbam-components-filters-interframe
     vbam-components-user-config
     ${OPENGL_LIBRARIES}
+    ${VBAM_SDL2_LIBS}
 )
 
 # adjust link command when making a static binary for gcc
@@ -312,8 +314,7 @@ target_link_libraries(visualboyadvance-m ${OPENAL_LIBRARY})
 # XAudio2.
 if(ENABLE_XAUDIO2)
     target_sources(visualboyadvance-m PRIVATE xaudio2.cpp)
-else()
-    target_compile_definitions(visualboyadvance-m PRIVATE NO_XAUDIO2)
+    target_compile_definitions(visualboyadvance-m PRIVATE VBAM_ENABLE_XAUDIO2)
 endif()
 
 # Direct3D.
@@ -325,8 +326,7 @@ endif()
 if(ENABLE_FAUDIO)
     find_package(FAudio REQUIRED)
     target_link_libraries(visualboyadvance-m FAudio::FAudio)
-else()
-    target_compile_definitions(visualboyadvance-m PRIVATE NO_FAUDIO)
+    target_compile_definitions(visualboyadvance-m PRIVATE VBAM_ENABLE_FAUDIO)
 endif()
 
 # wxWidgets.
@@ -604,11 +604,6 @@ add_custom_command(
         cmdevents.cpp
         copy-events.cmake
 )
-
-# # Win32 definitions common to all toolchains.
-# if (WIN32)
-#     add_compile_definitions(wxUSE_GUI=1)
-# endif()
 
 set(VBAM_LOCALIZABLE_FILES ${VBAM_WX_COMMON})
 list(APPEND VBAM_LOCALIZABLE_FILES

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -1686,30 +1686,13 @@ EVT_HANDLER(ToggleSound, "Enable/disable all sound channels")
 
 EVT_HANDLER(IncreaseVolume, "Increase volume")
 {
-    gopts.sound_vol += 5;
+    OPTION(kSoundVolume) += 5;
 
-    if (gopts.sound_vol > 200)
-        gopts.sound_vol = 200;
-
-    update_opts();
-    soundSetVolume((float)gopts.sound_vol / 100.0);
-    wxString msg;
-    msg.Printf(_("Volume: %d %%"), gopts.sound_vol);
-    systemScreenMessage(msg);
 }
 
 EVT_HANDLER(DecreaseVolume, "Decrease volume")
 {
-    gopts.sound_vol -= 5;
-
-    if (gopts.sound_vol < 0)
-        gopts.sound_vol = 0;
-
-    update_opts();
-    soundSetVolume((float)gopts.sound_vol / 100.0);
-    wxString msg;
-    msg.Printf(_("Volume: %d %%"), gopts.sound_vol);
-    systemScreenMessage(msg);
+    OPTION(kSoundVolume) -= 5;
 }
 
 EVT_HANDLER_MASK(NextFrame, "Next Frame", CMDEN_GB | CMDEN_GBA)
@@ -2174,45 +2157,13 @@ EVT_HANDLER_MASK(ChangeIFB, "Change Interframe Blending", CMDEN_NREC_ANY)
 
 EVT_HANDLER_MASK(SoundConfigure, "Sound options...", CMDEN_NREC_ANY)
 {
-    int oqual = gopts.sound_qual, oapi = gopts.audio_api;
-    bool oupmix = gopts.upmix, ohw = gopts.dsound_hw_accel;
-    wxString odev = gopts.audio_dev;
-    wxDialog* dlg = GetXRCDialog("SoundConfig");
-
-    if (ShowModal(dlg) != wxID_OK)
+    if (ShowModal(GetXRCDialog("SoundConfig")) != wxID_OK)
         return;
 
-    switch (panel->game_type()) {
-    case IMAGE_UNKNOWN:
-        break;
-
-    case IMAGE_GB:
-        gb_effects_config.echo = (float)gopts.gb_echo / 100.0;
-        gb_effects_config.stereo = (float)gopts.gb_stereo / 100.0;
-        gbSoundSetSampleRate(!gopts.sound_qual ? 48000 : 44100 / (1 << (gopts.sound_qual - 1)));
-        break;
-
-    case IMAGE_GBA:
-        soundSetSampleRate(!gopts.sound_qual ? 48000 : 44100 / (1 << (gopts.sound_qual - 1)));
-        soundFiltering = (float)gopts.gba_sound_filter / 100.0f;
-        break;
-    }
-
-    // changing sample rate causes driver reload, so no explicit reload needed
-    if (oqual == gopts.sound_qual &&
-        // otherwise reload if API changes
-        (oapi != gopts.audio_api || odev != gopts.audio_dev ||
-            // or init-only options
-            (oapi == AUD_XAUDIO2 && oupmix != gopts.upmix) || (oapi == AUD_FAUDIO && oupmix != gopts.upmix) || (oapi == AUD_DIRECTSOUND && ohw != gopts.dsound_hw_accel))) {
-        soundShutdown();
-
-        if (!soundInit()) {
-            wxLogError(_("Could not initialize the sound driver!"));
-        }
-    }
-
-    soundSetVolume((float)gopts.sound_vol / 100.0);
-    update_opts();
+    // No point in observing these since they can only be set in this dialog.
+    gb_effects_config.echo = (float)OPTION(kSoundGBEcho) / 100.0;
+    gb_effects_config.stereo = (float)OPTION(kSoundGBStereo) / 100.0;
+    soundFiltering = (float)OPTION(kSoundGBAFiltering) / 100.0f;
 }
 
 EVT_HANDLER(EmulatorDirectories, "Directories...")

--- a/src/wx/config/internal/option-internal.h
+++ b/src/wx/config/internal/option-internal.h
@@ -27,18 +27,18 @@ nonstd::optional<OptionID> StringToOptionId(const wxString& input);
 wxString FilterToString(const Filter& value);
 wxString InterframeToString(const Interframe& value);
 wxString RenderMethodToString(const RenderMethod& value);
-wxString AudioApiToString(int value);
-wxString SoundQualityToString(int value);
+wxString AudioApiToString(const AudioApi& value);
+wxString AudioRateToString(const AudioRate& value);
 Filter StringToFilter(const wxString& config_name, const wxString& input);
 Interframe StringToInterframe(const wxString& config_name, const wxString& input);
 RenderMethod StringToRenderMethod(const wxString& config_name, const wxString& input);
-int StringToAudioApi(const wxString& config_name, const wxString& input);
-int StringToSoundQuality(const wxString& config_name, const wxString& input);
+AudioApi StringToAudioApi(const wxString& config_name, const wxString& input);
+AudioRate StringToSoundQuality(const wxString& config_name, const wxString& input);
 
 wxString AllEnumValuesForType(Option::Type type);
 
 // Max value for enum types.
-int MaxForType(Option::Type type);
+size_t MaxForType(Option::Type type);
 
 }  // namespace internal
 }  // namespace config

--- a/src/wx/config/option-id.h
+++ b/src/wx/config/option-id.h
@@ -130,7 +130,9 @@ enum class OptionID {
     kSoundGBEnableEffects,
     kSoundGBStereo,
     kSoundGBSurround,
-    kSoundQuality,
+    kSoundAudioRate,
+    kSoundDSoundHWAccel,
+    kSoundUpmix,
     kSoundVolume,
 
     // Do not add anything under here.

--- a/src/wx/config/option-proxy.h
+++ b/src/wx/config/option-proxy.h
@@ -134,7 +134,9 @@ static constexpr std::array<Option::Type, kNbOptions> kOptionsTypes = {
     /*kSoundGBEnableEffects*/ Option::Type::kBool,
     /*kSoundGBStereo*/ Option::Type::kInt,
     /*kSoundGBSurround*/ Option::Type::kBool,
-    /*kSoundQuality*/ Option::Type::kSoundQuality,
+    /*kSoundAudioRate*/ Option::Type::kAudioRate,
+    /*kSoundDSoundHWAccel*/ Option::Type::kBool,
+    /*kSoundUpmix*/ Option::Type::kBool,
     /*kSoundVolume*/ Option::Type::kInt,
 };
 
@@ -208,6 +210,22 @@ public:
     int32_t Max() const { return option_->GetIntMax(); }
 
     bool operator=(int32_t value) { return Set(value); }
+    bool operator+=(int32_t value) {
+        const int new_value = Get() + value;
+        if (new_value > Max()) {
+            return Set(Max());
+        } else {
+            return Set(new_value);
+        }
+    }
+    bool operator-=(int32_t value) {
+        const int new_value = Get() - value;
+        if (new_value < Min()) {
+            return Set(Min());
+        } else {
+            return Set(new_value);
+        }
+    }
     operator int32_t() const { return Get(); }
 
 private:
@@ -308,6 +326,44 @@ public:
 
     bool operator=(RenderMethod value) { return Set(value); }
     operator RenderMethod() const { return Get(); }
+
+private:
+    Option* option_;
+};
+
+template <OptionID ID>
+class OptionProxy<
+    ID,
+    typename std::enable_if<kOptionsTypes[static_cast<size_t>(ID)] ==
+                            Option::Type::kAudioApi>::type> {
+public:
+    OptionProxy() : option_(Option::ByID(ID)) {}
+    ~OptionProxy() = default;
+
+    AudioApi Get() const { return option_->GetAudioApi(); }
+    bool Set(AudioApi value) { return option_->SetAudioApi(value); }
+
+    bool operator=(AudioApi value) { return Set(value); }
+    operator AudioApi() const { return Get(); }
+
+private:
+    Option* option_;
+};
+
+template <OptionID ID>
+class OptionProxy<
+    ID,
+    typename std::enable_if<kOptionsTypes[static_cast<size_t>(ID)] ==
+                            Option::Type::kAudioRate>::type> {
+public:
+    OptionProxy() : option_(Option::ByID(ID)) {}
+    ~OptionProxy() = default;
+
+    AudioRate Get() const { return option_->GetAudioRate(); }
+    bool Set(AudioRate value) { return option_->SetAudioRate(value); }
+
+    bool operator=(AudioRate value) { return Set(value); }
+    operator AudioRate() const { return Get(); }
 
 private:
     Option* option_;

--- a/src/wx/config/option.cpp
+++ b/src/wx/config/option.cpp
@@ -17,8 +17,7 @@ namespace config {
 
 // static
 Option* Option::ByName(const wxString& config_name) {
-    nonstd::optional<OptionID> option_id =
-        internal::StringToOptionId(config_name);
+    nonstd::optional<OptionID> option_id = internal::StringToOptionId(config_name);
     if (!option_id) {
         return nullptr;
     }
@@ -33,8 +32,7 @@ Option* Option::ByID(OptionID id) {
 
 Option::~Option() = default;
 
-Option::Observer::Observer(OptionID option_id)
-    : option_(Option::ByID(option_id)) {
+Option::Observer::Observer(OptionID option_id) : option_(Option::ByID(option_id)) {
     assert(option_);
     option_->AddObserver(this);
 }
@@ -44,11 +42,9 @@ Option::Observer::~Observer() {
 
 Option::Option(OptionID id)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(),
       min_(),
@@ -59,11 +55,9 @@ Option::Option(OptionID id)
 
 Option::Option(OptionID id, bool* option)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(option),
       min_(),
@@ -74,11 +68,9 @@ Option::Option(OptionID id, bool* option)
 
 Option::Option(OptionID id, double* option, double min, double max)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(option),
       min_(min),
@@ -92,11 +84,9 @@ Option::Option(OptionID id, double* option, double min, double max)
 
 Option::Option(OptionID id, int32_t* option, int32_t min, int32_t max)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(option),
       min_(min),
@@ -110,11 +100,9 @@ Option::Option(OptionID id, int32_t* option, int32_t min, int32_t max)
 
 Option::Option(OptionID id, uint32_t* option, uint32_t min, uint32_t max)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(option),
       min_(min),
@@ -128,11 +116,9 @@ Option::Option(OptionID id, uint32_t* option, uint32_t min, uint32_t max)
 
 Option::Option(OptionID id, wxString* option)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(option),
       min_(),
@@ -143,74 +129,74 @@ Option::Option(OptionID id, wxString* option)
 
 Option::Option(OptionID id, Filter* option)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(option),
-      min_(0),
-      max_(internal::MaxForType(type_)) {
+      min_(),
+      max_(nonstd::in_place_type<size_t>, internal::MaxForType(type_)) {
     assert(id != OptionID::Last);
     assert(is_filter());
 }
 
 Option::Option(OptionID id, Interframe* option)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(option),
-      min_(0),
-      max_(internal::MaxForType(type_)) {
+      min_(),
+      max_(nonstd::in_place_type<size_t>, internal::MaxForType(type_)) {
     assert(id != OptionID::Last);
     assert(is_interframe());
 }
 
 Option::Option(OptionID id, RenderMethod* option)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(option),
-      min_(0),
-      max_(internal::MaxForType(type_)) {
+      min_(),
+      max_(nonstd::in_place_type<size_t>, internal::MaxForType(type_)) {
     assert(id != OptionID::Last);
     assert(is_render_method());
 }
 
-Option::Option(OptionID id, int* option)
+Option::Option(OptionID id, AudioApi* option)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(option),
-      min_(0),
-      max_(internal::MaxForType(type_)) {
+      min_(),
+      max_(nonstd::in_place_type<size_t>, internal::MaxForType(type_)) {
     assert(id != OptionID::Last);
-    assert(is_audio_api() || is_sound_quality());
+    assert(is_audio_api());
+}
 
-    // Validate the initial value.
-    SetEnumInt(*option);
+Option::Option(OptionID id, AudioRate* option)
+    : id_(id),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      type_(kOptionsTypes[static_cast<size_t>(id)]),
+      value_(option),
+      min_(),
+      max_(nonstd::in_place_type<size_t>, internal::MaxForType(type_)) {
+    assert(id != OptionID::Last);
+    assert(is_audio_rate());
 }
 
 Option::Option(OptionID id, uint16_t* option)
     : id_(id),
-      config_name_(
-          internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
+      config_name_(internal::kAllOptionsData[static_cast<size_t>(id)].config_name),
       command_(internal::kAllOptionsData[static_cast<size_t>(id)].command),
-      ux_helper_(wxGetTranslation(
-          internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
+      ux_helper_(wxGetTranslation(internal::kAllOptionsData[static_cast<size_t>(id)].ux_helper)),
       type_(kOptionsTypes[static_cast<size_t>(id)]),
       value_(option),
       min_(),
@@ -259,6 +245,16 @@ RenderMethod Option::GetRenderMethod() const {
     return *(nonstd::get<RenderMethod*>(value_));
 }
 
+AudioApi Option::GetAudioApi() const {
+    assert(is_audio_api());
+    return *(nonstd::get<AudioApi*>(value_));
+}
+
+AudioRate Option::GetAudioRate() const {
+    assert(is_audio_rate());
+    return *(nonstd::get<AudioRate*>(value_));
+}
+
 wxString Option::GetEnumString() const {
     switch (type_) {
         case Option::Type::kFilter:
@@ -268,10 +264,9 @@ wxString Option::GetEnumString() const {
         case Option::Type::kRenderMethod:
             return internal::RenderMethodToString(GetRenderMethod());
         case Option::Type::kAudioApi:
-            return internal::AudioApiToString(*(nonstd::get<int32_t*>(value_)));
-        case Option::Type::kSoundQuality:
-            return internal::SoundQualityToString(
-                *(nonstd::get<int32_t*>(value_)));
+            return internal::AudioApiToString(GetAudioApi());
+        case Option::Type::kAudioRate:
+            return internal::AudioRateToString(GetAudioRate());
 
         // We don't use default here to explicitly trigger a compiler warning
         // when adding a new value.
@@ -303,9 +298,8 @@ wxString Option::GetGbPaletteString() const {
 
     wxString palette_string;
     uint16_t const* value = nonstd::get<uint16_t*>(value_);
-    palette_string.Printf("%04X,%04X,%04X,%04X,%04X,%04X,%04X,%04X", value[0],
-                          value[1], value[2], value[3], value[4], value[5],
-                          value[6], value[7]);
+    palette_string.Printf("%04X,%04X,%04X,%04X,%04X,%04X,%04X,%04X", value[0], value[1], value[2],
+                          value[3], value[4], value[5], value[6], value[7]);
     return palette_string;
 }
 
@@ -322,12 +316,9 @@ bool Option::SetBool(bool value) {
 bool Option::SetDouble(double value) {
     assert(is_double());
     double old_value = GetDouble();
-    if (value < nonstd::get<double>(min_) ||
-        value > nonstd::get<double>(max_)) {
-        wxLogWarning(
-            _("Invalid value %f for option %s; valid values are %f - %f"),
-            value, config_name_, nonstd::get<double>(min_),
-            nonstd::get<double>(max_));
+    if (value < nonstd::get<double>(min_) || value > nonstd::get<double>(max_)) {
+        wxLogWarning(_("Invalid value %f for option %s; valid values are %f - %f"), value,
+                     config_name_, nonstd::get<double>(min_), nonstd::get<double>(max_));
         return false;
     }
     *nonstd::get<double*>(value_) = value;
@@ -340,12 +331,9 @@ bool Option::SetDouble(double value) {
 bool Option::SetInt(int32_t value) {
     assert(is_int());
     int old_value = GetInt();
-    if (value < nonstd::get<int32_t>(min_) ||
-        value > nonstd::get<int32_t>(max_)) {
-        wxLogWarning(
-            _("Invalid value %d for option %s; valid values are %d - %d"),
-            value, config_name_, nonstd::get<int32_t>(min_),
-            nonstd::get<int32_t>(max_));
+    if (value < nonstd::get<int32_t>(min_) || value > nonstd::get<int32_t>(max_)) {
+        wxLogWarning(_("Invalid value %d for option %s; valid values are %d - %d"), value,
+                     config_name_, nonstd::get<int32_t>(min_), nonstd::get<int32_t>(max_));
         return false;
     }
     *nonstd::get<int32_t*>(value_) = value;
@@ -358,12 +346,9 @@ bool Option::SetInt(int32_t value) {
 bool Option::SetUnsigned(uint32_t value) {
     assert(is_unsigned());
     uint32_t old_value = GetUnsigned();
-    if (value < nonstd::get<uint32_t>(min_) ||
-        value > nonstd::get<uint32_t>(max_)) {
-        wxLogWarning(
-            _("Invalid value %d for option %s; valid values are %d - %d"),
-            value, config_name_, nonstd::get<uint32_t>(min_),
-            nonstd::get<uint32_t>(max_));
+    if (value < nonstd::get<uint32_t>(min_) || value > nonstd::get<uint32_t>(max_)) {
+        wxLogWarning(_("Invalid value %d for option %s; valid values are %d - %d"), value,
+                     config_name_, nonstd::get<uint32_t>(min_), nonstd::get<uint32_t>(max_));
         return false;
     }
     *nonstd::get<uint32_t*>(value_) = value;
@@ -385,7 +370,7 @@ bool Option::SetString(const wxString& value) {
 
 bool Option::SetFilter(const Filter& value) {
     assert(is_filter());
-    assert(value != Filter::kLast);
+    assert(value < Filter::kLast);
     const Filter old_value = GetFilter();
     *nonstd::get<Filter*>(value_) = value;
     if (old_value != value) {
@@ -396,7 +381,7 @@ bool Option::SetFilter(const Filter& value) {
 
 bool Option::SetInterframe(const Interframe& value) {
     assert(is_interframe());
-    assert(value != Interframe::kLast);
+    assert(value < Interframe::kLast);
     const Interframe old_value = GetInterframe();
     *nonstd::get<Interframe*>(value_) = value;
     if (old_value != value) {
@@ -407,9 +392,31 @@ bool Option::SetInterframe(const Interframe& value) {
 
 bool Option::SetRenderMethod(const RenderMethod& value) {
     assert(is_render_method());
-    assert(value != RenderMethod::kLast);
+    assert(value < RenderMethod::kLast);
     const RenderMethod old_value = GetRenderMethod();
     *nonstd::get<RenderMethod*>(value_) = value;
+    if (old_value != value) {
+        CallObservers();
+    }
+    return true;
+}
+
+bool Option::SetAudioApi(const AudioApi& value) {
+    assert(is_audio_api());
+    assert(value < AudioApi::kLast);
+    const AudioApi old_value = GetAudioApi();
+    *nonstd::get<AudioApi*>(value_) = value;
+    if (old_value != value) {
+        CallObservers();
+    }
+    return true;
+}
+
+bool Option::SetAudioRate(const AudioRate& value) {
+    assert(is_audio_rate());
+    assert(value < AudioRate::kLast);
+    const AudioRate old_value = GetAudioRate();
+    *nonstd::get<AudioRate*>(value_) = value;
     if (old_value != value) {
         CallObservers();
     }
@@ -421,16 +428,13 @@ bool Option::SetEnumString(const wxString& value) {
         case Option::Type::kFilter:
             return SetFilter(internal::StringToFilter(config_name_, value));
         case Option::Type::kInterframe:
-            return SetInterframe(
-                internal::StringToInterframe(config_name_, value));
+            return SetInterframe(internal::StringToInterframe(config_name_, value));
         case Option::Type::kRenderMethod:
-            return SetRenderMethod(
-                internal::StringToRenderMethod(config_name_, value));
+            return SetRenderMethod(internal::StringToRenderMethod(config_name_, value));
         case Option::Type::kAudioApi:
-            return SetEnumInt(internal::StringToAudioApi(config_name_, value));
-        case Option::Type::kSoundQuality:
-            return SetEnumInt(
-                internal::StringToSoundQuality(config_name_, value));
+            return SetAudioApi(internal::StringToAudioApi(config_name_, value));
+        case Option::Type::kAudioRate:
+            return SetAudioRate(internal::StringToSoundQuality(config_name_, value));
 
         // We don't use default here to explicitly trigger a compiler warning
         // when adding a new value.
@@ -446,23 +450,6 @@ bool Option::SetEnumString(const wxString& value) {
     }
     assert(false);
     return false;
-}
-
-bool Option::SetEnumInt(int value) {
-    assert(is_audio_api() || is_sound_quality());
-    int32_t old_value = *nonstd::get<int32_t*>(value_);
-    if (value < nonstd::get<int32_t>(min_) ||
-        value > nonstd::get<int32_t>(max_)) {
-        wxLogWarning(_("Invalid value %d for option %s; valid values are %s"),
-                     value, config_name_,
-                     internal::AllEnumValuesForType(type_));
-        return false;
-    }
-    *nonstd::get<int32_t*>(value_) = value;
-    if (old_value != value) {
-        CallObservers();
-    }
-    return true;
 }
 
 bool Option::SetGbPalette(const std::array<uint16_t, 8>& value) {
@@ -536,6 +523,12 @@ uint32_t Option::GetUnsignedMax() const {
     return nonstd::get<uint32_t>(max_);
 }
 
+size_t Option::GetEnumMax() const {
+    assert(is_filter() || is_interframe() || is_render_method() || is_audio_api() ||
+           is_audio_rate());
+    return nonstd::get<size_t>(max_);
+}
+
 void Option::NextFilter() {
     assert(is_filter());
     const int old_value = static_cast<int>(GetFilter());
@@ -575,7 +568,7 @@ wxString Option::ToHelperString() const {
         case Option::Type::kInterframe:
         case Option::Type::kRenderMethod:
         case Option::Type::kAudioApi:
-        case Option::Type::kSoundQuality:
+        case Option::Type::kAudioRate:
             helper_string.Append(" (");
             helper_string.Append(internal::AllEnumValuesForType(type_));
             helper_string.Append(")");

--- a/src/wx/config/option.h
+++ b/src/wx/config/option.h
@@ -75,8 +75,36 @@ enum class RenderMethod {
     // Do not add anything under here.
     kLast,
 };
-static constexpr size_t kNbRenderMethods =
-    static_cast<size_t>(RenderMethod::kLast);
+static constexpr size_t kNbRenderMethods = static_cast<size_t>(RenderMethod::kLast);
+
+// Values for kAudioApi.
+enum class AudioApi {
+    kOpenAL,
+#if defined(__WXMSW__)
+    kDirectSound,
+#endif  // __WXMSW__
+#if defined(VBAM_ENABLE_XAUDIO2)
+    kXAudio2,
+#endif  // VBAM_ENABLE_XAUDIO2
+#if defined(VBAM_ENABLE_FAUDIO)
+    kFAudio,
+#endif  // VBAM_ENABLE_FAUDIO
+
+    // Do not add anything under here.
+    kLast,
+};
+static constexpr size_t kNbAudioApis = static_cast<size_t>(AudioApi::kLast);
+
+enum class AudioRate {
+    k48kHz = 0,
+    k44kHz,
+    k22kHz,
+    k11kHz,
+
+    // Do not add anything under here.
+    kLast,
+};
+static constexpr size_t kNbSoundRate = static_cast<size_t>(AudioRate::kLast);
 
 // This is incremented whenever we want to change a default value between
 // release versions. The option update code is in load_opts.
@@ -108,7 +136,7 @@ public:
         kInterframe,
         kRenderMethod,
         kAudioApi,
-        kSoundQuality,
+        kAudioRate,
         kGbPalette,
     };
 
@@ -165,11 +193,11 @@ public:
     bool is_interframe() const { return type() == Type::kInterframe; }
     bool is_render_method() const { return type() == Type::kRenderMethod; }
     bool is_audio_api() const { return type() == Type::kAudioApi; }
-    bool is_sound_quality() const { return type() == Type::kSoundQuality; }
+    bool is_audio_rate() const { return type() == Type::kAudioRate; }
     bool is_gb_palette() const { return type() == Type::kGbPalette; }
 
     // Returns a reference to the stored data. Will assert on type mismatch.
-    // Only enum types can use through GetEnumString().
+    // Only enum types can use GetEnumString().
     bool GetBool() const;
     double GetDouble() const;
     int32_t GetInt() const;
@@ -178,6 +206,8 @@ public:
     Filter GetFilter() const;
     Interframe GetInterframe() const;
     RenderMethod GetRenderMethod() const;
+    AudioApi GetAudioApi() const;
+    AudioRate GetAudioRate() const;
     wxString GetEnumString() const;
     std::array<uint16_t, 8> GetGbPalette() const;
     wxString GetGbPaletteString() const;
@@ -193,6 +223,8 @@ public:
     bool SetFilter(const Filter& value);
     bool SetInterframe(const Interframe& value);
     bool SetRenderMethod(const RenderMethod& value);
+    bool SetAudioApi(const AudioApi& value);
+    bool SetAudioRate(const AudioRate& value);
     bool SetEnumString(const wxString& value);
     bool SetGbPalette(const std::array<uint16_t, 8>& value);
     bool SetGbPaletteString(const wxString& value);
@@ -204,6 +236,7 @@ public:
     int32_t GetIntMax() const;
     uint32_t GetUnsignedMin() const;
     uint32_t GetUnsignedMax() const;
+    size_t GetEnumMax() const;
 
     // Special convenience modifiers.
     void NextFilter();
@@ -226,11 +259,10 @@ private:
     Option(OptionID id, Filter* option);
     Option(OptionID id, Interframe* option);
     Option(OptionID id, RenderMethod* option);
+    Option(OptionID id, AudioApi* option);
+    Option(OptionID id, AudioRate* option);
     Option(OptionID id, int* option);
     Option(OptionID id, uint16_t* option);
-
-    // Helper method for enums not fully converted yet.
-    bool SetEnumInt(int value);
 
     // Observer.
     void AddObserver(Observer* observer);
@@ -259,11 +291,16 @@ private:
                           Filter*,
                           Interframe*,
                           RenderMethod*,
+                          AudioApi*,
+                          AudioRate*,
                           uint16_t*>
         value_;
 
+    // Technically, `uint64_t` is only needed for 64 bits targets, as `size_t`.
+    // However, `size_t` is the same as `uint32_t` on 32 bits targets, resulting
+    // in a compiler error if we use `size_t` here.
     const nonstd::variant<nonstd::monostate, double, int32_t, uint32_t> min_;
-    const nonstd::variant<nonstd::monostate, double, int32_t, uint32_t> max_;
+    const nonstd::variant<nonstd::monostate, double, int32_t, uint32_t, uint64_t> max_;
 };
 
 }  // namespace config

--- a/src/wx/dialogs/display-config.cpp
+++ b/src/wx/dialogs/display-config.cpp
@@ -98,7 +98,7 @@ private:
             return false;
         }
 
-        if (static_cast<size_t>(selection) > config::kNbFilters) {
+        if (static_cast<size_t>(selection) >= option()->GetEnumMax()) {
             return false;
         }
 
@@ -131,7 +131,7 @@ private:
             return false;
         }
 
-        if (static_cast<size_t>(selection) > config::kNbInterframes) {
+        if (static_cast<size_t>(selection) >= option()->GetEnumMax()) {
             return false;
         }
 
@@ -245,7 +245,7 @@ DisplayConfig::DisplayConfig(wxWindow* parent)
     // Speed
     GetValidatedChild(this, "FrameSkip")
         ->SetValidator(
-            widgets::OptionSpinCtrlValidator(config::OptionID::kPrefFrameSkip));
+            widgets::OptionIntValidator(config::OptionID::kPrefFrameSkip));
 
     // On-Screen Display
     GetValidatedChild(this, "SpeedIndicator")

--- a/src/wx/dialogs/sound-config.cpp
+++ b/src/wx/dialogs/sound-config.cpp
@@ -1,0 +1,333 @@
+#include "wx/dialogs/sound-config.h"
+
+#include <wx/arrstr.h>
+#include <wx/checkbox.h>
+#include <wx/choice.h>
+#include <wx/clntdata.h>
+#include <wx/event.h>
+#include <wx/radiobut.h>
+#include <wx/slider.h>
+
+#include <wx/xrc/xmlres.h>
+#include <functional>
+
+#include "wx/config/option-id.h"
+#include "wx/config/option-proxy.h"
+#include "wx/config/option.h"
+#include "wx/dialogs/validated-child.h"
+#include "wx/widgets/option-validator.h"
+#include "wx/wxvbam.h"
+
+namespace dialogs {
+
+namespace {
+
+// Validator for the sound rate choice.
+class SoundRateValidator : public widgets::OptionValidator {
+public:
+    SoundRateValidator() : widgets::OptionValidator(config::OptionID::kSoundAudioRate) {}
+    ~SoundRateValidator() override = default;
+
+private:
+    // widgets::OptionValidator implementation.
+    wxObject* Clone() const override { return new SoundRateValidator(); }
+
+    bool IsWindowValueValid() override { return true; }
+
+    bool WriteToWindow() override {
+        wxChoice* choice = wxDynamicCast(GetWindow(), wxChoice);
+        assert(choice);
+        choice->SetSelection(static_cast<int>(option()->GetAudioRate()));
+        return true;
+    }
+
+    bool WriteToOption() override {
+        const wxChoice* choice = wxDynamicCast(GetWindow(), wxChoice);
+        assert(choice);
+        const int selection = choice->GetSelection();
+        if (selection == wxNOT_FOUND) {
+            return false;
+        }
+
+        if (static_cast<size_t>(selection) >= option()->GetEnumMax()) {
+            return false;
+        }
+
+        return option()->SetAudioRate(static_cast<config::AudioRate>(choice->GetSelection()));
+    }
+};
+
+// Validator for a wxRadioButton with an AudioApi value.
+class AudioApiValidator : public widgets::OptionValidator {
+public:
+    explicit AudioApiValidator(config::AudioApi audio_api)
+        : OptionValidator(config::OptionID::kSoundAudioAPI), audio_api_(audio_api) {
+        assert(audio_api < config::AudioApi::kLast);
+    }
+    ~AudioApiValidator() override = default;
+
+private:
+    // OptionValidator implementation.
+    wxObject* Clone() const override { return new AudioApiValidator(audio_api_); }
+
+    bool IsWindowValueValid() override { return true; }
+
+    bool WriteToWindow() override {
+        wxDynamicCast(GetWindow(), wxRadioButton)->SetValue(option()->GetAudioApi() == audio_api_);
+        return true;
+    }
+
+    bool WriteToOption() override {
+        if (wxDynamicCast(GetWindow(), wxRadioButton)->GetValue()) {
+            return option()->SetAudioApi(audio_api_);
+        }
+
+        return true;
+    }
+
+    const config::AudioApi audio_api_;
+};
+
+// Validator for the audio device wxChoice.
+class AudioDeviceValidator : public widgets::OptionValidator {
+public:
+    AudioDeviceValidator() : widgets::OptionValidator(config::OptionID::kSoundAudioDevice) {}
+    ~AudioDeviceValidator() override = default;
+
+private:
+    // OptionValidator implementation.
+    wxObject* Clone() const override { return new AudioDeviceValidator(); }
+
+    bool IsWindowValueValid() override { return true; }
+
+    bool WriteToWindow() override {
+        wxChoice* choice = wxDynamicCast(GetWindow(), wxChoice);
+        assert(choice);
+        const wxString& device = option()->GetString();
+        const int selection = choice->FindString(device);
+        if (selection == wxNOT_FOUND) {
+            return true;
+        }
+
+        choice->SetSelection(selection);
+        return true;
+    }
+
+    bool WriteToOption() override {
+        const wxChoice* choice = wxDynamicCast(GetWindow(), wxChoice);
+        assert(choice);
+        const int selection = choice->GetSelection();
+        if (selection == wxNOT_FOUND) {
+            return option()->SetString(wxEmptyString);
+        }
+
+        return option()->SetString(choice->GetString(selection));
+    }
+};
+
+}  // namespace
+
+// static
+SoundConfig* SoundConfig::NewInstance(wxWindow* parent) {
+    assert(parent);
+    return new SoundConfig(parent);
+}
+
+SoundConfig::SoundConfig(wxWindow* parent) : wxDialog(), keep_on_top_styler_(this) {
+#if !wxCHECK_VERSION(3, 1, 0)
+    // This needs to be set before loading any element on the window. This also
+    // has no effect since wx 3.1.0, where it became the default.
+    this->SetExtraStyle(wxWS_EX_VALIDATE_RECURSIVELY);
+#endif
+    wxXmlResource::Get()->LoadDialog(this, parent, "SoundConfig");
+
+    // Volume slider configuration.
+    wxSlider* volume_slider = GetValidatedChild<wxSlider>(this, "Volume");
+    volume_slider->SetValidator(widgets::OptionIntValidator(config::OptionID::kSoundVolume));
+    GetValidatedChild(this, "Volume100")
+        ->Bind(wxEVT_BUTTON, std::bind(&wxSlider::SetValue, volume_slider, 100));
+
+    // Sound quality.
+    GetValidatedChild(this, "Rate")->SetValidator(SoundRateValidator());
+
+    // Audio API selection.
+    wxWindow* audio_api_button = GetValidatedChild(this, "OpenAL");
+    audio_api_button->SetValidator(AudioApiValidator(config::AudioApi::kOpenAL));
+    audio_api_button->Bind(wxEVT_RADIOBUTTON,
+                           std::bind(&SoundConfig::OnAudioApiChanged, this, std::placeholders::_1,
+                                     config::AudioApi::kOpenAL));
+
+    audio_api_button = GetValidatedChild(this, "DirectSound");
+#if defined(__WXMSW__)
+    audio_api_button->SetValidator(AudioApiValidator(config::AudioApi::kDirectSound));
+    audio_api_button->Bind(wxEVT_RADIOBUTTON,
+                           std::bind(&SoundConfig::OnAudioApiChanged, this, std::placeholders::_1,
+                                     config::AudioApi::kDirectSound));
+#else
+    audio_api_button->Hide();
+#endif
+
+    audio_api_button = GetValidatedChild(this, "XAudio2");
+#if defined(VBAM_ENABLE_XAUDIO2)
+    audio_api_button->SetValidator(AudioApiValidator(config::AudioApi::kXAudio2));
+    audio_api_button->Bind(wxEVT_RADIOBUTTON,
+                           std::bind(&SoundConfig::OnAudioApiChanged, this, std::placeholders::_1,
+                                     config::AudioApi::kXAudio2));
+#else
+    audio_api_button->Hide();
+#endif
+
+    audio_api_button = GetValidatedChild(this, "FAudio");
+#if defined(VBAM_ENABLE_FAUDIO)
+    audio_api_button->SetValidator(AudioApiValidator(config::AudioApi::kFAudio));
+    audio_api_button->Bind(wxEVT_RADIOBUTTON,
+                           std::bind(&SoundConfig::OnAudioApiChanged, this, std::placeholders::_1,
+                                     config::AudioApi::kFAudio));
+#else
+    audio_api_button->Hide();
+#endif
+
+    // Upmix configuration.
+    upmix_checkbox_ = GetValidatedChild<wxCheckBox>(this, "Upmix");
+#if defined(VBAM_ENABLE_XAUDIO2) || defined(VBAM_ENABLE_FAUDIO)
+    upmix_checkbox_->SetValidator(widgets::OptionBoolValidator(config::OptionID::kSoundUpmix));
+#else
+    upmix_checkbox_->Hide();
+#endif
+
+    // DSound HW acceleration.
+    hw_accel_checkbox_ = GetValidatedChild<wxCheckBox>(this, "HWAccel");
+#if defined(__WXMSW__)
+    hw_accel_checkbox_->SetValidator(
+        widgets::OptionBoolValidator(config::OptionID::kSoundDSoundHWAccel));
+#else
+    hw_accel_checkbox_->Hide();
+#endif
+
+    // Buffers configuration.
+    buffers_info_label_ = GetValidatedChild<wxControl>(this, "BuffersInfo");
+    buffers_slider_ = GetValidatedChild<wxSlider>(this, "Buffers");
+    buffers_slider_->SetValidator(widgets::OptionIntValidator(config::OptionID::kSoundBuffers));
+    buffers_slider_->Bind(wxEVT_SLIDER, &SoundConfig::OnBuffersChanged, this);
+
+    // Game Boy configuration.
+    GetValidatedChild(this, "GBEcho")
+        ->SetValidator(widgets::OptionIntValidator(config::OptionID::kSoundGBEcho));
+    GetValidatedChild(this, "GBStereo")
+        ->SetValidator(widgets::OptionIntValidator(config::OptionID::kSoundGBStereo));
+
+    // Game Boy Advance configuration.
+    GetValidatedChild(this, "GBASoundFiltering")
+        ->SetValidator(widgets::OptionIntValidator(config::OptionID::kSoundGBAFiltering));
+
+    // Audio Device configuration.
+    audio_device_selector_ = GetValidatedChild<wxChoice>(this, "Device");
+    audio_device_selector_->SetValidator(AudioDeviceValidator());
+
+    this->Bind(wxEVT_SHOW, &SoundConfig::OnShow, this);
+
+    // Finally, fit everything nicely.
+    Fit();
+}
+
+void SoundConfig::OnShow(wxShowEvent& event) {
+    wxCommandEvent dummy_event;
+
+    // Referesh the buffers information.
+    OnBuffersChanged(dummy_event);
+
+    // Refresh the audio device selector.
+    OnAudioApiChanged(dummy_event, OPTION(kSoundAudioAPI));
+
+    // Let the event propagate.
+    event.Skip();
+}
+
+void SoundConfig::OnBuffersChanged(wxCommandEvent& event) {
+    const int buffers_count = buffers_slider_->GetValue();
+    const double buffer_time = static_cast<double>(buffers_count) / 60.0 * 1000.0;
+    buffers_info_label_->SetLabel(
+        wxString::Format(_("%d frame = %.2f ms"), buffers_count, buffer_time));
+
+    // Let the event propagate.
+    event.Skip();
+}
+
+void SoundConfig::OnAudioApiChanged(wxCommandEvent& event, config::AudioApi audio_api) {
+    audio_device_selector_->Clear();
+    audio_device_selector_->Append(_("Default device"), new wxStringClientData(wxEmptyString));
+
+    // Gather device names and IDs.
+    wxArrayString device_names;
+    wxArrayString device_ids;
+    switch (audio_api) {
+        case config::AudioApi::kOpenAL:
+            if (!GetOALDevices(device_names, device_ids)) {
+                return;
+            }
+            break;
+
+#if defined(__WXMSW__)
+        case config::AudioApi::kDirectSound:
+            if (!(GetDSDevices(device_names, device_ids))) {
+                return;
+            }
+            break;
+#endif
+
+#if defined(VBAM_ENABLE_XAUDIO2)
+        case config::AudioApi::kXAudio2:
+            if (!GetXA2Devices(device_names, device_ids)) {
+                return;
+            }
+            break;
+#endif
+
+#if defined(VBAM_ENABLE_FAUDIO)
+        case config::AudioApi::kFAudio:
+            if (!GetFADevices(device_names, device_ids)) {
+                return;
+            }
+            break;
+#endif
+
+        case config::AudioApi::kLast:
+            // This should never happen.
+            assert(false);
+            return;
+    }
+
+    audio_device_selector_->SetSelection(0);
+
+    for (size_t i = 0; i < device_names.size(); i++) {
+        audio_device_selector_->Append(device_names[i], new wxStringClientData(device_ids[i]));
+
+        if (audio_api == OPTION(kSoundAudioAPI) && OPTION(kSoundAudioDevice) == device_ids[i]) {
+            audio_device_selector_->SetSelection(i + 1);
+        }
+    }
+
+#if defined(VBAM_ENABLE_XAUDIO2) && defined(VBAM_ENABLE_FAUDIO)
+    upmix_checkbox_->Enable(audio_api == config::AudioApi::kXAudio2 ||
+                            audio_api == config::AudioApi::kFAudio);
+#elif defined(VBAM_ENABLE_XAUDIO2)
+    upmix_checkbox_->Enable(audio_api == config::AudioApi::kXAudio2);
+#elif defined(VBAM_ENABLE_FAUDIO)
+    upmix_checkbox_->Enable(audio_api == config::AudioApi::kFAudio);
+#else
+    upmix_checkbox_->Enable(false);
+#endif
+
+#if defined(__WXMSW__)
+    hw_accel_checkbox_->Enable(audio_api == config::AudioApi::kDirectSound);
+#else
+    hw_accel_checkbox_->Enable(false);
+#endif
+
+    current_audio_api_ = audio_api;
+
+    // Let the event propagate.
+    event.Skip();
+}
+
+}  // namespace dialogs

--- a/src/wx/dialogs/sound-config.h
+++ b/src/wx/dialogs/sound-config.h
@@ -1,0 +1,50 @@
+#ifndef VBAM_WX_DIALOGS_SOUND_CONFIG_H_
+#define VBAM_WX_DIALOGS_SOUND_CONFIG_H_
+
+#include <wx/dialog.h>
+#include <wx/event.h>
+
+#include "wx/config/option.h"
+#include "wx/widgets/keep-on-top-styler.h"
+
+// Forward declarations.
+class wxChoice;
+class wxCheckBox;
+class wxControl;
+class wxSlider;
+class wxWindow;
+
+namespace dialogs {
+
+// Manages the sound configuration dialog.
+class SoundConfig : public wxDialog {
+public:
+    static SoundConfig* NewInstance(wxWindow* parent);
+    ~SoundConfig() override = default;
+
+private:
+    // The constructor is private so initialization has to be done via the
+    // static method. This is because this class is destroyed when its
+    // owner, `parent` is destroyed. This prevents accidental deletion.
+    SoundConfig(wxWindow* parent);
+
+    void OnShow(wxShowEvent& event);
+
+    // Populate `buffers_info_label_` with the current buffer information.
+    void OnBuffersChanged(wxCommandEvent& event);
+
+    // Refresh `audio_device_selector_`.
+    void OnAudioApiChanged(wxCommandEvent& event, config::AudioApi api);
+
+    wxSlider* buffers_slider_;
+    wxControl* buffers_info_label_;
+    wxChoice* audio_device_selector_;
+    wxCheckBox* upmix_checkbox_;
+    wxCheckBox* hw_accel_checkbox_;
+    config::AudioApi current_audio_api_;
+    const widgets::KeepOnTopStyler keep_on_top_styler_;
+};
+
+}  // namespace dialogs
+
+#endif  // VBAM_WX_DIALOGS_SOUND_CONFIG_H_

--- a/src/wx/faudio.cpp
+++ b/src/wx/faudio.cpp
@@ -1,23 +1,24 @@
-#ifndef NO_FAUDIO
+#if !defined(VBAM_ENABLE_FAUDIO)
+#error "This file should only be compiled if FAudio is enabled"
+#endif
 
-// Application
-#include "wx/wxvbam.h"
-#include <stdio.h>
+#include <cstdio>
 
-// Interface
-#include "core/base/sound_driver.h"
+#include <string>
+#include <vector>
 
 // FAudio
 #include <faudio.h>
 
 // MMDevice API
 #include <mmdeviceapi.h>
-#include <string>
-#include <vector>
 
-// Internals
-#include "core/base/system.h" // for systemMessage()
+#include <wx/arrstr.h>
+
+#include "core/base/sound_driver.h"
+#include "core/base/system.h"
 #include "core/gba/gbaGlobals.h"
+#include "wx/config/option-proxy.h"
 
 int GetFADevices(FAudio* fa, wxArrayString* names, wxArrayString* ids,
     const wxString* match)
@@ -75,10 +76,11 @@ bool GetFADevices(wxArrayString& names, wxArrayString& ids)
 
 static int FAGetDev(FAudio* fa)
 {
-    if (gopts.audio_dev.empty())
+    const wxString& audio_device = OPTION(kSoundAudioDevice);
+    if (audio_device.empty())
         return 0;
     else {
-        int ret = GetFADevices(fa, NULL, NULL, &gopts.audio_dev);
+        int ret = GetFADevices(fa, NULL, NULL, &audio_device);
         return ret < 0 ? 0 : ret;
     }
 }
@@ -281,7 +283,7 @@ FAudio_Output::FAudio_Output()
     initialized = false;
     playing = false;
     freq = 0;
-    bufferCount = gopts.audio_buffers;
+    bufferCount = OPTION(kSoundBuffers);
     buffers = NULL;
     currentBuffer = 0;
     device_changed = false;
@@ -396,7 +398,7 @@ bool FAudio_Output::init(long sampleRate)
         return false;
     }
 
-    if (gopts.upmix) {
+    if (OPTION(kSoundUpmix)) {
         // set up stereo upmixing
         FAudioDeviceDetails dd;
         ZeroMemory(&dd, sizeof(dd));
@@ -626,5 +628,3 @@ SoundDriver* newFAudio_Output()
 {
     return new FAudio_Output();
 }
-
-#endif // #ifndef NO_FAUDIO

--- a/src/wx/opts.h
+++ b/src/wx/opts.h
@@ -9,7 +9,6 @@
 #include "wx/config/game-control.h"
 #include "wx/config/shortcuts.h"
 #include "wx/config/user-input.h"
-#include "wx/wxhead.h"
 
 // Forward declaration.
 class wxFileHistory;
@@ -20,8 +19,6 @@ extern const std::map<config::GameControl, std::set<config::UserInput>>
 
 extern struct opts_t {
     opts_t();
-    // while I would normally put large objects in front to reduce gaps,
-    // I instead organized this by opts.cpp table order
 
     /// Display
     wxVideoMode fs_mode;
@@ -52,23 +49,7 @@ extern struct opts_t {
     int max_scale = 0;
 
     /// Sound
-#ifdef __WXMSW__
-    int audio_api = AUD_XAUDIO2;
-#else
-    int audio_api = AUD_OPENAL;
-#endif
-    // 10 fixes stuttering on mac with openal, as opposed to 5
-    // also should be better for modern hardware in general
-    int audio_buffers = 10;
-    wxString audio_dev;
     int sound_en = 0x30f; // soundSetEnable()
-    int gba_sound_filter = 50;
-    int gb_echo = 20;
-    bool dsound_hw_accel;
-    int gb_stereo = 15;
-    int sound_qual = 1; // soundSetSampleRate() / gbSoundSetSampleRate()
-    int sound_vol = 100; // soundSetVolume()
-    bool upmix = false; // xa2 only
 
     /// Recent
     wxFileHistory* recent = nullptr;

--- a/src/wx/widgets/option-validator.cpp
+++ b/src/wx/widgets/option-validator.cpp
@@ -3,6 +3,7 @@
 #include <wx/checkbox.h>
 #include <wx/choice.h>
 #include <wx/radiobut.h>
+#include <wx/slider.h>
 #include <wx/spinctrl.h>
 
 namespace widgets {
@@ -90,30 +91,49 @@ bool OptionSelectedValidator::WriteToOption() {
     return false;
 }
 
-OptionSpinCtrlValidator::OptionSpinCtrlValidator(config::OptionID option_id)
+OptionIntValidator::OptionIntValidator(config::OptionID option_id)
     : OptionValidator(option_id) {
     assert(option()->is_int());
 }
 
-wxObject* OptionSpinCtrlValidator::Clone() const {
-    return new OptionSpinCtrlValidator(option()->id());
+wxObject* OptionIntValidator::Clone() const {
+    return new OptionIntValidator(option()->id());
 }
 
-bool OptionSpinCtrlValidator::IsWindowValueValid() {
+bool OptionIntValidator::IsWindowValueValid() {
     return true;
 }
 
-bool OptionSpinCtrlValidator::WriteToWindow() {
+bool OptionIntValidator::WriteToWindow() {
     wxSpinCtrl* spin_ctrl = wxDynamicCast(GetWindow(), wxSpinCtrl);
-    assert(spin_ctrl);
-    spin_ctrl->SetValue(option()->GetInt());
-    return true;
+    if (spin_ctrl) {
+        spin_ctrl->SetValue(option()->GetInt());
+        return true;
+    }
+
+    wxSlider* slider = wxDynamicCast(GetWindow(), wxSlider);
+    if (slider) {
+        slider->SetValue(option()->GetInt());
+        return true;
+    }
+
+    assert(false);
+    return false;
 }
 
-bool OptionSpinCtrlValidator::WriteToOption() {
+bool OptionIntValidator::WriteToOption() {
     const wxSpinCtrl* spin_ctrl = wxDynamicCast(GetWindow(), wxSpinCtrl);
-    assert(spin_ctrl);
-    return option()->SetInt(spin_ctrl->GetValue());
+    if (spin_ctrl) {
+        return option()->SetInt(spin_ctrl->GetValue());
+    }
+
+    const wxSlider* slider = wxDynamicCast(GetWindow(), wxSlider);
+    if (slider) {
+        return option()->SetInt(slider->GetValue());
+    }
+
+    assert(false);
+    return false;
 }
 
 OptionChoiceValidator::OptionChoiceValidator(config::OptionID option_id)
@@ -140,6 +160,32 @@ bool OptionChoiceValidator::WriteToOption() {
     const wxChoice* choice = wxDynamicCast(GetWindow(), wxChoice);
     assert(choice);
     return option()->SetUnsigned(choice->GetSelection());
+}
+
+OptionBoolValidator::OptionBoolValidator(config::OptionID option_id)
+    : OptionValidator(option_id) {
+    assert(option()->is_bool());
+}
+
+wxObject* OptionBoolValidator::Clone() const {
+    return new OptionBoolValidator(option()->id());
+}
+
+bool OptionBoolValidator::IsWindowValueValid() {
+    return true;
+}
+
+bool OptionBoolValidator::WriteToWindow() {
+    wxCheckBox* checkbox = wxDynamicCast(GetWindow(), wxCheckBox);
+    assert(checkbox);
+    checkbox->SetValue(option()->GetBool());
+    return true;
+}
+
+bool OptionBoolValidator::WriteToOption() {
+    const wxCheckBox* checkbox = wxDynamicCast(GetWindow(), wxCheckBox);
+    assert(checkbox);
+    return option()->SetBool(checkbox->GetValue());
 }
 
 }  // namespace widgets

--- a/src/wx/widgets/option-validator.h
+++ b/src/wx/widgets/option-validator.h
@@ -106,12 +106,12 @@ private:
     const uint32_t value_;
 };
 
-// Validator for a wxSpinCtrl  widget with a kInt Option. This will keep the
-// kInt Option and the wxSpinCtrl selection in sync.
-class OptionSpinCtrlValidator : public OptionValidator {
+// Validator for a wxSpinCtrl or wxSlider widget with a kInt Option. This will
+// keep the kInt Option and the wxSpinCtrl or wxSlider selection in sync.
+class OptionIntValidator : public OptionValidator {
 public:
-    explicit OptionSpinCtrlValidator(config::OptionID option_id);
-    ~OptionSpinCtrlValidator() override = default;
+    explicit OptionIntValidator(config::OptionID option_id);
+    ~OptionIntValidator() override = default;
 
     // Returns a copy of the object.
     wxObject* Clone() const override;
@@ -123,12 +123,29 @@ private:
     bool WriteToOption() override;
 };
 
-// Validator for a wxChoice  widget with a kUnsigned Option. This will keep the
+// Validator for a wxChoice widget with a kUnsigned Option. This will keep the
 // kUnsigned Option and the wxChoice selection in sync.
 class OptionChoiceValidator : public OptionValidator {
 public:
     explicit OptionChoiceValidator(config::OptionID option_id);
     ~OptionChoiceValidator() override = default;
+
+    // Returns a copy of the object.
+    wxObject* Clone() const override;
+
+private:
+    // OptionValidator implementation.
+    bool IsWindowValueValid() override;
+    bool WriteToWindow() override;
+    bool WriteToOption() override;
+};
+
+// Validator for a wxCheckBox widgets with a kBool Option. This will keep the
+// kBool Option and the wxCheckBox selection in sync.
+class OptionBoolValidator : public OptionValidator {
+public:
+    explicit OptionBoolValidator(config::OptionID option_id);
+    ~OptionBoolValidator() override = default;
 
     // Returns a copy of the object.
     wxObject* Clone() const override;

--- a/src/wx/wxhead.h
+++ b/src/wx/wxhead.h
@@ -59,16 +59,6 @@ using std::int32_t;
 
 #include "wx/wxutil.h"
 
-// This enum must be kept in sync with the one in vbam-options-static.cpp.
-// TODO: These 2 enums should be unified and a validator created for this enum.
-enum audioapi {
-    AUD_SDL,
-    AUD_OPENAL,
-    AUD_DIRECTSOUND,
-    AUD_XAUDIO2,
-    AUD_FAUDIO
-};
-
 // wxrc helpers (for dynamic strings instead of constant)
 #define XRCID_D(str) wxXmlResource::GetXRCID(str)
 //#define XRCCTRL_D(win, id, type) (wxStaticCast((win).FindWindow(XRCID_D(id)), type))

--- a/src/wx/wxutil.cpp
+++ b/src/wx/wxutil.cpp
@@ -1,6 +1,10 @@
 #include "wx/wxutil.h"
 
 int getKeyboardKeyCode(const wxKeyEvent& event) {
+    const int key_code = event.GetKeyCode();
+    if (key_code > WXK_START) {
+        return key_code;
+    }
     int uc = event.GetUnicodeKey();
     if (uc != WXK_NONE) {
         if (uc < 32) {  // not all control chars

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -13,6 +13,7 @@
 
 #include "core/base/system.h"
 #include "wx/config/option-observer.h"
+#include "wx/config/option.h"
 #include "wx/widgets/dpi-support.h"
 #include "wx/widgets/keep-on-top-styler.h"
 #include "wx/widgets/sdljoy.h"
@@ -616,12 +617,20 @@ protected:
     DECLARE_EVENT_TABLE()
 
 private:
+    void OnAudioRateChanged();
+    void OnVolumeChanged(config::Option* option);
+
+    bool schedule_audio_restart_ = false;
+
     const config::OptionsObserver render_observer_;
     const config::OptionsObserver scale_observer_;
     const config::OptionsObserver gb_border_observer_;
     const config::OptionsObserver gb_palette_observer_;
     const config::OptionsObserver gb_declick_observer_;
     const config::OptionsObserver lcd_filters_observer_;
+    const config::OptionsObserver audio_rate_observer_;
+    const config::OptionsObserver audio_volume_observer_;
+    const config::OptionsObserver audio_observer_;
 };
 
 // wxString version of OSD message
@@ -704,25 +713,24 @@ private:
 
 // I should add this to SoundDriver, but wxArrayString is wx-specific
 // I suppose I could make subclass wxSoundDriver.  maybe later.
-
 class SoundDriver;
 extern SoundDriver* newOpenAL();
 extern bool GetOALDevices(wxArrayString& names, wxArrayString& ids);
 
-#ifdef __WXMSW__
+#if defined(__WXMSW__)
 extern SoundDriver* newDirectSound();
 extern bool GetDSDevices(wxArrayString& names, wxArrayString& ids);
+#endif  // defined(__WXMSW__)
 
-#ifndef NO_XAUDIO2
+#if defined(VBAM_ENABLE_XAUDIO2)
 extern SoundDriver* newXAudio2_Output();
 extern bool GetXA2Devices(wxArrayString& names, wxArrayString& ids);
-#endif
+#endif  // defined(VBAM_ENABLE_XAUDIO2)
 
-#ifndef NO_FAUDIO
+#if defined(VBAM_ENABLE_FAUDIO)
 extern SoundDriver* newFAudio_Output();
 extern bool GetFADevices(wxArrayString& names, wxArrayString& ids);
-#endif
-#endif
+#endif  // defined(VBAM_ENABLE_FAUDIO)
 
 #if defined(VBAM_ENABLE_DEBUGGER)
 extern bool debugger;

--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -384,11 +384,9 @@
         </object>
         <object class="wxMenuItem" name="IncreaseVolume">
           <label>_Increase volume</label>
-          <enabled>0</enabled>
         </object>
         <object class="wxMenuItem" name="DecreaseVolume">
           <label>_Decrease volume</label>
-          <enabled>0</enabled>
         </object>
         <object class="wxMenuItem" name="ToggleSound">
           <label>_Toggle sound</label>

--- a/src/wx/xrc/SoundConfig.xrc
+++ b/src/wx/xrc/SoundConfig.xrc
@@ -101,14 +101,6 @@
               <object class="sizeritem">
                 <object class="wxBoxSizer">
                   <object class="sizeritem">
-                    <object class="wxRadioButton" name="SDL">
-                      <label translate="0">SDL</label>
-                      <style>wxRB_GROUP</style>
-                    </object>
-                    <flag>wxALL|wxEXPAND</flag>
-                    <border>5</border>
-                  </object>
-                  <object class="sizeritem">
                     <object class="wxRadioButton" name="OpenAL">
                       <label translate="0">OpenAL</label>
                     </object>


### PR DESCRIPTION
This fixes a number of issues with the current implementation. Namely, some options were not properly saved and the audio driver was not properly reloaded when some options were changed.
In addition, this moves most sound-related options to `g_owned_opts` and simplifies many call sites.