### PR TITLE
cmake: exposed TILED_RENDERING option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,10 @@ if(NOT EXISTS "${CMAKE_SOURCE_DIR}/.git")
     set(BUILD_TESTING OFF)
 endif()
 
+if(ENABLE_TILEDRENDER)
+    _add_compile_definitions(TILED_RENDERING)
+endif()
+
 # Configure gtest
 if(BUILD_TESTING)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -15,8 +15,13 @@ endif()
 
 option(ENABLE_SDL "Build the SDL port" ${ENABLE_SDL_DEFAULT})
 option(ENABLE_WX "Build the wxWidgets port" ${BUILD_DEFAULT})
+option(ENABLE_TILEDRENDER "Enable tiled renderer" ${BUILD_DEFAULT})
 option(ENABLE_DEBUGGER "Enable the debugger" ON)
 option(ENABLE_ASAN "Enable -fsanitize=address by default. Requires debug build with GCC/Clang" OFF)
+
+if(ENABLE_TILEDRENDER)
+    set(ENABLE_TILEDRENDER OFF)
+endif()
 
 # Static linking
 set(VBAM_STATIC_DEFAULT OFF)


### PR DESCRIPTION
This was originally added for the use of the libretro core, figured it should be added to cmake as a compile time option. Can be triggered when invoking cmake using -DENABLE_TILEDRENDER=ON