### PR TITLE
[gtest] Use googletest as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = win32-deps
 	url = https://github.com/visualboyadvance-m/win32-deps.git
 	branch = master
+[submodule "third_party/googletest"]
+	path = third_party/googletest
+	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,14 +90,9 @@ endif()
 
 # Configure gtest
 if(BUILD_TESTING)
-    FetchContent_Declare(googletest
-        URL https://github.com/google/googletest/archive/2d16ed055d09c3689d44b272adc097393de948a0.zip
-        EXCLUDE_FROM_ALL
-    )
-
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
-
+    set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+    add_subdirectory(./third_party/googletest)
     include(GoogleTest)
 endif()
 


### PR DESCRIPTION
Some Linux distributions use a hermetic build environment to build. This resulted in issues with `FetchContent` attempting to download googletest at configure time.
This fixes the issue by integrating googletest as a git submodule instead of downloading it at configure time.