### PR TITLE
Mark `wxEVT_KEY_DOWN` as processed in `wxvbamApp`

### DIFF
--- a/src/wx/wxvbam.cpp
+++ b/src/wx/wxvbam.cpp
@@ -1409,3 +1409,12 @@ int wxvbamApp::FilterEvent(wxEvent& event)
 
     return user_input_event.FilterProcessedInput(user_input.value());
 }
+
+bool wxvbamApp::ProcessEvent(wxEvent& event) {
+    if (event.GetEventType() == wxEVT_KEY_DOWN) {
+        // Mark the event as processed. This prevents wxWidgets from firing alerts on macOS.
+        // See https://github.com/wxWidgets/wxWidgets/issues/25262 for details.
+        return true;
+    }
+    return wxApp::ProcessEvent(event);
+}

--- a/src/wx/wxvbam.h
+++ b/src/wx/wxvbam.h
@@ -84,6 +84,7 @@ public:
             return false;
         }
     }
+    bool ProcessEvent(wxEvent& event) final;
 
     wxString GetConfigDir();
     wxString GetDataDir();


### PR DESCRIPTION
This prevents wxWidgets from triggering the alert sound on macOS. There should be no side effect from this.

Fixes #1384