### PR TITLE
Set volume level after closing SoundConfigure dialog

### DIFF
--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2161,6 +2161,8 @@ EVT_HANDLER_MASK(SoundConfigure, "Sound options...", CMDEN_NREC_ANY)
     gb_effects_config.echo = (float)OPTION(kSoundGBEcho) / 100.0;
     gb_effects_config.stereo = (float)OPTION(kSoundGBStereo) / 100.0;
     soundFiltering = (float)OPTION(kSoundGBAFiltering) / 100.0f;
+    // Missing Setup for volume here
+    soundSetVolume((float)OPTION(kSoundVolume) / 100.0f);
 }
 
 EVT_HANDLER(EmulatorDirectories, "Directories...")


### PR DESCRIPTION
tried to fix this issue (#1407) . the soundSetVolume() got removed (accidentally?) - this should fix the issue at least. even though it could use the soundVolume variable directly.
haven't been in c for some time and can't compile on my windows machine but it compiled on my debian 12.9 x86_64 system using the provided deps from installdeps.