### PR TITLE
Write shortcuts in the proper section

### DIFF
--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -416,11 +416,9 @@ void update_shortcut_opts() {
 
     // For keyboard shortcuts, it's easier to delete everything and start over.
     cfg->DeleteGroup("/Keyboard");
-    cfg->SetPath("/Keyboard");
     for (const auto& iter : wxGetApp().bindings()->GetKeyboardConfiguration()) {
         cfg->Write(iter.first, iter.second);
     }
-    cfg->SetPath("/");
 
     // For joypads, we just compare the strings.
     bool game_bindings_changed = false;

--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -1372,8 +1372,19 @@ int wxvbamApp::FilterEvent(wxEvent& event)
         return wxEventFilter::Event_Skip;
     }
 
-    // Queue the associated shortcut command.
-    wxCommandEvent* command_event = new wxCommandEvent(wxEVT_COMMAND_MENU_SELECTED, command_id);
+    // Find the associated checkable menu item (if any).
+    for (const cmditem& cmd_item : cmdtab) {
+        if (cmd_item.cmd_id == command_id) {
+            if (cmd_item.mi && cmd_item.mi->IsCheckable()) {
+                // Toggle the checkable menu item.
+                cmd_item.mi->Check(!cmd_item.mi->IsChecked());
+            }
+            break;
+        }
+    }
+
+    // Queue the associated shortcut command event.
+    wxCommandEvent* command_event = new wxCommandEvent(wxEVT_MENU, command_id);
     command_event->SetEventObject(this);
     frame->GetEventHandler()->QueueEvent(command_event);
 


### PR DESCRIPTION
Shortcuts were mistakenly written in `Keyboard/Keyboard` rather than in the `Keyboard` section.
In addition, this properly fixes toggling checkable menu item options via a shortcut.

Fixes #1334 