### PR TITLE
Added .srm save support; updated installdeps

### DIFF
--- a/src/sdl/SDL.cpp
+++ b/src/sdl/SDL.cpp
@@ -905,21 +905,34 @@ void sdlWriteBackupStateExchange(int from, int to, int backup)
 
 void sdlWriteBattery()
 {
-    char buffer[2048];
+    char savPath[2048];
+    char srmPath[2048];
+
     char *gameDir = sdlGetFilePath(filename);
     char *gameFile = sdlGetFilename(filename);
 
-    if (batteryDir)
-        snprintf(buffer, sizeof(buffer), "%s%c%s.sav", batteryDir, kFileSep, gameFile);
-    else if (access(gameDir, W_OK) == 0)
-        snprintf(buffer, sizeof(buffer), "%s%c%s.sav", gameDir, kFileSep, gameFile);
-    else
-        snprintf(buffer, sizeof(buffer), "%s%c%s.sav", homeDataDir, kFileSep, gameFile);
+    const char* baseDir = nullptr;
 
-    bool result = emulator.emuWriteBattery(buffer);
+    if (batteryDir)
+        baseDir = batteryDir;
+    else if (access(gameDir, W_OK) == 0)
+        baseDir = gameDir;
+    else
+        baseDir = homeDataDir;
+
+    snprintf(savPath, sizeof(savPath), "%s%c%s.sav", baseDir, kFileSep, gameFile);
+    snprintf(srmPath, sizeof(srmPath), "%s%c%s.srm", baseDir, kFileSep, gameFile);
+
+    const char* finalPath = savPath;
+
+    if (access(savPath, F_OK) != 0 && access(srmPath, F_OK) == 0) {
+        finalPath = srmPath;
+    }
+
+    bool result = emulator.emuWriteBattery(finalPath);
 
     if (result)
-        systemMessage(0, "Wrote battery '%s'", buffer);
+        systemMessage(0, "Wrote battery '%s'", finalPath);
 
     freeSafe(gameFile);
     freeSafe(gameDir);
@@ -927,21 +940,34 @@ void sdlWriteBattery()
 
 void sdlReadBattery()
 {
-    char buffer[2048];
+    char savPath[2048];
+    char srmPath[2048];
+
     char *gameDir = sdlGetFilePath(filename);
     char *gameFile = sdlGetFilename(filename);
 
-    if (batteryDir)
-        snprintf(buffer, sizeof(buffer), "%s%c%s.sav", batteryDir, kFileSep, gameFile);
-    else if (access(gameDir, W_OK) == 0)
-        snprintf(buffer, sizeof(buffer), "%s%c%s.sav", gameDir, kFileSep, gameFile);
-    else
-        snprintf(buffer, sizeof(buffer), "%s%c%s.sav", homeDataDir, kFileSep, gameFile);
+    const char* baseDir = nullptr;
 
-    bool result = emulator.emuReadBattery(buffer);
+    if (batteryDir)
+        baseDir = batteryDir;
+    else if (access(gameDir, W_OK) == 0)
+        baseDir = gameDir;
+    else
+        baseDir = homeDataDir;
+
+    snprintf(savPath, sizeof(savPath), "%s%c%s.sav", baseDir, kFileSep, gameFile);
+    snprintf(srmPath, sizeof(srmPath), "%s%c%s.srm", baseDir, kFileSep, gameFile);
+
+    const char* finalPath = savPath;
+
+    if (access(savPath, F_OK) != 0 && access(srmPath, F_OK) == 0) {
+        finalPath = srmPath;
+    }
+
+    bool result = emulator.emuReadBattery(finalPath);
 
     if (result)
-        systemMessage(0, "Loaded battery '%s'", buffer);
+        systemMessage(0, "Loaded battery '%s'", finalPath);
 
     freeSafe(gameFile);
     freeSafe(gameDir);

--- a/src/wx/panel.cpp
+++ b/src/wx/panel.cpp
@@ -773,8 +773,20 @@ void GameArea::LoadGame(const wxString& name)
         }
 
 #endif
-        bname.append(wxT(".sav"));
-        wxFileName bat(batdir, bname);
+        wxString base = bname;
+
+        wxString savName = base + wxT(".sav");
+        wxString srmName = base + wxT(".srm");
+
+        wxFileName bat;
+
+        if (wxFileExists(wxFileName(batdir, savName).GetFullPath())) {
+            bat.Assign(batdir, savName);
+        } else if (wxFileExists(wxFileName(batdir, srmName).GetFullPath())) {
+            bat.Assign(batdir, srmName);
+        } else {
+            bat.Assign(batdir, savName);
+        }
 
         if (emusys->emuReadBattery(UTF8(bat.GetFullPath()))) {
             wxString msg;
@@ -1129,8 +1141,21 @@ void GameArea::SaveBattery()
     }
 
 #endif
-    bname.append(wxT(".sav"));
-    wxFileName bat(batdir, bname);
+    wxString base = bname;
+
+    wxString savName = base + wxT(".sav");
+    wxString srmName = base + wxT(".srm");
+
+    wxFileName bat;
+
+    if (wxFileExists(wxFileName(batdir, savName).GetFullPath())) {
+        bat.Assign(batdir, savName);
+    } else if (wxFileExists(wxFileName(batdir, srmName).GetFullPath())) {
+        bat.Assign(batdir, srmName);
+    } else {
+        bat.Assign(batdir, savName);
+    }
+
     bat.Mkdir(0777, wxPATH_MKDIR_FULL);
     wxString fn = bat.GetFullPath();
 


### PR DESCRIPTION
Modified SDL.cpp and panel.cpp to add support for .srm save files (same binaries as .sav) if they exist, for both saving and loading.

Writing and reading will use .sav if found or if there's no save file, and .srm if it found .srm instead of .sav.

Updated installdeps to use correct package names for SDL3 and wxWidgets for Windows.