### PR TITLE
[build] Disable link

### DIFF
--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -77,7 +77,12 @@ else()
         set(ENABLE_LINK_DEFAULT ON)
     endif()
 endif()
-option(ENABLE_LINK "Enable GBA linking functionality" ${ENABLE_LINK_DEFAULT})
+option(ENABLE_LINK "Enable GBA linking functionality (BROKEN)" ${ENABLE_LINK_DEFAULT})
+
+if(ENABLE_LINK)
+    # Always disable link for now as SFML 2 is broken and we don't have a replacement yet.
+    set(ENABLE_LINK OFF CACHE BOOL "Enable GBA linking functionality (BROKEN)" FORCE)
+endif()
 
 # FFMpeg
 set(FFMPEG_DEFAULT OFF)

--- a/default.nix
+++ b/default.nix
@@ -2,7 +2,7 @@ with import <nixpkgs> {};
 stdenv.mkDerivation {
     name = "visualboyadvance-m";
     buildInputs = if stdenv.isDarwin then
-        [ ninja cmake nasm faudio gettext libintl pkg-config zip sfml zlib openal ffmpeg wxGTK32 SDL2 pcre pcre2 darwin.apple_sdk.frameworks.System darwin.apple_sdk.frameworks.IOKit darwin.apple_sdk.frameworks.Carbon darwin.apple_sdk.frameworks.Cocoa darwin.apple_sdk.frameworks.QuartzCore darwin.apple_sdk.frameworks.AudioToolbox darwin.apple_sdk.frameworks.OpenGL darwin.apple_sdk.frameworks.OpenAL llvmPackages_latest.clang llvmPackages_latest.bintools ]
+        [ ninja cmake nasm faudio gettext libintl pkg-config zip zlib openal ffmpeg wxGTK32 SDL2 pcre pcre2 darwin.apple_sdk.frameworks.System darwin.apple_sdk.frameworks.IOKit darwin.apple_sdk.frameworks.Carbon darwin.apple_sdk.frameworks.Cocoa darwin.apple_sdk.frameworks.QuartzCore darwin.apple_sdk.frameworks.AudioToolbox darwin.apple_sdk.frameworks.OpenGL darwin.apple_sdk.frameworks.OpenAL llvmPackages_latest.clang llvmPackages_latest.bintools ]
     else
-        [ ninja cmake gcc clang llvm llvmPackages.libcxx nasm faudio gettext libintl pkg-config zip sfml zlib openal ffmpeg wxGTK32 libGL libGLU glfw SDL2 gtk3-x11 pcre pcre2 util-linuxMinimal libselinux libsepol libthai libdatrie xorg.libXdmcp xorg.libXtst libxkbcommon libepoxy dbus at-spi2-core ];
+        [ ninja cmake gcc clang llvm llvmPackages.libcxx nasm faudio gettext libintl pkg-config zip zlib openal ffmpeg wxGTK32 libGL libGLU glfw SDL2 gtk3-x11 pcre pcre2 util-linuxMinimal libselinux libsepol libthai libdatrie xorg.libXdmcp xorg.libXtst libxkbcommon libepoxy dbus at-spi2-core ];
 }


### PR DESCRIPTION
SFML 2 no longer compiles with a modern compiler and we are blocked on SFML 3 being available in vcpkg to fix it. There is no easy way to backport fixes to SFML 2 so disable link for the time being.