### PR TITLE
[UserInput] Filter key events globally

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -73,6 +73,7 @@ set(VBAM_WX_COMMON
     widgets/checkedlistctrl.h
     widgets/client-data.h
     widgets/dpi-support.h
+    widgets/event-handler-provider.h
     widgets/group-check-box.cpp
     widgets/group-check-box.h
     widgets/keep-on-top-styler.cpp
@@ -87,6 +88,8 @@ set(VBAM_WX_COMMON
     widgets/user-input-event.h
     widgets/sdl-poller.cpp
     widgets/sdl-poller.h
+    widgets/shortcut-menu-bar.cpp
+    widgets/shortcut-menu-bar.h
     widgets/utils.cpp
     widgets/utils.h
     widgets/webupdatedef.h

--- a/src/wx/config/user-input.cpp
+++ b/src/wx/config/user-input.cpp
@@ -230,12 +230,16 @@ JoyId JoyId::Invalid() {
     return JoyId(kInvalidSdlIndex);
 }
 
-wxString JoyId::ToString() const {
+wxString JoyId::ToConfigString() const {
     return wxString::Format("Joy%d", sdl_index_ + 1);
 }
 
-wxString JoyInput::ToString() const {
-    const wxString joy_string = joy_.ToString();
+wxString JoyId::ToLocalizedString() const {
+    return wxString::Format(_("Joystick %d"), sdl_index_ + 1);
+}
+
+wxString JoyInput::ToConfigString() const {
+    const wxString joy_string = joy_.ToConfigString();
     switch (control_) {
         case JoyControl::AxisPlus:
             return wxString::Format("%s-Axis%d+", joy_string, control_index_);
@@ -251,6 +255,30 @@ wxString JoyInput::ToString() const {
             return wxString::Format("%s-Hat%dW", joy_string, control_index_);
         case JoyControl::HatEast:
             return wxString::Format("%s-Hat%dE", joy_string, control_index_);
+    }
+
+    // Unreachable.
+    assert(false);
+    return wxEmptyString;
+}
+
+wxString JoyInput::ToLocalizedString() const {
+    const wxString joy_string = joy_.ToLocalizedString();
+    switch (control_) {
+        case JoyControl::AxisPlus:
+            return wxString::Format(_("%s: Axis %d+"), joy_string, control_index_);
+        case JoyControl::AxisMinus:
+            return wxString::Format(_("%s: Axis %d-"), joy_string, control_index_);
+        case JoyControl::Button:
+            return wxString::Format(_("%s: Button %d"), joy_string, control_index_);
+        case JoyControl::HatNorth:
+            return wxString::Format(_("%s: Hat %d North"), joy_string, control_index_);
+        case JoyControl::HatSouth:
+            return wxString::Format(_("%s: Hat %d South"), joy_string, control_index_);
+        case JoyControl::HatWest:
+            return wxString::Format(_("%s: Hat %d West"), joy_string, control_index_);
+        case JoyControl::HatEast:
+            return wxString::Format(_("%s: Hat %d East"), joy_string, control_index_);
     }
 
     // Unreachable.
@@ -291,10 +319,6 @@ wxString KeyboardInput::ToLocalizedString() const {
     }
 
     const wxString accel_string = wxAcceleratorEntry(mod_, key_).ToRawString().MakeUpper();
-    if (!accel_string.IsAscii()) {
-        // Unicode handling.
-        return wxString::Format("%d:%d", key_, mod_);
-    }
     return accel_string;
 }
 
@@ -336,7 +360,7 @@ wxString UserInput::ToConfigString() const {
         case Device::Keyboard:
             return keyboard_input().ToConfigString();
         case Device::Joystick:
-            return joy_input().ToString();
+            return joy_input().ToConfigString();
     }
 
     // Unreachable.
@@ -351,7 +375,7 @@ wxString UserInput::ToLocalizedString() const {
         case Device::Keyboard:
             return keyboard_input().ToLocalizedString();
         case Device::Joystick:
-            return joy_input().ToString();
+            return joy_input().ToLocalizedString();
     }
 
     // Unreachable.

--- a/src/wx/config/user-input.h
+++ b/src/wx/config/user-input.h
@@ -70,7 +70,8 @@ public:
     constexpr explicit JoyId(int sdl_index) : sdl_index_(sdl_index){};
     ~JoyId() = default;
 
-    wxString ToString() const;
+    wxString ToConfigString() const;
+    wxString ToLocalizedString() const;
 
     constexpr bool operator==(const JoyId& other) const { return sdl_index_ == other.sdl_index_; }
     constexpr bool operator!=(const JoyId& other) const { return sdl_index_ != other.sdl_index_; }
@@ -100,7 +101,8 @@ public:
     constexpr JoyControl control() const { return control_; }
     constexpr uint8_t control_index() const { return control_index_; }
 
-    wxString ToString() const;
+    wxString ToConfigString() const;
+    wxString ToLocalizedString() const;
 
     constexpr bool operator==(const JoyInput& other) const {
         return joy_ == other.joy_ && control_ == other.control_ &&

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -165,7 +165,6 @@ GameArea::GameArea()
                        config::OptionID::kSoundBuffers, config::OptionID::kSoundDSoundHWAccel,
                        config::OptionID::kSoundUpmix},
                       [&](config::Option*) { schedule_audio_restart_ = true; }) {
-    this->SetClientObject(new widgets::UserInputEventSender(this));
     SetSizer(new wxBoxSizer(wxVERTICAL));
     // all renderers prefer 32-bit
     // well, "simple" prefers 24-bit, but that's not available for filters
@@ -1461,7 +1460,6 @@ DrawingPanel::DrawingPanel(wxWindow* parent, int _width, int _height)
     , wxPanel(parent, wxID_ANY, wxPoint(0, 0), parent->GetClientSize(),
           wxFULL_REPAINT_ON_RESIZE | wxWANTS_CHARS)
 {
-    this->SetClientObject(new widgets::UserInputEventSender(this));
 }
 
 void DrawingPanelBase::DrawingPanelInit()
@@ -2193,7 +2191,6 @@ GLDrawingPanel::GLDrawingPanel(wxWindow* parent, int _width, int _height)
     , wxglc(parent, wxID_ANY, glopts, wxPoint(0, 0), parent->GetClientSize(),
           wxFULL_REPAINT_ON_RESIZE | wxWANTS_CHARS)
 {
-    this->SetClientObject(new widgets::UserInputEventSender(this));
     widgets::RequestHighResolutionOpenGlSurfaceForWindow(this);
     SetContext();
 }

--- a/src/wx/viewsupt.h
+++ b/src/wx/viewsupt.h
@@ -1,6 +1,8 @@
 #ifndef VBAM_WX_VIEWSUPT_H_
 #define VBAM_WX_VIEWSUPT_H_
 
+#include <cstdint>
+
 #include <wx/wx.h>
 #include <wx/window.h>
 #include <wx/image.h>
@@ -14,7 +16,7 @@
 #include <wx/stattext.h>
 #include <wx/checkbox.h>
 
-#include <stdint.h> // for uint32_t
+#include "wx/widgets/user-input-event.h"
 
 // avoid exporting too much stuff
 namespace Viewers {
@@ -218,7 +220,7 @@ protected:
     int addrlen;
 
     void MouseEvent(wxMouseEvent& ev);
-    void KeyEvent(wxKeyEvent& ev);
+    void KeyEvent(widgets::UserInputEvent& ev);
     // the subwidgets
     wxPanel disp;
     wxScrollBar sb;

--- a/src/wx/widgets/event-handler-provider.h
+++ b/src/wx/widgets/event-handler-provider.h
@@ -1,0 +1,21 @@
+#ifndef VBAM_WX_WIDGETS_EVENT_HANDLER_PROVIDER_H_
+#define VBAM_WX_WIDGETS_EVENT_HANDLER_PROVIDER_H_
+
+// Forward declaration.
+class wxEvtHandler;
+
+namespace widgets {
+
+// Abstract interface to provide the currently active event handler to use for
+// user input events.
+class EventHandlerProvider {
+public:
+    virtual ~EventHandlerProvider() = default;
+
+    // Returns the currently active event handler to use for user input events.
+    virtual wxEvtHandler* event_handler() = 0;
+};
+
+}  // namespace widgets
+
+#endif  // VBAM_WX_WIDGETS_EVENT_HANDLER_PROVIDER_H_

--- a/src/wx/widgets/sdl-poller.cpp
+++ b/src/wx/widgets/sdl-poller.cpp
@@ -300,12 +300,14 @@ void JoyState::Notify() {
     SetRumble(rumbling_);
 }
 
-SdlPoller::SdlPoller(const EventHandlerProvider handler_provider)
+SdlPoller::SdlPoller(EventHandlerProvider* const handler_provider)
     : enable_game_controller_(OPTION(kSDLGameControllerMode)),
       handler_provider_(handler_provider),
       game_controller_enabled_observer_(
           config::OptionID::kSDLGameControllerMode,
           [this](config::Option* option) { ReconnectControllers(option->GetBool()); }) {
+    assert(handler_provider);
+
     wxTimer::Start(50);
     SDL_Init(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_EVENTS);
     SDL_GameControllerEventState(SDL_ENABLE);
@@ -406,7 +408,7 @@ void SdlPoller::Notify() {
         }
 
         if (!event_data.empty()) {
-            wxEvtHandler* handler = handler_provider_();
+            wxEvtHandler* handler = handler_provider_->event_handler();
             if (handler) {
                 handler->QueueEvent(new UserInputEvent(std::move(event_data)));
             }

--- a/src/wx/widgets/sdl-poller.h
+++ b/src/wx/widgets/sdl-poller.h
@@ -1,7 +1,6 @@
 #ifndef WX_WIDGETS_SDL_POLLER_H_
 #define WX_WIDGETS_SDL_POLLER_H_
 
-#include <functional>
 #include <map>
 
 #include <wx/timer.h>
@@ -9,6 +8,7 @@
 #include <SDL.h>
 
 #include "wx/config/option-observer.h"
+#include "wx/widgets/event-handler-provider.h"
 
 // Forward declarations.
 class wxEvtHandler;
@@ -18,16 +18,13 @@ namespace widgets {
 // Forward declaration.
 class JoyState;
 
-// Provider for the event handler to send the events to.
-using EventHandlerProvider = std::function<wxEvtHandler*()>;
-
 // The SDL worker is responsible for handling SDL events and firing the
 // appropriate `UserInputEvent` for joysticks.
 // It is used to fire `UserInputEvent` for joysticks. This class should be kept
 // as a singleton owned by the application object.
 class SdlPoller final : public wxTimer {
 public:
-    explicit SdlPoller(const EventHandlerProvider handler_provider);
+    explicit SdlPoller(EventHandlerProvider* const handler_provider);
     ~SdlPoller() final;
 
     // Disable copy and copy assignment.
@@ -59,7 +56,7 @@ private:
     bool enable_game_controller_ = false;
 
     // The provider of event handlers to send the events to.
-    const EventHandlerProvider handler_provider_;
+    EventHandlerProvider* const handler_provider_;
 
     // Observer for the game controller enabled option.
     const config::OptionsObserver game_controller_enabled_observer_;

--- a/src/wx/widgets/shortcut-menu-bar.cpp
+++ b/src/wx/widgets/shortcut-menu-bar.cpp
@@ -1,0 +1,14 @@
+#include "wx/widgets/shortcut-menu-bar.h"
+
+#include <wx/accel.h>
+
+namespace widgets {
+
+void ShortcutMenuBar::SetAcceleratorTable(const wxAcceleratorTable& /*accel*/) {
+    // Do nothing. We don't want to set up accelerators on the menu bar.
+    wxMenuBar::SetAcceleratorTable(wxNullAcceleratorTable);
+}
+
+wxIMPLEMENT_DYNAMIC_CLASS(ShortcutMenuBar, wxMenuBar);
+
+}  // namespace widgets

--- a/src/wx/widgets/shortcut-menu-bar.h
+++ b/src/wx/widgets/shortcut-menu-bar.h
@@ -1,0 +1,23 @@
+#ifndef VBAM_WIDGETS_SHORTCUT_MENU_BAR_H_
+#define VBAM_WIDGETS_SHORTCUT_MENU_BAR_H_
+
+#include <wx/menu.h>
+
+namespace widgets {
+
+// A menu bar with no accelerator table. This is used to prevent the menu bar
+// from stealing keyboard shortcuts from the main window.
+class ShortcutMenuBar : public wxMenuBar {
+public:
+    ShortcutMenuBar() = default;
+    ~ShortcutMenuBar() override = default;
+
+    // wxMenuBar implementation.
+    void SetAcceleratorTable(const wxAcceleratorTable& accel) override;
+
+    wxDECLARE_DYNAMIC_CLASS(ShortcutMenuBar);
+};
+
+}  // namespace widgets
+
+#endif  // VBAM_WIDGETS_SHORTCUT_MENU_BAR_H_

--- a/src/wx/widgets/user-input-ctrl.cpp
+++ b/src/wx/widgets/user-input-ctrl.cpp
@@ -30,7 +30,6 @@ bool UserInputCtrl::Create(wxWindow* parent,
                            const wxSize& size,
                            long style,
                            const wxString& name) {
-    this->SetClientObject(new UserInputEventSender(this));
     this->Bind(VBAM_EVT_USER_INPUT, &UserInputCtrl::OnUserInput, this);
     this->Bind(wxEVT_SET_FOCUS, [this](wxFocusEvent& event) {
         last_focus_time_ = wxGetUTCTimeMillis();

--- a/src/wx/widgets/user-input-event.h
+++ b/src/wx/widgets/user-input-event.h
@@ -10,6 +10,7 @@
 #include <wx/event.h>
 
 #include "wx/config/user-input.h"
+#include "wx/widgets/event-handler-provider.h"
 
 namespace widgets {
 
@@ -53,34 +54,32 @@ private:
 };
 
 // Object that is used to fire user input events when a key is pressed or
-// released. To use this object, attach it to a wxWindow and listen for
-// the VBAM_EVT_USER_INPUT_DOWN and VBAM_EVT_USER_INPUT_UP events.
-class UserInputEventSender final : public wxClientData {
+// released. This class should be kept as a singleton owned by the application
+// object. It is meant to be used in the FilterEvent() method of the app.
+class KeyboardInputSender final : public wxClientData {
 public:
-    // `window` must not be nullptr. Will assert otherwise.
-    // `window` must outlive this object.
-    explicit UserInputEventSender(wxWindow* const window);
-    ~UserInputEventSender() override;
+    explicit KeyboardInputSender(EventHandlerProvider* const handler_provider);
+    ~KeyboardInputSender() override;
 
     // Disable copy and copy assignment.
-    UserInputEventSender(const UserInputEventSender&) = delete;
-    UserInputEventSender& operator=(const UserInputEventSender&) = delete;
+    KeyboardInputSender(const KeyboardInputSender&) = delete;
+    KeyboardInputSender& operator=(const KeyboardInputSender&) = delete;
+
+    // Processes the provided key event and sends the appropriate user input
+    // event to the current event handler.
+    void ProcessKeyEvent(wxKeyEvent& event);
 
 private:
     // Keyboard event handlers.
     void OnKeyDown(wxKeyEvent& event);
     void OnKeyUp(wxKeyEvent& event);
 
-    // Resets the internal state. Called on focus in/out.
-    void Reset(wxFocusEvent& event);
-
     std::unordered_set<wxKeyCode> active_keys_;
     std::unordered_set<wxKeyModifier> active_mods_;
     std::unordered_set<config::KeyboardInput> active_mod_inputs_;
 
-    // The wxWindow this object is attached to.
-    // Must outlive this object.
-    wxWindow* const window_;
+    // The provider of event handlers to send the events to.
+    EventHandlerProvider* const handler_provider_;
 };
 
 }  // namespace widgets

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -18,6 +18,7 @@
 #include "wx/config/option.h"
 #include "wx/dialogs/base-dialog.h"
 #include "wx/widgets/dpi-support.h"
+#include "wx/widgets/event-handler-provider.h"
 #include "wx/widgets/keep-on-top-styler.h"
 #include "wx/widgets/sdl-poller.h"
 #include "wx/widgets/user-input-event.h"
@@ -59,7 +60,7 @@ inline std::string ToString(const wxChar* aString)
 
 class MainFrame;
 
-class wxvbamApp final : public wxApp {
+class wxvbamApp final : public wxApp, public widgets::EventHandlerProvider {
 public:
     wxvbamApp();
 
@@ -133,8 +134,8 @@ protected:
     int console_status = 0;
 
 private:
-    // Returns the currently active event handler to use for user input events.
-    wxEvtHandler* GetJoyEventHandler();
+    // EventHandlerProvider implementation.
+    wxEvtHandler* event_handler() override;
 
     config::Bindings bindings_;
     config::EmulatedGamepad emulated_gamepad_;
@@ -143,6 +144,7 @@ private:
     char* home = nullptr;
 
     widgets::SdlPoller sdl_poller_;
+    widgets::KeyboardInputSender keyboard_input_sender_;
 
     // Main configuration file.
     wxFileName config_file_;
@@ -200,14 +202,14 @@ public:
     void GetMenuOptionBool(const wxString& menuName, bool* field);
     void SetMenuOption(const wxString& menuName, bool value);
 
-    int FilterEvent(wxEvent& event);
-
     GameArea* GetPanel()
     {
         return panel;
     }
 
     wxString GetGamePath(wxString path);
+
+    bool CanProcessShortcuts() const { return !menus_opened && !dialog_opened; }
 
     // wxMSW pauses the game for menu popups and modal dialogs, but wxGTK
     // does not.  It's probably desirable to pause the game.  To do this for

--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 <resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">
-  <object class="wxMenuBar" name="MainMenu">
+  <object class="wxMenuBar" name="MainMenu" subclass="ShortcutMenuBar">
     <object class="wxMenu">
       <label>_File</label>
       <object class="wxMenuItem" name="wxID_OPEN">


### PR DESCRIPTION
This changes key events to be filtered globally by the application, preventing any widget from accessing them. Widgets should instead use the new VBAM_USER_INPUT_EVENT event.

In addition, this explicitly removes accelerator handling from wxWidgets main menu, allowing us to populate joystick options in the menu without firing wxWidgets assertions.