### PR TITLE
[UserInput] Only process shortcut commands once

### DIFF
--- a/src/wx/widgets/user-input-ctrl.h
+++ b/src/wx/widgets/user-input-ctrl.h
@@ -61,7 +61,7 @@ public:
 
 private:
     // Event handler.
-    void OnUserInputUp(widgets::UserInputEvent& event);
+    void OnUserInput(widgets::UserInputEvent& event);
 
     // Updates the text in the control to reflect the current inputs.
     void UpdateText();
@@ -71,10 +71,6 @@ private:
     // The last time the control was focused. This is used to ignore events sent
     // very shortly after activation.
     wxLongLong last_focus_time_ = 0;
-
-    // Set to true after one input has been received. This is used to ignore
-    // subsequent events until the control is focused again.
-    bool is_navigating_away_ = false;
 
     std::unordered_set<config::UserInput> inputs_;
 };

--- a/src/wx/widgets/user-input-event.h
+++ b/src/wx/widgets/user-input-event.h
@@ -2,6 +2,9 @@
 #define WX_WIDGETS_USER_INPUT_EVENT_H_
 
 #include <unordered_set>
+#include <vector>
+
+#include <optional.hpp>
 
 #include <wx/clntdata.h>
 #include <wx/event.h>
@@ -10,20 +13,43 @@
 
 namespace widgets {
 
-// Event fired when a user input is pressed or released. The event contains the
-// user input that was pressed or released.
+// Event fired when a set of user input are pressed or released. The event
+// contains the set of user input that were pressed or released. The order
+// in the vector matters, this is the order in which the inputs were pressed or
+// released.
 class UserInputEvent final : public wxEvent {
 public:
-    UserInputEvent(const config::UserInput& input, bool pressed);
+    // Data for the event. Contains the user input and whether it was pressed or
+    // released.
+    struct Data {
+        const config::UserInput input;
+        const bool pressed;
+
+        Data(config::UserInput input, bool pressed) : input(input), pressed(pressed){};
+    };
+
+    UserInputEvent(std::vector<Data> event_data);
     virtual ~UserInputEvent() override = default;
+
+    // Disable copy and copy assignment.
+    UserInputEvent(const UserInputEvent&) = delete;
+    UserInputEvent& operator=(const UserInputEvent&) = delete;
+
+    // Returns the first pressed input, if any.
+    nonstd::optional<config::UserInput> FirstReleasedInput() const;
+
+    // Mark `event_data` as processed and returns the new event filter. This is
+    // meant to be used with FilterEvent() to process global shortcuts before
+    // sending the event to the next handler.
+    int FilterProcessedInput(const config::UserInput& user_input);
 
     // wxEvent implementation.
     wxEvent* Clone() const override;
 
-    const config::UserInput& input() const { return input_; }
+    const std::vector<Data>& data() const { return data_; }
 
 private:
-    const config::UserInput input_;
+    std::vector<Data> data_;
 };
 
 // Object that is used to fire user input events when a key is pressed or
@@ -59,9 +85,7 @@ private:
 
 }  // namespace widgets
 
-// Fired when a user input is pressed.
-wxDECLARE_EVENT(VBAM_EVT_USER_INPUT_DOWN, widgets::UserInputEvent);
-// Fired when a user input is released.
-wxDECLARE_EVENT(VBAM_EVT_USER_INPUT_UP, widgets::UserInputEvent);
+// Fired when a set of user inputs are pressed or released.
+wxDECLARE_EVENT(VBAM_EVT_USER_INPUT, widgets::UserInputEvent);
 
 #endif  // WX_WIDGETS_USER_INPUT_EVENT_H_

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -530,8 +530,7 @@ protected:
 
     bool paused;
     void OnIdle(wxIdleEvent&);
-    void OnUserInputDown(widgets::UserInputEvent& event);
-    void OnUserInputUp(widgets::UserInputEvent& event);
+    void OnUserInput(widgets::UserInputEvent& event);
     void PaintEv(wxPaintEvent& ev);
     void EraseBackground(wxEraseEvent& ev);
     void OnSize(wxSizeEvent& ev);


### PR DESCRIPTION
This modifies the UserInputEvent class to fire a vector of events at once, rather than individual down/up events for each UserInput. This simplifies handling of the global event filter and prevents the firing of spurious events.

This also fixes a bug when pressing "Ctrl+1" would trigger the command for both the command assigned to "Ctrl+1" and to "1". Now, only the "Ctrl+1" command will fire.