### PR TITLE
[Dialogs] Prevent viewers from causing a crash

### DIFF
--- a/src/wx/gfxviewers.cpp
+++ b/src/wx/gfxviewers.cpp
@@ -1683,7 +1683,9 @@ public:
     }
 
 protected:
-    int charbase_, is256_, palette_;
+    int charbase_ = 0;
+    int is256_ = 0;
+    int palette_ = 0;
     wxControl *tileno_, *addr_;
     int selx_, sely_;
 


### PR DESCRIPTION
Some of the viewers dialogs were not properly set up and were causing a crash at runtime.