### PR TITLE
gb: use BIOS for emulated system

### DIFF
--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -932,13 +932,26 @@ static void gb_init(void)
     if (option_colorizerHack)
         option_useBios = false;
 
-    if (option_useBios) {
+    // Load BIOS for the actual system being emulated
+    // gbHardware: 1=GB, 2=GBC, 4=SGB/SGB2, 8=GBA
+    // Only load BIOS for GB and GBC modes
+    bool useBios = false;
+    if (option_useBios && (gbHardware == 1 || gbHardware == 2)) {
+        int biosIndex;
+        if (gbHardware == 2) {
+            // Game Boy Color
+            biosIndex = 1;  // gbc_bios.bin
+        } else {
+            // Game Boy
+            biosIndex = 0;  // gb_bios.bin
+        }
         snprintf(biosfile, sizeof(biosfile), "%s%c%s",
-            retro_system_directory, SLASH, biosname[gbCgbMode ? 1 : 0]);
+            retro_system_directory, SLASH, biosname[biosIndex]);
         log("Loading bios: %s\n", biosfile);
+        useBios = true;
     }
-
-    gbCPUInit(biosfile, option_useBios);
+    // For SGB/SGB2 (4) and GBA (8), no BIOS is loaded
+    gbCPUInit(biosfile, useBios);
 
     if (gbBorderOn) {
         systemWidth = gbBorderLineSkip = kSGBWidth;

--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -2227,9 +2227,19 @@ int main(int argc, char** argv)
             if (!failed) {
                 gbGetHardwareType();
 
-                // used for the handling of the gb Boot Rom
-                if (gbHardware & 7)
+                // Load BIOS for the actual system being emulated
+                // gbHardware: 1=GB, 2=GBC, 4=SGB/SGB2, 8=GBA
+                // Only load BIOS for GB and GBC modes
+                if (gbHardware == 2) {
+                    // Game Boy Color
+                    gbCPUInit(biosFileNameGBC, coreOptions.useBios);
+                } else if (gbHardware == 1) {
+                    // Game Boy
                     gbCPUInit(biosFileNameGB, coreOptions.useBios);
+                } else {
+                    // SGB/SGB2 (4) or GBA (8) - no BIOS loaded
+                    gbCPUInit(NULL, false);
+                }
 
                 cartridgeType = IMAGE_GB;
                 emulator = GBSystem;

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -472,10 +472,23 @@ void GameArea::LoadGame(const wxString& name)
         // Set up the core for the colorizer hack.
         setColorizerHack(OPTION(kGBColorizerHack));
 
-        const bool use_bios = gbCgbMode ? OPTION(kPrefUseBiosGBC).Get()
-                                        : OPTION(kPrefUseBiosGB).Get();
+        // Load BIOS for the actual system being emulated
+        // gbHardware: 1=GB, 2=GBC, 4=SGB/SGB2, 8=GBA
+        // Only load BIOS for GB and GBC modes
+        bool use_bios = false;
+        wxString bios_file;
 
-        const wxString bios_file = gbCgbMode ? OPTION(kGBGBCBiosFile).Get() : OPTION(kGBBiosFile).Get();
+        if (gbHardware == 2) {
+            // Game Boy Color
+            use_bios = OPTION(kPrefUseBiosGBC).Get();
+            bios_file = OPTION(kGBGBCBiosFile).Get();
+        } else if (gbHardware == 1) {
+            // Game Boy
+            use_bios = OPTION(kPrefUseBiosGB).Get();
+            bios_file = OPTION(kGBBiosFile).Get();
+        }
+        // For SGB/SGB2 (4) and GBA (8), use_bios remains false (no BIOS loaded)
+
         gbCPUInit(bios_file.To8BitData().data(), use_bios);
 
         if (use_bios && !coreOptions.useBios) {


### PR DESCRIPTION
Use the BIOS file if specified for the system set as being emulated for GameBoy ROMs, not the BIOS for the system of the cartridge type. This allows for e.g. a GBC ROM with GBA features to work correctly.

Fixed with Claude.