### PR TITLE
[dialogs] Display all controls in AccelConfig on Mac

### DIFF
--- a/src/wx/dialogs/accel-config.cpp
+++ b/src/wx/dialogs/accel-config.cpp
@@ -145,8 +145,10 @@ AccelConfig::AccelConfig(wxWindow* parent,
         PopulateTreeWithMenu(&command_to_item_id_, tree_, id, menu->GetMenu(i), recents,
                              menu->GetMenuLabelText(i) + '\n');
     }
-    tree_->ExpandAll();
     tree_->SelectItem(menu_id);
+
+    // Set a minimum size for the tree so the default dialog size is reasonable.
+    tree_->SetMinSize(wxSize(300, 300));
 
     int w, h;
     current_keys_->GetTextExtent("CTRL-ALT-SHIFT-ENTER", &w, &h);

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -97,7 +97,7 @@ public:
     bool pending_fullscreen;
 #if __WXMAC__
     // I suppose making this work will require tweaking the bundle
-    void MacOpenFile(const wxString& f)
+    void MacOpenFile(const wxString& f) override
     {
         pending_load = f;
     };

--- a/src/wx/xrc/AccelConfig.xrc
+++ b/src/wx/xrc/AccelConfig.xrc
@@ -2,7 +2,7 @@
 <resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">
   <object class="wxDialog" name="AccelConfig">
     <title>Key Shortcuts</title>
-    <style>wxRESIZE_BORDER</style>
+    <style>wxRESIZE_BORDER|wxCLOSE_BOX</style>
     <object class="wxBoxSizer">
       <orient>wxVERTICAL</orient>
       <flag>wxEXPAND</flag>
@@ -56,6 +56,7 @@
             </object>
           </object>
           <object class="sizeritem">
+            <flag>wxEXPAND</flag>
             <object class="wxBoxSizer">
               <object class="sizeritem">
                 <object class="wxButton" name="Assign">
@@ -80,7 +81,6 @@
               </object>
               <orient>wxVERTICAL</orient>
             </object>
-            <flag>wxEXPAND</flag>
           </object>
           <object class="sizeritem">
             <flag>wxALL</flag>
@@ -98,6 +98,7 @@
             </object>
           </object>
           <object class="sizeritem">
+            <flag>wxEXPAND</flag>
             <object class="wxBoxSizer">
               <object class="sizeritem">
                 <flag>wxALL</flag>
@@ -113,7 +114,6 @@
               </object>
               <orient>wxVERTICAL</orient>
             </object>
-            <flag>wxEXPAND</flag>
           </object>
         </object>
       </object>


### PR DESCRIPTION
Calling `ExpandAll()` on the `wxTreeCtrl` would cause it to display outside of its intended view, hiding other controls. Instead, this sets a minimum size for the tree control, so the default window size is reasonable.

Fixes #1348 