### PR TITLE
[build] Disable link on MinGW

### DIFF
--- a/.github/workflows/msys2-build.yml
+++ b/.github/workflows/msys2-build.yml
@@ -6,14 +6,12 @@ jobs:
     strategy:
       matrix:
         build_type: [release, debug]
-        build_options: [default, link_off, translations_only, libretro]
+        build_options: [default, translations_only, libretro]
         include:
           - cmake_build: '-DCMAKE_BUILD_TYPE=Release'
             build_type: release
           - cmake_build: '-DCMAKE_BUILD_TYPE=Debug'
             build_type: debug
-          - cmake_options: '-DENABLE_LINK=OFF'
-            build_options: link_off
           - cmake_options: '-DTRANSLATIONS_ONLY=ON'
             build_options: translations_only
           - libretro_build: 'DEBUG=0'

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -68,7 +68,7 @@ endif()
 find_package(PkgConfig)
 
 # Link / SFML
-if(TRANSLATIONS_ONLY)
+if(TRANSLATIONS_ONLY OR MINGW)
     set(ENABLE_LINK_DEFAULT OFF)
 else()
     find_package(SFML 2.4 COMPONENTS network system)


### PR DESCRIPTION
A recent libc++ update started enforcing correct type use for char_traits, breaking the SFML headers. Temporarily disable the Link option by default on MinGW to work around this issue.