### PR TITLE
[Sound] Set volume on game startup

### DIFF
--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -437,6 +437,9 @@ void GameArea::LoadGame(const wxString& name)
         emusys = &GBASystem;
     }
 
+    // Set sound volume.
+    soundSetVolume((float)OPTION(kSoundVolume) / 100.0);
+
     if (OPTION(kGeomFullScreen)) {
         GameArea::ShowFullScreen(true);
     }


### PR DESCRIPTION
On startup, the internal emulator sound volume is set to 100%. The user value in the wx frontend is not used until the emulator volume slider is modified, resulting in games starting with volume at 100% on startup.

This fixes #1407 by always setting the internal emulator sound volume on game startup.