### PR TITLE
[Experimental]Reimplement BG Enable Delay

### DIFF
--- a/src/core/gba/gba.cpp
+++ b/src/core/gba/gba.cpp
@@ -3000,7 +3000,8 @@ void CPUUpdateRegister(uint32_t address, uint16_t value)
                 bgEnableState[2] = 0;
             }
             else {
-                if (VCOUNT == 0 || videoMode > 2) {
+                // BG2 is affine in modes 1-2, immediate enable for affine
+                if (VCOUNT == 0 || videoMode > 0) {
                     bgEnableState[2] = 4;
                 }
                 else {
@@ -3017,7 +3018,8 @@ void CPUUpdateRegister(uint32_t address, uint16_t value)
                 bgEnableState[3] = 0;
             }
             else {
-                if (VCOUNT == 0 || videoMode > 2) {
+                // BG3 is affine in mode 2, immediate enable for affine
+                if (VCOUNT == 0 || videoMode == 2) {
                     bgEnableState[3] = 4;
                 }
                 else {


### PR DESCRIPTION
This changes it from a global delay that only triggers mid frame to also handling other states, mode combinations, etc

Fixes #376
<img width="1806" height="1374" alt="image" src="https://github.com/user-attachments/assets/ccc36ff7-606e-44c1-9162-a2d3695e6ea0" />

Doesn't regress lady sia
<img width="1806" height="1374" alt="image" src="https://github.com/user-attachments/assets/4b5ff282-92f7-4d19-8736-32f25d52b487" />


hacking the affine to run immediately got Advanced Guardian Heroes to work
<img width="1806" height="1374" alt="image" src="https://github.com/user-attachments/assets/afcdd8e6-41ad-4197-a603-c2c0725d5139" />

this needs further work though, we need to do it properly not hackish.
