### PR TITLE
Disable dialog position save/restore on wxGTK

### DIFF
--- a/src/wx/dialogs/accel-config.cpp
+++ b/src/wx/dialogs/accel-config.cpp
@@ -177,6 +177,14 @@ AccelConfig::AccelConfig(wxWindow* parent,
     Bind(wxEVT_BUTTON, &AccelConfig::OnResetAll, this, XRCID("ResetAll"));
     Bind(wxEVT_TEXT, &AccelConfig::OnKeyInput, this, key_input_->GetId());
 
+#if !WX_RESIZE_DIALOGS
+    // On wxGTK, the dialog resizing is broken, so we need to set a fixed size.
+    SetWindowStyle(GetWindowStyle() & ~wxRESIZE_BORDER);
+    const wxSize dialog_size(800, 800);
+    SetMinSize(dialog_size);
+    SetMaxSize(dialog_size);
+#endif  // !WX_RESIZE_DIALOGS
+
     // And fit everything nicely.
     Fit();
 }

--- a/src/wx/dialogs/base-dialog.cpp
+++ b/src/wx/dialogs/base-dialog.cpp
@@ -38,15 +38,19 @@ private:
             return;
         }
 
+#if WX_RESIZE_DIALOGS
         const wxRect dialog_rect = this->Get()->GetRect();
         this->SaveValue("x", dialog_rect.x);
         this->SaveValue("y", dialog_rect.y);
         this->SaveValue("width", dialog_rect.width);
         this->SaveValue("height", dialog_rect.height);
+#endif  // WX_RESIZE_DIALOGS
     }
 
     bool Restore() override {
         dialog_shown_ = true;
+
+#if WX_RESIZE_DIALOGS
         wxRect dialog_rect(0, 0, 0, 0);
         if (!this->RestoreValue("x", &dialog_rect.x)) {
             return false;
@@ -62,6 +66,7 @@ private:
         };
 
         this->Get()->SetSize(dialog_rect);
+#endif  // WX_RESIZE_DIALOGS
         return true;
     }
 

--- a/src/wx/dialogs/base-dialog.h
+++ b/src/wx/dialogs/base-dialog.h
@@ -8,6 +8,13 @@
 
 #include "core/base/check.h"
 
+#if defined(__WXGTK__)
+// Moving and resizing dialogs does not work properly on wxGTK.
+#define WX_RESIZE_DIALOGS 0
+#else
+#define WX_RESIZE_DIALOGS 1
+#endif
+
 namespace dialogs {
 
 class BaseDialog : public wxDialog {


### PR DESCRIPTION
This is currently broken on Wayland, resulting in dialogs showing up in random locations.