### PR TITLE
Move cmdtab and command enable flags to config/

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -17,6 +17,8 @@ set(VBAM_WX_COMMON
     config/bindings.h
     config/command.cpp
     config/command.h
+    config/cmdtab.cpp
+    config/cmdtab.h
     config/emulated-gamepad.cpp
     config/emulated-gamepad.h
     config/internal/bindings-internal.cpp
@@ -101,7 +103,7 @@ set(VBAM_WX_COMMON
     ${VBAM_GENERATED_DIR}/wx/builtin-over.h
     ${VBAM_GENERATED_DIR}/wx/cmdhandlers.h
     ${VBAM_GENERATED_DIR}/wx/cmd-evtable.h
-    ${VBAM_GENERATED_DIR}/wx/cmdtab.cpp
+    ${VBAM_GENERATED_DIR}/wx/config/internal/cmdtab.cpp
 )
 
 if(NOT ZIP_PROGRAM)
@@ -601,7 +603,7 @@ add_custom_command(
 # all using portable cmake code
 add_custom_command(
     OUTPUT
-        ${VBAM_GENERATED_DIR}/wx/cmdtab.cpp
+        ${VBAM_GENERATED_DIR}/wx/config/internal/cmdtab.cpp
         ${VBAM_GENERATED_DIR}/wx/cmdhandlers.h
         ${VBAM_GENERATED_DIR}/wx/cmd-evtable.h
     COMMAND

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -22,17 +22,13 @@
 #include "core/gba/gbaGlobals.h"
 #include "core/gba/gbaPrint.h"
 #include "core/gba/gbaSound.h"
+#include "wx/config/cmdtab.h"
 #include "wx/config/option-proxy.h"
 #include "wx/config/option.h"
 #include "wx/dialogs/game-maker.h"
 
 #define GetXRCDialog(n) \
     wxStaticCast(wxGetApp().frame->FindWindowByName(n), wxDialog)
-
-bool cmditem_lt(const struct cmditem& cmd1, const struct cmditem& cmd2)
-{
-    return wxStrcmp(cmd1.cmd, cmd2.cmd) < 0;
-}
 
 void MainFrame::GetMenuOptionBool(const wxString& menuName, bool* field)
 {

--- a/src/wx/config/cmdtab.cpp
+++ b/src/wx/config/cmdtab.cpp
@@ -1,0 +1,16 @@
+#include "wx/config/cmdtab.h"
+
+#include <wx/wxcrt.h>
+
+// Initializer for struct cmditem
+cmditem new_cmditem(const wxString cmd,
+                    const wxString name,
+                    int cmd_id,
+                    int mask_flags,
+                    wxMenuItem* mi) {
+    return cmditem {cmd, name, cmd_id, mask_flags, mi};
+}
+
+bool cmditem_lt(const struct cmditem& cmd1, const struct cmditem& cmd2) {
+    return wxStrcmp(cmd1.cmd, cmd2.cmd) < 0;
+}

--- a/src/wx/config/cmdtab.h
+++ b/src/wx/config/cmdtab.h
@@ -1,0 +1,62 @@
+#ifndef VBAM_WX_CONFIG_CMDTAB_H_
+#define VBAM_WX_CONFIG_CMDTAB_H_
+
+#include <vector>
+
+#include <wx/string.h>
+
+// Forward declaration.
+class wxMenuItem;
+
+// List of all commands with their descriptions
+// sorted by cmd field for binary searching
+// filled in by copy-events.cmake
+struct cmditem {
+    const wxString cmd;
+    const wxString name;
+    int cmd_id;
+    int mask_flags;  // if non-0, one of the flags must be turned on in win
+    // to enable this command
+    wxMenuItem* mi;  // the menu item to invoke command, if present
+};
+
+extern std::vector<cmditem> cmdtab;
+
+// Initializer for struct cmditem
+cmditem new_cmditem(const wxString cmd = "",
+                    const wxString name = "",
+                    int cmd_id = 0,
+                    int mask_flags = 0,
+                    wxMenuItem* mi = nullptr);
+
+// for binary search
+bool cmditem_lt(const struct cmditem& cmd1, const struct cmditem& cmd2);
+
+// here are those conditions
+enum { CMDEN_GB = (1 << 0), // GB ROM loaded
+    CMDEN_GBA = (1 << 1), // GBA ROM loaded
+    // the rest imply the above, unless:
+    //   _ANY -> does not imply either
+    //   _GBA -> only implies GBA
+    CMDEN_REWIND = (1 << 2), // rewind states available
+    CMDEN_SREC = (1 << 3), // sound recording in progress
+    CMDEN_NSREC = (1 << 4), // no sound recording
+    CMDEN_VREC = (1 << 5), // video recording
+    CMDEN_NVREC = (1 << 6), // no video recording
+    CMDEN_GREC = (1 << 7), // game recording
+    CMDEN_NGREC = (1 << 8), // no game recording
+    CMDEN_GPLAY = (1 << 9), // game playback
+    CMDEN_NGPLAY = (1 << 10), // no game playback
+    CMDEN_SAVST = (1 << 11), // any save states
+    CMDEN_GDB = (1 << 12), // gdb connected
+    CMDEN_NGDB_GBA = (1 << 13), // gdb not connected
+    CMDEN_NGDB_ANY = (1 << 14), // gdb not connected
+    CMDEN_NREC_ANY = (1 << 15), // not a/v recording
+    CMDEN_LINK_ANY = (1 << 16), // link enabled
+
+    CMDEN_NEVER = (1 << 31) // never (for NOOP)
+};
+#define ONLOAD_CMDEN (CMDEN_NSREC | CMDEN_NVREC | CMDEN_NGREC | CMDEN_NGPLAY)
+#define UNLOAD_CMDEN_KEEP (CMDEN_NGDB_ANY | CMDEN_NREC_ANY | CMDEN_LINK_ANY)
+
+#endif  // VBAM_WX_CONFIG_CMDTAB_H_

--- a/src/wx/config/command.cpp
+++ b/src/wx/config/command.cpp
@@ -2,10 +2,11 @@
 
 #include <map>
 
-#include <wx/wxchar.h>
+#include <wx/log.h>
+#include <wx/translation.h>
 
+#include "wx/config/cmdtab.h"
 #include "wx/strutils.h"
-#include "wx/wxvbam.h"
 
 namespace config {
 namespace {
@@ -107,17 +108,15 @@ wxString GameCommand::ToUXString() const {
 }
 
 wxString ShortcutCommand::ToConfigString() const {
-    int cmd = 0;
-    for (cmd = 0; cmd < ncmds; cmd++)
-        if (cmdtab[cmd].cmd_id == id_)
-            break;
-    if (cmd == ncmds) {
-        // Command not found. This should never happen.
-        assert(false);
-        return wxEmptyString;
+    for (const cmditem& cmd_item : cmdtab) {
+        if (cmd_item.cmd_id == id_) {
+            return wxString::Format("Keyboard/%s", cmd_item.cmd);
+        }
     }
 
-    return wxString::Format("Keyboard/%s", cmdtab[cmd].cmd);
+    // Command not found. This should never happen.
+    assert(false);
+    return wxEmptyString;
 }
 
 // static
@@ -158,14 +157,14 @@ nonstd::optional<Command> Command::FromString(const wxString& name) {
             return nonstd::nullopt;
         }
 
-        const cmditem* cmd = std::lower_bound(
-            &cmdtab[0], &cmdtab[ncmds], cmditem{parts[1], wxString(), 0, 0, NULL}, cmditem_lt);
-        if (cmd == &cmdtab[ncmds] || wxStrcmp(parts[1], cmd->cmd)) {
+        const auto iter = std::lower_bound(cmdtab.begin(), cmdtab.end(),
+                                           cmditem{parts[1], wxString(), 0, 0, NULL}, cmditem_lt);
+        if (iter == cmdtab.end()) {
             wxLogDebug("Command ID %s not found", parts[1]);
             return nonstd::nullopt;
         }
 
-        return Command(ShortcutCommand(cmd->cmd_id));
+        return Command(ShortcutCommand(iter->cmd_id));
     }
 }
 

--- a/src/wx/guiinit.cpp
+++ b/src/wx/guiinit.cpp
@@ -38,6 +38,7 @@
 #include "core/gba/gbaCheats.h"
 #include "core/gba/gbaFlash.h"
 #include "core/gba/gbaGlobals.h"
+#include "wx/config/cmdtab.h"
 #include "wx/config/option-proxy.h"
 #include "wx/dialogs/accel-config.h"
 #include "wx/dialogs/base-dialog.h"
@@ -1785,82 +1786,82 @@ bool MainFrame::BindControls()
 #endif
 
         // save all menu items in the command table
-        for (int i = 0; i < ncmds; i++) {
-            wxMenuItem* mi = cmdtab[i].mi = XRCITEM_I(cmdtab[i].cmd_id);
+        for (cmditem& cmd_item : cmdtab) {
+            wxMenuItem* mi = cmd_item.mi = XRCITEM_I(cmd_item.cmd_id);
 // remove unsupported commands first
 #ifdef NO_FFMPEG
 
-            if (cmdtab[i].mask_flags & (CMDEN_SREC | CMDEN_NSREC | CMDEN_VREC | CMDEN_NVREC)) {
+            if (cmd_item.mask_flags & (CMDEN_SREC | CMDEN_NSREC | CMDEN_VREC | CMDEN_NVREC)) {
                 if (mi)
                     mi->GetMenu()->Remove(mi);
-                cmdtab[i].mi = NULL;
+                cmd_item.mi = NULL;
                 continue;
             }
 
 #endif
 #ifndef GBA_LOGGING
 
-            if (cmdtab[i].cmd_id == XRCID("Logging")) {
+            if (cmd_item.cmd_id == XRCID("Logging")) {
                 if (mi)
                     mi->GetMenu()->Remove(mi);
-                cmdtab[i].mi = NULL;
+                cmd_item.mi = NULL;
                 continue;
             }
 
 #endif
 #if defined(__WXMAC__) || defined(__WXGTK__)
 
-            if (cmdtab[i].cmd_id == XRCID("AllowKeyboardBackgroundInput")
+            if (cmd_item.cmd_id == XRCID("AllowKeyboardBackgroundInput")
 #if defined(__WXGTK__)
                 && IsWayland()
 #endif
                ) {
                 if (mi)
                     mi->GetMenu()->Remove(mi);
-                cmdtab[i].mi = NULL;
+                cmd_item.mi = NULL;
                 continue;
             }
 
 #endif
 #ifdef NO_LINK
 
-            if (cmdtab[i].cmd_id == XRCID("LanLink") || cmdtab[i].cmd_id == XRCID("LinkType0Nothing") || cmdtab[i].cmd_id == XRCID("LinkType1Cable") || cmdtab[i].cmd_id == XRCID("LinkType2Wireless") || cmdtab[i].cmd_id == XRCID("LinkType3GameCube") || cmdtab[i].cmd_id == XRCID("LinkType4Gameboy") || cmdtab[i].cmd_id == XRCID("LinkAuto") || cmdtab[i].cmd_id == XRCID("SpeedOn") || cmdtab[i].cmd_id == XRCID("LinkProto") || cmdtab[i].cmd_id == XRCID("LinkConfigure")) {
+            if (cmd_item.cmd_id == XRCID("LanLink") || cmd_item.cmd_id == XRCID("LinkType0Nothing") || cmd_item.cmd_id == XRCID("LinkType1Cable") || cmd_item.cmd_id == XRCID("LinkType2Wireless") || cmd_item.cmd_id == XRCID("LinkType3GameCube") || cmd_item.cmd_id == XRCID("LinkType4Gameboy") || cmd_item.cmd_id == XRCID("LinkAuto") || cmd_item.cmd_id == XRCID("SpeedOn") || cmd_item.cmd_id == XRCID("LinkProto") || cmd_item.cmd_id == XRCID("LinkConfigure")) {
                 if (mi)
                     mi->GetMenu()->Remove(mi);
-                cmdtab[i].mi = NULL;
+                cmd_item.mi = NULL;
                 continue;
             }
 
 #else
 
             // Always disable Wireless link for now, this has never worked.
-            if (cmdtab[i].cmd_id == XRCID("LinkType2Wireless")) {
+            if (cmd_item.cmd_id == XRCID("LinkType2Wireless")) {
                 if (mi)
                     mi->GetMenu()->Remove(mi);
-                cmdtab[i].mi = NULL;
+                cmd_item.mi = NULL;
                 continue;
             }
 
 #endif
 #if !defined(VBAM_ENABLE_DEBUGGER)
 
-            if (cmdtab[i].cmd_id == XRCID("DebugGDBBreak") || cmdtab[i].cmd_id == XRCID("DebugGDBDisconnect") || cmdtab[i].cmd_id == XRCID("DebugGDBBreakOnLoad") || cmdtab[i].cmd_id == XRCID("DebugGDBPort"))
+            if (cmd_item.cmd_id == XRCID("DebugGDBBreak") || cmd_item.cmd_id == XRCID("DebugGDBDisconnect") || cmd_item.cmd_id == XRCID("DebugGDBBreakOnLoad") || cmd_item.cmd_id == XRCID("DebugGDBPort"))
             {
                 if (mi)
                 {
                     mi->GetMenu()->Enable(mi->GetId(), false);
                     //mi->GetMenu()->Remove(mi);
                 }
-                cmdtab[i].mi = NULL;
+                cmd_item.mi = NULL;
                 continue;
             }
 #endif  // !defined(VBAM_ENABLE_DEBUGGER)
 #if defined(NO_ONLINEUPDATES)
-            if (cmdtab[i].cmd_id == XRCID("UpdateEmu"))
+            if (cmd_item.cmd_id == XRCID("UpdateEmu"))
             {
                 if (mi)
                     mi->GetMenu()->Remove(mi);
-                cmdtab[i].mi = NULL;
+                cmd_item.mi = NULL;
                 continue;
             }
 #endif
@@ -1877,11 +1878,11 @@ bool MainFrame::BindControls()
 
                 // store checkable items
                 if (mi->IsCheckable()) {
-                    checkable_mi_t cmi = { cmdtab[i].cmd_id, mi, 0, 0 };
+                    checkable_mi_t cmi = { cmd_item.cmd_id, mi, 0, 0 };
                     checkable_mi.push_back(cmi);
 
                     for (const config::Option& option : config::Option::All()) {
-                        if (cmdtab[i].cmd == option.command()) {
+                        if (cmd_item.cmd == option.command()) {
                             if (option.is_int()) {
                                 MenuOptionIntMask(
                                     option.command(), option.GetInt(), (1 << 0));

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -41,6 +41,7 @@
 #include "core/gba/gbaRtc.h"
 #include "core/gba/gbaSound.h"
 #include "wx/background-input.h"
+#include "wx/config/cmdtab.h"
 #include "wx/config/emulated-gamepad.h"
 #include "wx/config/option-id.h"
 #include "wx/config/option-proxy.h"

--- a/src/wx/sys.cpp
+++ b/src/wx/sys.cpp
@@ -11,6 +11,7 @@
 #include "core/gba/gbaGlobals.h"
 #include "core/gba/gbaSound.h"
 #include "wx/audio/audio.h"
+#include "wx/config/cmdtab.h"
 #include "wx/config/emulated-gamepad.h"
 #include "wx/config/option-proxy.h"
 #include "wx/wxvbam.h"

--- a/src/wx/widgets/client-data.h
+++ b/src/wx/widgets/client-data.h
@@ -4,6 +4,7 @@
 #include <cassert>
 
 #include <wx/clntdata.h>
+#include <wx/ctrlsub.h>
 #include <wx/window.h>
 
 namespace widgets {
@@ -15,6 +16,13 @@ public:
     // Returns the data stored in the ClientData object.
     static const T& From(wxWindow* window) {
         wxClientData* data = window->GetClientObject();
+        assert(data);
+        return static_cast<ClientData<T>*>(data)->data();
+    }
+
+    // Returns the data stored in the ClientData object for a container.
+    static const T& From(wxItemContainer* container, size_t index) {
+        wxClientData* data = container->GetClientObject(index);
         assert(data);
         return static_cast<ClientData<T>*>(data)->data();
     }

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -34,6 +34,7 @@
 #include "core/gba/gbaSound.h"
 #include "wx/builtin-over.h"
 #include "wx/builtin-xrc.h"
+#include "wx/config/cmdtab.h"
 #include "wx/config/emulated-gamepad.h"
 #include "wx/config/option-proxy.h"
 #include "wx/config/option.h"
@@ -163,14 +164,6 @@ IMPLEMENT_DYNAMIC_CLASS(MainFrame, wxFrame)
 #ifndef NO_ONLINEUPDATES
 #include "autoupdater/autoupdater.h"
 #endif // NO_ONLINEUPDATES
-
-// Initializer for struct cmditem
-cmditem new_cmditem(const wxString cmd, const wxString name, int cmd_id,
-                    int mask_flags, wxMenuItem* mi)
-{
-    struct cmditem tmp = {cmd, name, cmd_id, mask_flags, mi};
-    return tmp;
-}
 
 // generate config file path
 static void get_config_path(wxPathList& path, bool exists = true)
@@ -755,8 +748,9 @@ bool wxvbamApp::OnCmdLineParsed(wxCmdLineParser& cl)
         }
 
         wxPrintf(_("The commands available for the Keyboard/* option are:\n\n"));
-        for (int i = 0; i < ncmds; i++)
-            wxPrintf(wxT("%s (%s)\n"), cmdtab[i].cmd.c_str(), cmdtab[i].name.c_str());
+        for (const cmditem& cmd_item : cmdtab) {
+            wxPrintf("%s (%s)\n", cmd_item.cmd.c_str(), cmd_item.name.c_str());
+        }
 
         console_mode = true;
         return true;
@@ -1049,9 +1043,11 @@ wxString MainFrame::GetGamePath(wxString path)
 
 void MainFrame::enable_menus()
 {
-    for (int i = 0; i < ncmds; i++)
-        if (cmdtab[i].mask_flags && cmdtab[i].mi)
-            cmdtab[i].mi->Enable((cmdtab[i].mask_flags & cmd_enable) != 0);
+    for (const cmditem& cmd_item : cmdtab) {
+        if (cmd_item.mask_flags && cmd_item.mi) {
+            cmd_item.mi->Enable((cmd_item.mask_flags & cmd_enable) != 0);
+        }
+    }
 
     if (cmd_enable & CMDEN_SAVST)
         for (int i = 0; i < 10; i++)
@@ -1179,11 +1175,11 @@ void MainFrame::ResetRecentAccelerators() {
 }
 
 void MainFrame::ResetMenuAccelerators() {
-    for (int i = 0; i < ncmds; i++) {
-        if (!cmdtab[i].mi) {
+    for (const cmditem& cmd_item : cmdtab) {
+        if (!cmd_item.mi) {
             continue;
         }
-        ResetMenuItemAccelerator(cmdtab[i].mi);
+        ResetMenuItemAccelerator(cmd_item.mi);
     }
     ResetRecentAccelerators();
 }

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -164,33 +164,6 @@ DECLARE_APP(wxvbamApp);
     }                                                      \
     void MainFrame::Do##n()
 
-// here are those conditions
-enum { CMDEN_GB = (1 << 0), // GB ROM loaded
-    CMDEN_GBA = (1 << 1), // GBA ROM loaded
-    // the rest imply the above, unless:
-    //   _ANY -> does not imply either
-    //   _GBA -> only implies GBA
-    CMDEN_REWIND = (1 << 2), // rewind states available
-    CMDEN_SREC = (1 << 3), // sound recording in progress
-    CMDEN_NSREC = (1 << 4), // no sound recording
-    CMDEN_VREC = (1 << 5), // video recording
-    CMDEN_NVREC = (1 << 6), // no video recording
-    CMDEN_GREC = (1 << 7), // game recording
-    CMDEN_NGREC = (1 << 8), // no game recording
-    CMDEN_GPLAY = (1 << 9), // game playback
-    CMDEN_NGPLAY = (1 << 10), // no game playback
-    CMDEN_SAVST = (1 << 11), // any save states
-    CMDEN_GDB = (1 << 12), // gdb connected
-    CMDEN_NGDB_GBA = (1 << 13), // gdb not connected
-    CMDEN_NGDB_ANY = (1 << 14), // gdb not connected
-    CMDEN_NREC_ANY = (1 << 15), // not a/v recording
-    CMDEN_LINK_ANY = (1 << 16), // link enabled
-
-    CMDEN_NEVER = (1 << 31) // never (for NOOP)
-};
-#define ONLOAD_CMDEN (CMDEN_NSREC | CMDEN_NVREC | CMDEN_NGREC | CMDEN_NGPLAY)
-#define UNLOAD_CMDEN_KEEP (CMDEN_NGDB_ANY | CMDEN_NREC_ANY | CMDEN_LINK_ANY)
-
 struct checkable_mi_t {
     int cmd;
     wxMenuItem* mi;
@@ -609,25 +582,6 @@ private:
 
 // wxString version of OSD message
 void systemScreenMessage(const wxString& msg);
-
-// List of all commands with their descriptions
-// sorted by cmd field for binary searching
-// filled in by copy-events.cmake
-extern struct cmditem {
-    const wxString cmd, name;
-    int cmd_id;
-    int mask_flags; // if non-0, one of the flags must be turned on in win
-    // to enable this command
-    wxMenuItem* mi; // the menu item to invoke command, if present
-} cmdtab[];
-extern const int ncmds;
-
-// Initializer for struct cmditem
-cmditem new_cmditem(const wxString cmd = wxT(""), const wxString name = wxT(""),
-                    int cmd_id = 0, int mask_flags = 0, wxMenuItem* mi = NULL);
-
-// for binary search
-extern bool cmditem_lt(const struct cmditem& cmd1, const struct cmditem& cmd2);
 
 #include "wx/rpi.h"
 #include <wx/dynlib.h>

--- a/src/wx/xrc/AccelConfig.xrc
+++ b/src/wx/xrc/AccelConfig.xrc
@@ -2,49 +2,58 @@
 <resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">
   <object class="wxDialog" name="AccelConfig">
     <title>Key Shortcuts</title>
+    <style>wxRESIZE_BORDER</style>
     <object class="wxBoxSizer">
+      <orient>wxVERTICAL</orient>
       <flag>wxEXPAND</flag>
       <object class="sizeritem">
+        <option>1</option>
+        <flag>wxEXPAND</flag>
         <object class="wxFlexGridSizer">
+          <cols>3</cols>
+          <rows>2</rows>
+          <growablerows>0</growablerows>
+          <growablecols>0</growablecols>
           <object class="sizeritem">
+            <flag>wxEXPAND</flag>
             <object class="wxBoxSizer">
+              <orient>wxVERTICAL</orient>
+              <flag>wxEXPAND</flag>
               <object class="sizeritem">
+                <flag>wxALL</flag>
+                <border>5</border>
                 <object class="wxStaticText">
                   <label>Co_mmands:</label>
                 </object>
-                <flag>wxALL</flag>
-                <border>5</border>
               </object>
               <object class="sizeritem">
-                <object class="wxTreeCtrl" name="Commands">
-                  <style>wxTR_HAS_BUTTONS|wxTR_NO_LINES|wxTR_FULL_ROW_HIGHLIGHT|wxTR_HIDE_ROOT</style>
-                  <size>300,300</size>
-                </object>
-                <flag>wxALL|wxEXPAND</flag>
-                <border>5</border>
-              </object>
-              <orient>wxVERTICAL</orient>
-            </object>
-            <flag>wxEXPAND</flag>
-          </object>
-          <object class="sizeritem">
-            <object class="wxBoxSizer">
-              <object class="sizeritem">
-                <object class="wxStaticText">
-                  <label>Current Keys:</label>
-                </object>
-                <flag>wxALL</flag>
-                <border>5</border>
-              </object>
-              <object class="sizeritem">
-                <object class="wxListBox" name="Current"/>
                 <option>1</option>
                 <flag>wxALL|wxEXPAND</flag>
                 <border>5</border>
+                <object class="wxTreeCtrl" name="Commands">
+                  <style>wxTR_HAS_BUTTONS|wxTR_NO_LINES|wxTR_FULL_ROW_HIGHLIGHT|wxTR_HIDE_ROOT</style>
+                </object>
               </object>
-              <orient>wxVERTICAL</orient>
             </object>
+          </object>
+          <object class="sizeritem">
             <flag>wxEXPAND</flag>
+            <object class="wxBoxSizer">
+              <orient>wxVERTICAL</orient>
+              <object class="sizeritem">
+                <flag>wxALL</flag>
+                <border>5</border>
+                <object class="wxStaticText">
+                  <label>Current Keys:</label>
+                </object>
+              </object>
+              <object class="sizeritem">
+                <option>1</option>
+                <flag>wxALL|wxEXPAND</flag>
+                <border>5</border>
+                <object class="wxListBox" name="Current"/>
+              </object>
+            </object>
           </object>
           <object class="sizeritem">
             <object class="wxBoxSizer">
@@ -73,9 +82,11 @@
             </object>
             <flag>wxEXPAND</flag>
           </object>
-          <cols>3</cols>
           <object class="sizeritem">
+            <flag>wxALL</flag>
+            <border>5</border>
             <object class="wxBoxSizer">
+              <orient>wxVERTICAL</orient>
               <object class="sizeritem">
                 <object class="wxStaticText">
                   <label>Currently assigned to:</label>
@@ -84,19 +95,16 @@
               <object class="sizeritem">
                 <object class="wxStaticText" name="AlreadyThere"/>
               </object>
-              <orient>wxVERTICAL</orient>
             </object>
-            <flag>wxALL</flag>
-            <border>5</border>
           </object>
           <object class="sizeritem">
             <object class="wxBoxSizer">
               <object class="sizeritem">
+                <flag>wxALL</flag>
+                <border>5</border>
                 <object class="wxStaticText">
                   <label>Shortcut Key:</label>
                 </object>
-                <flag>wxALL</flag>
-                <border>5</border>
               </object>
               <object class="sizeritem">
                 <object class="UserInputCtrl" name="Shortcut" />
@@ -110,6 +118,8 @@
         </object>
       </object>
       <object class="sizeritem">
+        <flag>wxALL|wxEXPAND</flag>
+        <border>5</border>
         <object class="wxStdDialogButtonSizer">
           <object class="button">
             <object class="wxButton" name="wxID_OK"/>
@@ -118,8 +128,6 @@
             <object class="wxButton" name="wxID_CANCEL"/>
           </object>
         </object>
-        <flag>wxALL|wxEXPAND</flag>
-        <border>5</border>
       </object>
     </object>
   </object>


### PR DESCRIPTION
* Moves cmdtab to config/. This removes the dependency on the wxvbam.h header from the config/ directory.
* Fixes a number of issues in the shortcuts configuration window:
  * The "Remove" command was not working properly due to an incorrect refactor.
  * The window is now fully expandable.