### PR TITLE
[GB] Add support for per-game overrides

### DIFF
--- a/src/core/base/system.h
+++ b/src/core/base/system.h
@@ -70,7 +70,7 @@ extern struct CoreOptions {
     int skipSaveGameBattery = 1;
     int skipSaveGameCheats = 0;
     int useBios = 0;
-    int winGbPrinterEnabled = 1;
+    int gbPrinterEnabled = 1;
     uint32_t speedup_throttle = 100;
     uint32_t speedup_frame_skip = 9;
     uint32_t throttle = 100;

--- a/src/core/base/system.h
+++ b/src/core/base/system.h
@@ -70,7 +70,7 @@ extern struct CoreOptions {
     int skipSaveGameBattery = 1;
     int skipSaveGameCheats = 0;
     int useBios = 0;
-    int gbPrinterEnabled = 1;
+    int gbPrinterEnabled = 0;
     uint32_t speedup_throttle = 100;
     uint32_t speedup_frame_skip = 9;
     uint32_t throttle = 100;

--- a/src/core/gb/gb.cpp
+++ b/src/core/gb/gb.cpp
@@ -1416,7 +1416,7 @@ void gbWriteMemory(uint16_t address, uint8_t value)
         EmuReseted = false;
         gbMemory[0xff02] = value;
         if (gbSerialOn && (GetLinkMode() == LINK_GAMEBOY_IPC || GetLinkMode() == LINK_GAMEBOY_SOCKET
-        || GetLinkMode() == LINK_DISCONNECTED || coreOptions.winGbPrinterEnabled)) {
+        || GetLinkMode() == LINK_DISCONNECTED || coreOptions.gbPrinterEnabled)) {
 
             gbSerialTicks = GBSERIAL_CLOCK_TICKS;
 

--- a/src/gb-over.ini
+++ b/src/gb-over.ini
@@ -1,0 +1,4 @@
+# Game Boy Overrrides
+
+[ALLEY WAY]
+gbPrinter = 0

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -590,7 +590,7 @@ void retro_init(void)
     coreOptions.parseDebug = true;
     coreOptions.cheatsEnabled = 0;
     coreOptions.skipSaveGameBattery = 0;
-    coreOptions.winGbPrinterEnabled = 0;
+    coreOptions.gbPrinterEnabled = 0;
 
     struct retro_log_callback log;
     struct retro_rumble_interface rumble;

--- a/src/sdl/ConfigManager.cpp
+++ b/src/sdl/ConfigManager.cpp
@@ -189,7 +189,7 @@ struct option argOptions[] = {
 	{ "gb-emulator-type", required_argument, 0, OPT_GB_EMULATOR_TYPE },
 	{ "gb-frame-skip", required_argument, 0, OPT_GB_FRAME_SKIP },
 	{ "gb-palette-option", required_argument, 0, OPT_GB_PALETTE_OPTION },
-	{ "gb-printer", no_argument, &coreOptions.winGbPrinterEnabled, 1 },
+	{ "gb-printer", no_argument, &coreOptions.gbPrinterEnabled, 1 },
 	{ "gdb", required_argument, 0, 'G' },
 	{ "help", no_argument, &optPrintUsage, 1 },
 	{ "ifb-filter", required_argument, 0, 'I' },
@@ -236,7 +236,7 @@ struct option argOptions[] = {
 	{ "no-speedup-mute", no_argument, 0, OPT_NO_SPEEDUP_MUTE },
 	{ "use-bios", no_argument, &coreOptions.useBios, 1 },
 	{ "verbose", required_argument, 0, 'v' },
-	{ "win-gb-printer-enabled", no_argument, &coreOptions.winGbPrinterEnabled, 1 },
+	{ "win-gb-printer-enabled", no_argument, &coreOptions.gbPrinterEnabled, 1 },
 
 
 	{ NULL, no_argument, NULL, 0 }
@@ -351,7 +351,7 @@ void LoadConfig()
 	coreOptions.speedup_throttle_frame_skip = ReadPref("speedupThrottleFrameSkip", 0);
 	coreOptions.speedup_mute = ReadPref("speedupMute", 1);
 	coreOptions.useBios = ReadPrefHex("useBiosGBA");
-	coreOptions.winGbPrinterEnabled = ReadPref("gbPrinter", 0);
+	coreOptions.gbPrinterEnabled = ReadPref("gbPrinter", 0);
 
 	int soundQuality = (ReadPrefHex("soundQuality", 1));
 	switch (soundQuality) {

--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -59,6 +59,7 @@ set(VBAM_WX_COMMON
     ${VBAM_GENERATED_DIR}/wx/builtin-over.h
     ${VBAM_GENERATED_DIR}/wx/cmdhandlers.h
     ${VBAM_GENERATED_DIR}/wx/cmd-evtable.h
+    ${VBAM_GENERATED_DIR}/wx/gb-builtin-over.h
 )
 
 if(NOT ZIP_PROGRAM)
@@ -640,6 +641,12 @@ add_custom_command(
     OUTPUT ${VBAM_GENERATED_DIR}/wx/builtin-over.h
     COMMAND ${BIN2C} ${CMAKE_SOURCE_DIR}/src/vba-over.ini ${VBAM_GENERATED_DIR}/wx/builtin-over.h builtin_over
     DEPENDS ${CMAKE_SOURCE_DIR}/src/vba-over.ini ${BIN2C}
+)
+
+add_custom_command(
+    OUTPUT ${VBAM_GENERATED_DIR}/wx/gb-builtin-over.h
+    COMMAND ${BIN2C} ${CMAKE_SOURCE_DIR}/src/gb-over.ini ${VBAM_GENERATED_DIR}/wx/gb-builtin-over.h gb_builtin_over
+    DEPENDS ${CMAKE_SOURCE_DIR}/src/gb-over.ini ${BIN2C}
 )
 
 set(VBAM_LOCALIZABLE_FILES ${VBAM_WX_COMMON} ${VBAM_LOCALIZABLE_WX_CONFIG_FILES})

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -1990,7 +1990,7 @@ EVT_HANDLER(GameBoyAdvanceConfigure, "Game Boy Advance options...")
         XRCCTRL(*dlg, "GameCode", wxControl)
             ->SetLabel(s);
         cmt = wxString((const char*)&g_rom[0xa0], wxConvLibc, 12);
-        wxFileConfig* cfg = wxGetApp().overrides;
+        wxFileConfig* cfg = wxGetApp().overrides_.get();
 
         if (cfg->HasGroup(s)) {
             cfg->SetPath(s);
@@ -2024,7 +2024,7 @@ EVT_HANDLER(GameBoyAdvanceConfigure, "Game Boy Advance options...")
     if (panel->game_type() == IMAGE_GBA) {
         agbPrintEnable(OPTION(kPrefAgbPrint));
         wxString s = wxString((const char*)&g_rom[0xac], wxConvLibc, 4);
-        wxFileConfig* cfg = wxGetApp().overrides;
+        wxFileConfig* cfg = wxGetApp().overrides_.get();
         bool chg;
 
         if (cfg->HasGroup(s)) {
@@ -2297,7 +2297,7 @@ EVT_HANDLER(RetainAspect, "Retain aspect ratio when resizing")
 
 EVT_HANDLER(Printer, "Enable printer emulation")
 {
-    GetMenuOptionInt("Printer", &coreOptions.winGbPrinterEnabled, 1);
+    GetMenuOptionInt("Printer", &coreOptions.gbPrinterEnabled, 1);
 #if (defined __WIN32__ || defined _WIN32)
 #ifndef NO_LINK
     gbSerialFunction = gbStartLink;
@@ -2305,7 +2305,7 @@ EVT_HANDLER(Printer, "Enable printer emulation")
     gbSerialFunction = NULL;
 #endif
 #endif
-    if (coreOptions.winGbPrinterEnabled)
+    if (coreOptions.gbPrinterEnabled)
         gbSerialFunction = gbPrinterSend;
 
     update_opts();

--- a/src/wx/config/internal/option-internal.cpp
+++ b/src/wx/config/internal/option-internal.cpp
@@ -312,7 +312,7 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kPrefFlashSize, &g_owned_opts.flash_size, 0, 1),
         Option(OptionID::kPrefFrameSkip, &g_owned_opts.frame_skip, -1, 9),
         Option(OptionID::kPrefGBPaletteOption, &gbPaletteOption, 0, 2),
-        Option(OptionID::kPrefGBPrinter, &coreOptions.winGbPrinterEnabled, 0, 1),
+        Option(OptionID::kPrefGBPrinter, &coreOptions.gbPrinterEnabled, 0, 1),
         Option(OptionID::kPrefGDBBreakOnLoad, &g_owned_opts.gdb_break_on_load),
         Option(OptionID::kPrefGDBPort, &gopts.gdb_port, 0, 65535),
 #ifndef NO_LINK

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -1,11 +1,13 @@
 #ifndef VBAM_WX_WXVBAM_H_
 #define VBAM_WX_WXVBAM_H_
 
+#include <cstdio>
+#include <ctime>
 #include <list>
+#include <memory>
 #include <stdexcept>
 #include <iostream>
-#include <stdio.h>
-#include <time.h>
+
 #include <wx/log.h>
 #include <wx/propdlg.h>
 #include <wx/datetime.h>
@@ -106,7 +108,8 @@ public:
     widgets::SdlPoller* sdl_poller() { return &sdl_poller_; }
 
     // vba-over.ini
-    wxFileConfig* overrides = nullptr;
+    std::unique_ptr<wxFileConfig> overrides_;
+    std::unique_ptr<wxFileConfig> gb_overrides_;
 
     wxFileName rom_database;
     wxFileName rom_database_scene;


### PR DESCRIPTION
Alleyway is a buggy game that does not work properly when a Game Boy Printer is connected. In order to work around this issue, this adds upport for built-in per-software Game Boy overrides. In addition, this renames various variables to make their meaning clearer.

* This only supports built-in overrides. External INI files are not supported.
* Only the Game Boy Printer option is supported, this only takes effect on game startup and the general configuration option is restored when the game is unloaded.
* As a result, it is possible to override the per-game override by manually setting the option while the game is running, this is working as intended.
* Future refactors of the option handling will manage overrides better.

Fixes #1368