### PR TITLE
prevent the zip program from being incompletely downloaded

### DIFF
--- a/src/wx/CMakeLists.txt
+++ b/src/wx/CMakeLists.txt
@@ -69,16 +69,29 @@ if(NOT ZIP_PROGRAM)
         if(NOT DEFINED POWERSHELL)
             message(FATAL_ERROR "Powershell is required for extraction.")
         endif()
-
-        # Get zip binaries from wxrc.
-        file(DOWNLOAD "https://www.willus.com/archive/zip64/infozip_binaries_win32.zip" ${CMAKE_CURRENT_BINARY_DIR}/infozip_binaries_win32.zip)
-
+        set(_url "https://www.willus.com/archive/zip64/infozip_binaries_win32.zip")
+        set(_path "${CMAKE_CURRENT_BINARY_DIR}/infozip_binaries_win32.zip")
+        set(_sha "b338a0f35e1f849d3466d4260fd8a51f2afe9cdf136cc07cc4d54b00cee13650")
+        foreach(_i RANGE 1 3)
+            # Get zip binaries from wxrc.
+            file(DOWNLOAD "${_url}" "${_path}" SHOW_PROGRESS STATUS _s)
+            list(GET _s 0 _c)
+            if(_c EQUAL 0)
+                file(SHA256 "${_path}" _h)
+                file(SIZE "${_path}" _z)
+                if(_h STREQUAL _sha AND _z GREATER 0)
+                    break()
+                endif()
+            endif()
+            file(REMOVE "${_path}")
+            if(_i EQUAL 3)
+                message(FATAL_ERROR "Download failed or SHA256 mismatch after 3 attempts.")
+            endif()
+        endforeach()
         # Unzip it.
-        execute_process(
-            COMMAND "${POWERSHELL}" -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('${CMAKE_CURRENT_BINARY_DIR}/infozip_binaries_win32.zip', '${CMAKE_CURRENT_BINARY_DIR}'); }"
-        )
-
-        set(ZIP_PROGRAM ${CMAKE_CURRENT_BINARY_DIR}/zip.exe CACHE STRING "zip compressor executable" FORCE)
+        execute_process(COMMAND "${POWERSHELL}" -NoLogo -NoProfile -ExecutionPolicy Bypass
+            -Command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('${_path}', '${CMAKE_CURRENT_BINARY_DIR}'); }")
+        set(ZIP_PROGRAM "${CMAKE_CURRENT_BINARY_DIR}/zip.exe" CACHE STRING "zip compressor executable" FORCE)
     endif()
     if(ZIP_PROGRAM)
         set(ZIP_PROGRAM "${ZIP_PROGRAM}" CACHE STRING "zip compressor executable" FORCE)


### PR DESCRIPTION
sometimes the infozip_binaries_win32.zip file can fail to download completely creating a wrong sized or 0MB file that fails as the following

1> [CMake] Exception calling "ExtractToDirectory" with "2" argument(s): "Central Directory corrupt."
1> [CMake] At line:1 char:53
1> [CMake] + ... ileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('C:/Users/Ho ...
1> [CMake] +                 ~~~~~~~~~~~~~
1> [CMake]     + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
1> [CMake]     + FullyQualifiedErrorId : InvalidDataException


 this results in the inability to build successfully, with the following.

> build\x64-static-Debug\src\wx\wxvbam.xrs" wxvbam.xrs$xrc_AccelConfig.xrc wxvbam.xrs$xrc_CheatAdd.xrc wxvbam.xrs$xrc_CheatCreate.xrc wxvbam.xrs$xrc_CheatEdit.xrc wxvbam.xrs$xrc_CheatList.xrc wxvbam.xrs$xrc_CodeSelect.xrc wxvbam.xrs$xrc_DirectoriesConfig.xrc wxvbam.xrs$xrc_Disassemble.xrc wxvbam.xrs$xrc_DisplayConfig.xrc wxvbam.xrs$xrc_ExportSPS.xrc wxvbam.xrs$xrc_GBAROMInfo.xrc wxvbam.xrs$xrc_GBColorPrefPanel.xrc wxvbam.xrs$xrc_GBDisassemble.xrc wxvbam.xrs$xrc_GBMapViewer.xrc wxvbam.xrs$xrc_GBOAMViewer.xrc wxvbam.xrs$xrc_GBPaletteViewer.xrc wxvbam.xrs$xrc_GBPrinter.xrc wxvbam.xrs$xrc_GBROMInfo.xrc wxvbam.xrs$xrc_GBTileViewer.xrc wxvbam.xrs$xrc_GameBoyAdvanceConfig.xrc wxvbam.xrs$xrc_GameBoyConfig.xrc wxvbam.xrs$xrc_GeneralConfig.xrc wxvbam.xrs$xrc_IOViewer.xrc wxvbam.xrs$xrc_JoyPanel.xrc wxvbam.xrs$xrc_JoypadConfig.xrc wxvbam.xrs$xrc_LinkConfig.xrc wxvbam.xrs$xrc_Logging.xrc wxvbam.xrs$xrc_MainFrame.xrc wxvbam.xrs$visualboyadvance-m.xpm wxvbam.xrs$xrc_MainIcon.xrc wxvbam.xrs$xrc_MainMenu.xrc wxvbam.xrs$xrc_MapViewer.xrc wxvbam.xrs$xrc_MemSelRegion.xrc wxvbam.xrs$xrc_MemViewer.xrc wxvbam.xrs$xrc_NetLink.xrc wxvbam.xrs$xrc_OAMViewer.xrc wxvbam.xrs$xrc_PaletteViewer.xrc wxvbam.xrs$xrc_SoundConfig.xrc wxvbam.xrs$xrc_TileViewer.xrc wxvbam.xrs$xrc_SpeedupConfig.xrc' failed (error 2: The system cannot find the file specified.)


This PR adds a 3x retry, progress status and hash validation for the zip package.