### PR TITLE
Migrate vba-m.com links in .github folder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
   - type: markdown
     attributes:
       value: |
-            Please try the nightly build from: https://nightly.vba-m.com and factory resetting the emulator from the Help menu.
+            Please try the nightly build from: https://nightly.visualboyadvance-m.org and factory resetting the emulator from the Help menu.
             On Linux build master from source or use the edge snap.
             And last but not least, search for existing reports via the filters bar on the issues page.
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: VBA-M Forum
-    url: https://board.vba-m.com/
+    url: https://board.visualboyadvance-m.org/
     about: For general questions and support please join our forum or our
   - name: VBA-M IRC Channel
     url: https://web.libera.chat/#vba-m

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,7 +14,7 @@ body:
   - type: markdown
     attributes:
       value: |
-            Please try a nightly build from: https://nightly.vba-m.com to see if your idea has already been implemented.
+            Please try a nightly build from: https://nightly.visualboyadvance-m.org to see if your idea has already been implemented.
             On Linux build master from source or use the edge snap.
             And last but not least, search for existing requests via the filters bar on the issues page.
   - type: textarea


### PR DESCRIPTION
Update dead links from old domain `vba-m.com` to `visualboyadvance-m.org`