### PR TITLE
Default LCD Filter to enabled for GBA/GB

### DIFF
--- a/src/wx/config/internal/option-internal.cpp
+++ b/src/wx/config/internal/option-internal.cpp
@@ -176,7 +176,7 @@ std::array<Option, kNbOptions>& Option::All() {
         /// GB
         wxString gb_bios = wxEmptyString;
         bool colorizer_hack = false;
-        bool gb_lcd_filter = false;
+        bool gb_lcd_filter = true;
         wxString gbc_bios = wxEmptyString;
         bool print_auto_page = true;
         bool print_screen_cap = false;
@@ -185,7 +185,7 @@ std::array<Option, kNbOptions>& Option::All() {
         uint32_t gb_lighten = 0;
 
         /// GBA
-        bool gba_lcd_filter = false;
+        bool gba_lcd_filter = true;
 #ifndef NO_LINK
         bool link_auto = false;
         bool link_hacks = true;

--- a/src/wx/config/option.h
+++ b/src/wx/config/option.h
@@ -127,7 +127,7 @@ static constexpr size_t kNbSoundRate = static_cast<size_t>(AudioRate::kLast);
 
 // This is incremented whenever we want to change a default value between
 // release versions. The option update code is in load_opts.
-static constexpr uint32_t kIniLatestVersion = 1;
+static constexpr uint32_t kIniLatestVersion = 2;
 
 // Represents a single option saved in the INI file. Option does not own the
 // individual option, but keeps a pointer to where the data is actually saved.

--- a/src/wx/opts.cpp
+++ b/src/wx/opts.cpp
@@ -382,8 +382,11 @@ void load_opts(bool first_time_launch) {
                     OPTION(kGBALinkTimeout) = 500;
                 }
 #endif
-                // Previous default was true.
-                OPTION(kGBALCDFilter) = false;
+            }
+            case 1: { // up to 2.2.2 included.
+                // Previous defaults were false.
+                OPTION(kGBALCDFilter) = true;
+                OPTION(kGBLCDFilter)  = true;
             }
         }
         ini_version++;


### PR DESCRIPTION
Set the defaults for GB and GBA LCD Filter to enabled and rewrite the values in previous versions of the config to enabled as well.