### PR TITLE
[CI] Remove workaround for MSVC CI

### DIFF
--- a/.github/workflows/visual-studio-build.yml
+++ b/.github/workflows/visual-studio-build.yml
@@ -37,54 +37,6 @@ jobs:
             msvc_arch: amd64_arm64
     runs-on: windows-latest
     steps:
-      # TODO: Remove these 2 steps after May 13, 2024.
-      # See https://github.com/actions/runner-images/issues/9701 for details.
-      - name: Delete components
-        run: |
-          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-          $componentsToRemove= @(
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.ARM"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.ARM.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.ARM64"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.ARM64.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.x86.x64"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.x86.x64.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.ATL"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.ATL.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.ATL.ARM"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.ATL.ARM.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.ATL.ARM64"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.ATL.ARM64.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.MFC"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.MFC.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.MFC.ARM"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.MFC.ARM.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.MFC.ARM64"
-            "Microsoft.VisualStudio.Component.VC.14.38.17.8.MFC.ARM64.Spectre"
-          )
-          [string]$workloadArgs = $componentsToRemove | ForEach-Object {" --remove " +  $_}
-          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-          # should be run twice
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-
-      - name: Install components
-        run: |
-          Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-          $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
-          $componentsToAdd= @(
-            "Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64"
-            "Microsoft.VisualStudio.Component.VC.14.39.17.9.ARM64.Spectre"
-            "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
-            "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64.Spectre"
-          )
-          [string]$workloadArgs = $componentsToAdd | ForEach-Object {" --add " +  $_}
-          $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
-          # should be run twice
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-          $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
-
       - name: Checkout the code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Upstream GitHub actions now use a single toolchain version. Fixes #1297