### PR TITLE
[FAudio] Always convert UTF-16 names

### DIFF
--- a/src/wx/config/strutils.cpp
+++ b/src/wx/config/strutils.cpp
@@ -1,6 +1,10 @@
 #include "wx/config/strutils.h"
 
+#include <cstdint>
+
 #include <wx/tokenzr.h>
+
+#include "core/base/check.h"
 
 namespace config {
 
@@ -35,6 +39,42 @@ wxArrayString str_split(const wxString& text, const wxString& sep, bool empty_to
 wxArrayString str_split_with_sep(const wxString& text, const wxString& sep)
 {
     return str_split(text, sep, true);
+}
+
+std::vector<uint8_t> utf16_to_utf8(const uint16_t* utf16) {
+    std::vector<uint8_t> out;
+    for (size_t i = 0; utf16[i]; i++) {
+        uint16_t c = utf16[i];
+        if (c < 0x80) {
+            out.push_back(c);
+        } else if (c < 0x800) {
+            out.push_back(0xC0 | (c >> 6));
+            out.push_back(0x80 | (c & 0x3F));
+        } else if (c < 0xD800 || c >= 0xE000) {
+            // Regular 3-byte UTF-8 character.
+            out.push_back(0xE0 | (c >> 12));
+            out.push_back(0x80 | ((c >> 6) & 0x3F));
+            out.push_back(0x80 | (c & 0x3F));
+        } else {
+            // Surrogate pair, construct the original code point.
+            const uint32_t high = c;
+
+            // The next code unit must be a low surrogate.
+            i++;
+            const uint32_t low = utf16[i];
+            VBAM_CHECK(low);
+            VBAM_CHECK(low >= 0xDC00 && low < 0xE000);
+
+            const uint32_t codepoint = 0x10000 + ((high & 0x3FF) << 10) + (low & 0x3FF);
+
+            // Convert to UTF-8.
+            out.push_back(0xF0 | (codepoint >> 18));
+            out.push_back(0x80 | ((codepoint >> 12) & 0x3F));
+            out.push_back(0x80 | ((codepoint >> 6) & 0x3F));
+            out.push_back(0x80 | (codepoint & 0x3F));
+        }
+    }
+    return out;
 }
 
 } // namespace config

--- a/src/wx/config/strutils.h
+++ b/src/wx/config/strutils.h
@@ -1,6 +1,9 @@
 #ifndef VBAM_WX_CONFIG_STRUTILS_H_
 #define VBAM_WX_CONFIG_STRUTILS_H_
 
+#include <cstdint>
+#include <vector>
+
 #include <wx/string.h>
 #include <wx/arrstr.h>
 
@@ -13,6 +16,10 @@ wxArrayString str_split(const wxString& text, const wxString& sep, bool empty_to
 // If "A,,,B" is the text and "," is sep, then
 // 'A', ',' and 'B' will be in the output.
 wxArrayString str_split_with_sep(const wxString& text, const wxString& sep);
+
+// Converts a null-terminated array of UTF-16 code units to a vector of UTF-8 code units.
+// This will assert if the input is not a valid UTF-16 string.
+std::vector<uint8_t> utf16_to_utf8(const uint16_t* utf16);
 
 } // namespace config
 


### PR DESCRIPTION
On Windows, wchar_t is 16 bits and represents UTF-16 code units. However, on other platforms, wchar_t is typically implemented as 32 bits to represent UTF-32 code units. In order to work around this problem, we always convert the string we get from FAudio, which is represented as UTF-16 code units, into UTF-8 and let wxString handle the conversion to its native type internally.