### PR TITLE
build: unpack XAudio2_7.dll at init, add to PATH

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -659,6 +659,20 @@ list(APPEND VBAM_LOCALIZABLE_FILES
     ${CMAKE_SOURCE_DIR}/src/core/gba/gbaLink.cpp
 )
 
+if(WIN32 AND (X86_64 OR X86_32) AND ENABLE_XAUDIO2)
+    if(NOT DEFINED XAUDIO_27_BIN_DIR)
+        set(XAUDIO_27_BIN_DIR ${CMAKE_SOURCE_DIR}/win32-deps/xaudio27-dll)
+    endif()
+
+    if(X86_64)
+        set(XAUDIO_27_DLL ${XAUDIO_27_BIN_DIR}/x64/XAudio2_7.dll)
+    elseif(X86_32)
+        set(XAUDIO_27_DLL ${XAUDIO_27_BIN_DIR}/x86/XAudio2_7.dll)
+    endif()
+
+    configure_file(audio/internal/xaudio27-dll-path.h.in ${CMAKE_BINARY_DIR}/xaudio27-dll-path.h)
+endif()
+
 if(APPLE)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
     set(CMAKE_INSTALL_RPATH "@loader_path/../Frameworks")

--- a/src/wx/audio/internal/xaudio27-dll-path.h.in
+++ b/src/wx/audio/internal/xaudio27-dll-path.h.in
@@ -1,0 +1,1 @@
+#define XAUDIO27_DLL_PATH "@XAUDIO_27_DLL@"

--- a/src/wx/audio/internal/xaudio27-dll-rc.h
+++ b/src/wx/audio/internal/xaudio27-dll-rc.h
@@ -1,0 +1,6 @@
+#ifndef XAUDIO27_RC_H
+#define XAUDIO27_RC_H
+
+#define XAUDIO27_DLL_RC 301
+
+#endif /* XAUDIO27_RC_H */

--- a/src/wx/wxvbam.rc
+++ b/src/wx/wxvbam.rc
@@ -19,8 +19,11 @@ AAAAA_MAINICON ICON "icons/visualboyadvance-m.ico"
 
 #include "autoupdater/wxmsw/winsparkle-rc.h"
 #include "winsparkle-path.h"
+#include "audio/internal/xaudio27-dll-rc.h"
+#include "xaudio27-dll-path.h"
 
 WINSPARKLE_DLL_RC RCDATA WINSPARKLE_DLL_PATH
+XAUDIO27_DLL_RC   RCDATA XAUDIO27_DLL_PATH
 
 #endif /* NO_ONLINEUPDATES */
 


### PR DESCRIPTION
Use a Windows resource for the XAudio2_7.dll which may not be installed by the user.

At the initialization of the XAudio driver, create a temp directory, unpack the dll into it, and add it to the PATH environment variable so that COM can load it.

On destruction, run a cmd.exe command to wait and remove the temp directory, because this cannot be done by the process as the dll is loaded into it and we don't have a handle to it.