### PR TITLE
Add Game Boy Player SIO rumble support

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -124,6 +124,8 @@ if(ENABLE_LINK)
     target_sources(vbam-core
         PRIVATE
         gba/gbaLink.cpp
+        gba/gbpSio.cpp
+        gba/gbpSio.h
         gba/internal/gbaSockClient.cpp
         gba/internal/gbaSockClient.h
 

--- a/src/core/base/system.h
+++ b/src/core/base/system.h
@@ -76,6 +76,7 @@ extern struct CoreOptions {
     int skipSaveGameCheats = 0;
     int useBios = 0;
     int gbPrinterEnabled = 0;
+    int gbpEnabled = 1;
     uint32_t speedup_throttle = 100;
     uint32_t speedup_frame_skip = 9;
     uint32_t throttle = 100;

--- a/src/core/gba/gba.cpp
+++ b/src/core/gba/gba.cpp
@@ -35,6 +35,7 @@
 
 #if !defined(NO_LINK)
 #include "core/gba/gbaLink.h"
+#include "core/gba/gbpSio.h"
 #endif  // !defined(NOLINK)
 
 #if !defined(__LIBRETRO__)
@@ -809,6 +810,17 @@ static inline void CPUTestIRQ(bool software_unmask = false)
                    ((armIrqEnable ? 1 : 0) << 22) |
                    (((int)IME & 1) << 23) |
                    ((software_unmask ? 1 : 0) << 24));
+}
+
+// Exposed for IF mutators living in other translation units -- currently
+// the GBP SIO module (gbpSio.cpp), which raises the serial IRQ on transfer
+// completion and must re-arm kSchedIrq just like the in-TU completion path
+// gbaScheduler_OnSioComplete() does. Without this, the raised IF.serial bit
+// is never delivered (the legacy end-of-CPULoop IRQ block was removed in the
+// scheduler rewrite).
+void CPUReevaluateIRQ()
+{
+    CPUTestIRQ();
 }
 
 // Scheduler callback: a pending SIO Normal-8/32 internal-clock transfer
@@ -4275,8 +4287,18 @@ void CPUUpdateRegister(uint32_t address, uint16_t value)
         const uint32_t mode       = (value >> 12) & 0x3u;
         const bool     start_edge = (value & 0x80) && !(old_siocnt & 0x80);
         const bool     internal   = (value & 0x01) != 0;
+        // The Game Boy Player runs its own SIO transfer machinery
+        // (GbpHandleSioStart / GbpLinkUpdateTick). Letting the generic
+        // kSchedSio completion also fire would double-handle the transfer
+        // and clobber the GBP handshake response, breaking rumble.
+#if !defined(NO_LINK)
+        const bool gbp_owns_sio = GbpWillHandleSio();
+#else
+        const bool gbp_owns_sio = false;
+#endif
         const bool cycle_accurate_path =
-            start_edge && rcnt_plain && internal && (mode == 0 || mode == 1);
+            start_edge && rcnt_plain && internal && (mode == 0 || mode == 1)
+            && !gbp_owns_sio;
         // [SIO] sio-cnt-write extra layout:
         //   bits  0..15 : raw value written (low 16 bits of `value`)
         //   bit   16    : start_edge -- bit-7 0->1 transition this write
@@ -5291,6 +5313,12 @@ void CPULoop(int ticks)
                                 CPUTestIRQ();
                             }
                             CPUCheckDMA(1, 0x0f);
+
+#ifndef NO_LINK
+                            if (coreOptions.gbpEnabled) {
+                                GBPUpdate();
+                            }
+#endif
                         }
 
                         UPDATE_REG(IO_REG_DISPSTAT, DISPSTAT);
@@ -5764,11 +5792,19 @@ void CPULoop(int ticks)
             ticks -= clockTicks;
 
 #ifndef NO_LINK
-            if (GetLinkMode() != LINK_DISCONNECTED)
+            if (GetLinkMode() != LINK_DISCONNECTED || GBPIsActive())
                 LinkUpdate(clockTicks);
 #endif
 
             cpuNextEvent = CPUUpdateTicks();
+
+#ifndef NO_LINK
+            {
+                int gbp_rem = GBPTransferEnd();
+                if (gbp_rem > 0 && gbp_rem < cpuNextEvent)
+                    cpuNextEvent = gbp_rem;
+            }
+#endif
 
             if (cpuDmaTicksToUpdate > 0) {
                 if (cpuDmaTicksToUpdate > cpuNextEvent)

--- a/src/core/gba/gbaCpu.h
+++ b/src/core/gba/gbaCpu.h
@@ -77,6 +77,11 @@ extern void CPUUndefinedException();
 extern void CPUSoftwareInterrupt();
 extern void CPUSoftwareInterrupt(int comment);
 
+// Re-arm the kSchedIrq scheduler event after IF/IE/IME have been mutated from
+// a translation unit that cannot see the file-local CPUTestIRQ() (e.g. the GBP
+// SIO module). Required for any externally-raised IRQ to actually be delivered.
+extern void CPUReevaluateIRQ();
+
 // Waitstates when accessing data
 inline int dataTicksAccess16(uint32_t address) // DATA 8/16bits NON SEQ
 {

--- a/src/core/gba/gbaLink.cpp
+++ b/src/core/gba/gbaLink.cpp
@@ -35,6 +35,8 @@
 #include "core/base/port.h"
 #include "core/gba/gba.h"
 #include "core/gba/gbaCpu.h"
+#include "core/gba/gbaGlobals.h"
+#include "core/gba/gbpSio.h"
 #include "core/gba/internal/gbaSockClient.h"
 
 #ifdef _MSC_VER
@@ -708,6 +710,11 @@ ConnectionState InitLink(LinkMode mode)
 
 void StartLink(uint16_t siocnt)
 {
+    if (GbpHandleSioStart(siocnt, cpuNextEvent)) {
+        UPDATE_REG(COMM_SIOCNT, siocnt);
+        return;
+    }
+
     if (!linkDriver || !linkDriver->start) {
         // Stand-alone (no real link cable) fallback. Some games rely on
         // SIOCNT being updated so they don't hang, so we have to commit
@@ -822,6 +829,8 @@ void StartGPLink(uint16_t value)
 
 void LinkUpdate(int ticks)
 {
+    GbpLinkUpdateTick(ticks);
+
     if (!linkDriver || !linkDriver->update) {
         return;
     }
@@ -845,6 +854,9 @@ void CheckLinkConnection()
 
 void CloseLink(void)
 {
+    // Reset GBP state unconditionally so rumble doesn't get stuck on.
+    GbpReset();
+
     if (!linkDriver || !linkDriver->close) {
         return; // Nothing to do
     }

--- a/src/core/gba/gbpSio.cpp
+++ b/src/core/gba/gbpSio.cpp
@@ -1,0 +1,375 @@
+#include "core/gba/gbpSio.h"
+
+#if defined(NO_LINK)
+#error "This file should not be compiled with NO_LINK."
+#endif  // defined(NO_LINK)
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include "core/base/port.h"
+#include "core/base/system.h"
+#include "core/gba/gba.h"
+#include "core/gba/gbaCpu.h"
+#include "core/gba/gbaGlobals.h"
+#include "core/gba/gbaLink.h"
+
+// same thing gbalink.cpp does
+#ifdef UPDATE_REG
+#undef UPDATE_REG
+#endif
+#define UPDATE_REG(address, value) WRITE16LE(((uint16_t*)&g_ioMem[address]), value)
+
+namespace {
+constexpr uint16_t kSioTransStart = 0x0080;
+constexpr uint16_t kSioIrqEnable  = 0x4000;
+
+constexpr int kGbpTransfersPerFrame = 17;
+
+// mgba uses 2048
+constexpr int kGbpInterTransferCycles = 2048;
+}  //namespace
+
+// ported from mGBA src/gba/sio/gbp.c
+// MurmurHash3 from mGBA src/util/hash.c, originally by Austin Appleby, public domain
+
+// transfer table from gbatek: https://problemkaputt.de/gbatek-gba-gameboy-player.htm
+static const uint32_t gbp_tx_data[] = {
+    0x0000494E,
+    0x0000494E,
+    0xB6B1494E,
+    0xB6B1544E,
+    0xABB1544E,
+    0xABB14E45,
+    0xB1BA4E45,
+    0xB1BA4F44,
+    0xB0BB4F44,
+    0xB0BB8002,
+    0x10000010,
+    0x20000013,
+    0x30000003,
+    0x30000003,
+    0x30000003,
+    0x30000003,
+    0x30000003,
+};
+
+// first 112 bytes of GBA paletteRAM when the GBP boot logo is on screen
+static const uint8_t gbp_logo_palette[112] = {
+    0xDF, 0xFF, 0x0C, 0x64, 0x0C, 0xE4, 0x2D, 0xE4,
+    0x4E, 0x64, 0x4E, 0xE4, 0x6E, 0xE4, 0xAF, 0x68,
+    0xB0, 0xE8, 0xD0, 0x68, 0xF0, 0x68, 0x11, 0x69,
+    0x11, 0xE9, 0x32, 0x6D, 0x32, 0xED, 0x73, 0xED,
+    0x93, 0x6D, 0x94, 0xED, 0xB4, 0x6D, 0xD5, 0xF1,
+    0xF5, 0x71, 0xF6, 0xF1, 0x16, 0x72, 0x57, 0x72,
+    0x57, 0xF6, 0x78, 0x76, 0x78, 0xF6, 0x99, 0xF6,
+    0xB9, 0xF6, 0xD9, 0x76, 0xDA, 0xF6, 0x1B, 0x7B,
+    0x1B, 0xFB, 0x3C, 0xFB, 0x5C, 0x7B, 0x7D, 0x7B,
+    0x7D, 0xFF, 0x9D, 0x7F, 0xBE, 0x7F, 0xFF, 0x7F,
+    0x2D, 0x64, 0x8E, 0x64, 0x8F, 0xE8, 0xF1, 0xE8,
+    0x52, 0x6D, 0x73, 0x6D, 0xB4, 0xF1, 0x16, 0xF2,
+    0x37, 0x72, 0x98, 0x76, 0xFA, 0x7A, 0xFA, 0xFA,
+    0x5C, 0xFB, 0xBE, 0xFF, 0xDE, 0x7F, 0xFF, 0xFF
+};
+
+// mgba compares against 0xEEDA6963 but vba-m pre-swaps 16-bit vram values internally
+static const uint32_t GBP_LOGO_HASH = 0xE6BC5CD1;
+
+// rumblepong (gba homebrew) seems to draw the gbp logo
+// in mode 3. I'm not aware of any retail game that does,
+// and mgba doesn't check for it, but it can be enabled
+// if needed
+#ifdef GBP_DETECT_MODE3
+static const uint32_t GBP_LOGO_HASH_MODE3 = 0xc13fffd9;
+#endif
+
+static bool gbp_active        = false;
+static int  gbp_tx_position   = 0;
+static int  gbp_transfer_end  = 0;  // countdown in CPU ticks until transfer done
+static bool gbp_rumble_state  = false;
+static int  gbp_inputs_posted = 0;  // cycles 0→1→2→0 each VBlank; at 2 we fake directions pressed
+
+
+static uint32_t gbp_transfers_this_frame     = 0;
+
+
+#ifdef GBP_SIO_DEBUG
+static uint32_t gbp_vblank_counter           = 0;
+static int      gbp_frames_since_last_irq    = 0;
+#endif
+
+// MurmurHash3_x86_32 (seed=0, little-endian), ported from mGBA src/util/hash.c
+static uint32_t gbp_murmur3(const uint8_t* data, size_t len)
+{
+    static const uint32_t c1 = 0xcc9e2d51u;
+    static const uint32_t c2 = 0x1b873593u;
+
+    uint32_t h1 = 0;
+    const int nblocks = (int)(len / 4);
+
+    for (int i = -nblocks; i; i++) {
+        uint32_t k1;
+        memcpy(&k1, data + ((size_t)(nblocks + i) * 4), 4);
+        // little-endian: no byte-swap needed on LE hosts; for BE hosts we swap
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+        k1 = ((k1 >> 24) & 0xFF) | ((k1 >> 8) & 0xFF00) |
+             ((k1 << 8) & 0xFF0000) | ((k1 << 24) & 0xFF000000u);
+#endif
+        k1 *= c1;
+        k1  = (k1 << 15) | (k1 >> 17);
+        k1 *= c2;
+
+        h1 ^= k1;
+        h1  = (h1 << 13) | (h1 >> 19);
+        h1  = h1 * 5 + 0xe6546b64u;
+    }
+
+    // tail bytes
+    const uint8_t* tail = data + (size_t)nblocks * 4;
+    uint32_t k1 = 0;
+    switch (len & 3) {
+    case 3: k1 ^= (uint32_t)tail[2] << 16; /* fall through */
+    case 2: k1 ^= (uint32_t)tail[1] << 8;  /* fall through */
+    case 1: k1 ^= tail[0];
+        k1 *= c1;
+        k1  = (k1 << 15) | (k1 >> 17);
+        k1 *= c2;
+        h1 ^= k1;
+    }
+
+    h1 ^= (uint32_t)len;
+    // fmix32
+    h1 ^= h1 >> 16; h1 *= 0x85ebca6bu;
+    h1 ^= h1 >> 13; h1 *= 0xc2b2ae35u;
+    h1 ^= h1 >> 16;
+    return h1;
+}
+
+static void GbpRumbleSet(bool enable)
+{
+    if (gbp_rumble_state == enable)
+        return;
+    gbp_rumble_state = enable;
+    systemCartridgeRumble(enable);
+#ifdef GBP_SIO_DEBUG
+    fprintf(stderr, "  >> rumble %s (VBlank %u, tx%u) <<\n",
+            enable ? "ON" : "OFF", gbp_vblank_counter, gbp_transfers_this_frame + 1);
+#endif
+}
+
+// is the gba currently displaying the gbp logo?
+static bool CheckGBPScreen()
+{
+    if (!g_paletteRAM || !g_vram)
+        return false;
+
+#ifdef GBP_DETECT_MODE3
+    uint16_t dispcnt = READ16LE(&g_ioMem[IO_REG_DISPCNT]);
+    if ((dispcnt & 0x7) == 3) {
+        return gbp_murmur3(&g_vram[0x4000], 0x4000) == GBP_LOGO_HASH_MODE3;
+    }
+#endif
+    // Hash the VRAM map region only after the cheaper palette compare passes.
+    if (memcmp(g_paletteRAM, gbp_logo_palette, sizeof(gbp_logo_palette)) != 0)
+        return false;
+    return gbp_murmur3(&g_vram[0x4000], 0x4000) == GBP_LOGO_HASH;
+}
+
+void GBPUpdate()
+{
+    // real gbp doesn't use the internal link if anything is connected to the external serial
+    if (GetLinkMode() != LINK_DISCONNECTED) {
+        if (gbp_active) {
+            gbp_active        = false;
+            gbp_transfer_end  = 0;
+            gbp_inputs_posted = 0;
+            GbpRumbleSet(false);
+            P1 = 0x03FF;
+            UPDATE_REG(IO_REG_KEYINPUT, P1);
+        }
+        return;
+    }
+
+    if (CheckGBPScreen()) {
+        if (!gbp_active) {
+#ifdef GBP_SIO_DEBUG
+            uint16_t dispcnt = READ16LE(&g_ioMem[IO_REG_DISPCNT]);
+            fprintf(stderr,
+                    "  >> GBP active=true (DISPCNT mode=%d) <<\n",
+                    dispcnt & 0x7);
+#endif
+            gbp_active        = true;
+            gbp_tx_position   = 0;
+            gbp_inputs_posted = 0;
+        }
+
+        gbp_inputs_posted = (gbp_inputs_posted + 1) % 3; //0 → 1 → 2 → 0
+        if (gbp_inputs_posted == 2) {
+            // clear bits 4-7 (Right/Left/Up/Down) = all pressed.
+            P1 = P1 & ~0x00F0u;
+        } else {
+            P1 = 0x03FF;  //nothing pressed
+        }
+        UPDATE_REG(IO_REG_KEYINPUT, P1);
+    } else if (gbp_inputs_posted != 0) {
+        // logo gone
+        gbp_inputs_posted = 0;
+        P1 = 0x03FF;
+        UPDATE_REG(IO_REG_KEYINPUT, P1);
+    }
+
+    // 12 step nintendo handshake then rumble data rx
+    if (gbp_active) {
+        gbp_tx_position = 0;
+#ifdef GBP_SIO_DEBUG
+        ++gbp_vblank_counter;
+        fprintf(stderr, "== VBlank %u ==\n", gbp_vblank_counter);
+
+        // stall watchdog + transfer-rate sampler
+        {
+            if (gbp_transfers_this_frame == 0) {
+                ++gbp_frames_since_last_irq;
+                if (gbp_frames_since_last_irq == 30) {
+                    fprintf(stderr,
+                            "  >> STALL: %d frames with no transfers (VBlank %u) <<\n",
+                            gbp_frames_since_last_irq, gbp_vblank_counter);
+                }
+            } else {
+                if (gbp_frames_since_last_irq >= 30) {
+                    fprintf(stderr,
+                            "  >> STALL RECOVERED after %d frames (VBlank %u) <<\n",
+                            gbp_frames_since_last_irq, gbp_vblank_counter);
+                }
+                gbp_frames_since_last_irq = 0;
+            }
+        }
+#endif
+        
+        gbp_transfers_this_frame = 0;
+    }
+}
+
+bool GBPIsActive()
+{
+    return gbp_transfer_end > 0;
+}
+
+bool GbpWillHandleSio()
+{
+    //same logic as GbpHandleSioStart
+    return gbp_active && coreOptions.gbpEnabled;
+}
+
+int GBPTransferEnd()
+{
+    return gbp_transfer_end;
+}
+
+bool GbpHandleSioStart(uint16_t siocnt, int& cpuNextEventRef)
+{
+    if (!gbp_active || !coreOptions.gbpEnabled)
+        return false;
+
+    // NORMAL_32 mode test, equivalent to GetSIOMode() == NORMAL32 in gbaLink.cpp:
+    //   RCNT bit 15 clear, SIOCNT bits 13:12 == 0b01.
+    uint16_t rcnt = READ16LE(&g_ioMem[COMM_RCNT]);
+    bool isNormal32 = !(rcnt & 0x8000) && ((siocnt & 0x3000) == 0x1000);
+
+    // match mGBA 0.10.5 (src/gba/sio/gbp.c _gbpSioWriteRegister): every
+    // SIOCNT write with START=1 unconditionally reschedules the transfer
+    // (mTimingDeschedule + mTimingSchedule(2048)).  
+    if (isNormal32 && (siocnt & kSioTransStart)) {
+        uint32_t rx = READ32LE(&g_ioMem[COMM_SIODATA32_L]);
+#ifdef GBP_SIO_DEBUG
+        {
+            int      clamped     = gbp_tx_position > 16 ? 16 : gbp_tx_position;
+            uint32_t tx_will_send = gbp_tx_data[clamped];
+            fprintf(stderr,
+                    "  arm  tx%u pos=%d siocnt=0x%04X rcnt=0x%04X rx=0x%08X "
+                    "tx_will_send=0x%08X ticks=%d\n",
+                    gbp_transfers_this_frame + 1, gbp_tx_position, siocnt, rcnt, rx,
+                    tx_will_send, cpuTotalTicks);
+        }
+#endif
+        if (gbp_tx_position >= 12) {
+            // 0x22 in bits [1:0] and [5:4] = rumble on; 0x00/0x11 = off.
+            // matches mGBA 0.10.5
+            // (src/gba/sio/gbp.c _gbpSioWriteRegister)
+            GbpRumbleSet((rx & 0x33u) == 0x22u);
+        }
+
+        // match mGBA's 2048 cycles
+        gbp_transfer_end = kGbpInterTransferCycles + cpuTotalTicks;
+        // Truncate the current CPULoop sub-period to the transfer
+        // deadline.  Without this, the gba.cpp event-block clip at
+        // GBPTransferEnd() only takes effect *for the next* sub-period
+        // — whatever older event sized the current one decides when the
+        // GBP transfer can actually fire, producing variable late
+        // transfers and the observed SIO state-machine stalls
+        // (long stretches of state_at_fire == 0 while the pattern
+        // engine re-asserts level=2).  Mirrors the role of
+        // mTimingSchedule's priority-queue insertion in mGBA.
+        int rel = gbp_transfer_end - cpuTotalTicks;
+        if (rel < cpuNextEventRef) {
+            cpuNextEventRef = rel;
+        }
+    }
+    // always return true so we don't fall through to the normal SIO handler
+    return true;
+}
+
+void GbpLinkUpdateTick(int ticks)
+{
+    // cap to 17 transfers per frame, as stated on gbatek
+    if (gbp_active && gbp_transfer_end > 0 &&
+        gbp_transfers_this_frame < (uint32_t)kGbpTransfersPerFrame) {
+        gbp_transfer_end -= ticks;
+        if (gbp_transfer_end <= 0) {
+            gbp_transfer_end = 0;
+
+            // mgba wraps around to 0, should we do the same here?
+            int pos = gbp_tx_position;
+            if (pos > kGbpTransfersPerFrame - 1) {
+                pos = kGbpTransfersPerFrame - 1;
+            }
+            uint32_t tx = gbp_tx_data[pos];
+#ifdef GBP_SIO_DEBUG
+            {
+                uint32_t rx_at_fire = READ32LE(&g_ioMem[COMM_SIODATA32_L]);
+                fprintf(stderr,
+                        "  fire tx%u pos=%d rx=0x%08X tx=0x%08X ticks=%d\n",
+                        gbp_transfers_this_frame + 1, pos, rx_at_fire, tx, cpuTotalTicks);
+            }
+#endif
+            if (gbp_tx_position < kGbpTransfersPerFrame - 1) {
+                ++gbp_tx_position;
+            }
+            UPDATE_REG(COMM_SIODATA32_L, (uint16_t)(tx & 0xFFFFu));
+            UPDATE_REG(COMM_SIODATA32_H, (uint16_t)(tx >> 16));
+            uint16_t cnt = READ16LE(&g_ioMem[COMM_SIOCNT]) & (uint16_t)~kSioTransStart;
+            UPDATE_REG(COMM_SIOCNT, cnt);
+            if (cnt & kSioIrqEnable) {
+                IF |= 0x80;
+                UPDATE_REG(IO_REG_IF, IF);
+                // the scheduler rewrite removed the
+                // end-of-CPULoop (IF & IE) check, so raising IF alone no
+                // longer delivers the serial IRQ -- it must be routed
+                // through the kSchedIrq scheduler, same as
+                // gbaScheduler_OnSioComplete().
+                CPUReevaluateIRQ();
+            }
+
+            gbp_transfers_this_frame++;
+        }
+    }
+}
+
+void GbpReset()
+{
+    gbp_active        = false;
+    gbp_tx_position   = 0;
+    gbp_transfer_end  = 0;
+    gbp_inputs_posted = 0;
+    GbpRumbleSet(false);
+}

--- a/src/core/gba/gbpSio.h
+++ b/src/core/gba/gbpSio.h
@@ -1,0 +1,72 @@
+#ifndef VBAM_CORE_GBA_GBPSIO_H_
+#define VBAM_CORE_GBA_GBPSIO_H_
+
+#include <cstdint>
+
+#if defined(NO_LINK)
+#error "This file should not be included with NO_LINK."
+#endif  // defined(NO_LINK)
+
+/**
+ * Called once per VBlank to detect the Game Boy Player boot screen and enable
+ * SIO rumble emulation when present.
+ */
+extern void GBPUpdate();
+
+/**
+ * Returns true while Game Boy Player SIO rumble emulation is active.
+ * Used to ensure LinkUpdate is ticked even when no link driver is in use.
+ */
+extern bool GBPIsActive();
+
+/**
+ * Returns the remaining CPU ticks until the in-flight GBP transfer completes,
+ * or 0 when no transfer is pending.  Read by the CPU event scheduler to clip
+ * cpuNextEvent so the transfer fires on time.
+ */
+extern int GBPTransferEnd();
+
+/**
+ * Handle the GBP branch of StartLink.  When the GBP screen has been detected,
+ * intercepts NORMAL_32 SIO transfers, decodes rumble commands from the data
+ * the game sends, anchors the transfer deadline, and clips cpuNextEvent to it.
+ *
+ * The cpuNextEvent reference parameter is load-bearing: the deadline anchor
+ * and the cpuNextEvent clip must remain atomic with one another.  See the
+ * comment block inside the implementation for the full rationale.
+ *
+ * @param siocnt          The value of SIOCNT being written
+ * @param cpuNextEventRef Reference to the CPU event scheduler's deadline
+ * @return true if GBP consumed the transfer.  When true, the caller must
+ *         UPDATE_REG(COMM_SIOCNT, siocnt) and return without falling through
+ *         to any other link driver's start path.
+ */
+extern bool GbpHandleSioStart(uint16_t siocnt, int& cpuNextEventRef);
+
+/**
+ * Returns true when the GBP module will consume a Normal SIO transfer started
+ * this instruction, i.e. the GBP screen is active and rumble emulation is
+ * enabled.  Used by the CPU's SIOCNT-write handler to suppress the generic
+ * cycle-accurate SIO completion path (kSchedSio), which would otherwise
+ * double-handle the transfer and clobber the GBP handshake response.
+ *
+ * Unlike GBPIsActive() (which is true only while a transfer is in flight),
+ * this reflects whether GBP owns the transfer at the START edge.
+ */
+extern bool GbpWillHandleSio();
+
+/**
+ * Handle the GBP branch of LinkUpdate.  Ticks the transfer countdown, fires
+ * the SIO completion IRQ when it expires, and (in GBP_SIO_DEBUG builds)
+ * samples the game's SIO-FSM state.  Safe to call unconditionally — early-outs
+ * when no GBP transfer is pending.
+ */
+extern void GbpLinkUpdateTick(int ticks);
+
+/**
+ * Reset all GBP SIO state.  Called from CloseLink so rumble doesn't get stuck
+ * on across ROM loads or link-mode transitions.
+ */
+extern void GbpReset();
+
+#endif  // VBAM_CORE_GBA_GBPSIO_H_

--- a/src/libretro/libretro.cpp
+++ b/src/libretro/libretro.cpp
@@ -1450,11 +1450,18 @@ static void update_variables_gba() {
         systemUpdateSolarSensor(sensorDarknessLevel);
     }
 
-    char options[4][35] = {
+    var.key = "vbam_gbpenabled";
+    var.value = NULL;
+    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+        coreOptions.gbpEnabled = !strcmp(var.value, "enabled");
+    }
+
+    char options[5][35] = {
         "vbam_soundinterpolation",
         "vbam_soundfiltering",
         "vbam_forceRTCenable",
         "vbam_solarsensor",
+        "vbam_gbpenabled"
     };
 
     struct retro_core_option_display option_display_gba;

--- a/src/libretro/libretro_core_options.h
+++ b/src/libretro/libretro_core_options.h
@@ -428,6 +428,20 @@ struct retro_core_option_v2_definition option_defs_us[] = {
         "0"
     },
     {
+        "vbam_gbpenabled",
+        "Enable Game Boy Player",
+        NULL,
+        "Enable Game Boy Player SIO emulation (handshake + rumble).",
+        NULL,
+        "system",
+        {
+            { "disabled", NULL },
+            { "enabled",  NULL },
+            { NULL, NULL },
+        },
+        "enabled"
+    },
+    {
         "vbam_astick_deadzone",
         "Sensors Deadzone (%)",
         NULL,

--- a/src/sdl/ConfigManager.cpp
+++ b/src/sdl/ConfigManager.cpp
@@ -199,6 +199,7 @@ struct option argOptions[] = {
 	{ "gb-frame-skip", required_argument, 0, OPT_GB_FRAME_SKIP },
 	{ "gb-palette-option", required_argument, 0, OPT_GB_PALETTE_OPTION },
 	{ "gb-printer", no_argument, &coreOptions.gbPrinterEnabled, 1 },
+	{ "gbp", no_argument, &coreOptions.gbpEnabled, 1 },
 	{ "gdb", required_argument, 0, 'G' },
 	{ "help", no_argument, &optPrintUsage, 1 },
 	{ "ifb-filter", required_argument, 0, 'I' },
@@ -364,6 +365,7 @@ void LoadConfig()
 	coreOptions.speedup_mute = ReadPref("speedupMute", 1);
 	coreOptions.useBios = ReadPrefHex("useBiosGBA");
 	coreOptions.gbPrinterEnabled = ReadPref("gbPrinter", 0);
+	coreOptions.gbpEnabled = ReadPref("gbpEnabled", 1);
 
 	int soundQuality = (ReadPrefHex("soundQuality", 1));
 	switch (soundQuality) {

--- a/src/wx/cmdevents.cpp
+++ b/src/wx/cmdevents.cpp
@@ -2663,6 +2663,11 @@ EVT_HANDLER_MASK(GBALcdFilter, "Enable LCD filter", CMDEN_GBA)
     GetMenuOptionConfig("GBALcdFilter", config::OptionID::kGBALCDFilter);
 }
 
+EVT_HANDLER_MASK(GBPEnabled, "Enable Game Boy Player", CMDEN_GBA)
+{
+    GetMenuOptionConfig("GBPEnabled", config::OptionID::kPrefGBPEnabled);
+}
+
 EVT_HANDLER_MASK(GBLcdFilter, "Enable LCD filter", CMDEN_GB)
 {
     GetMenuOptionConfig("GBLcdFilter", config::OptionID::kGBLCDFilter);

--- a/src/wx/config/internal/option-internal.cpp
+++ b/src/wx/config/internal/option-internal.cpp
@@ -389,6 +389,7 @@ std::array<Option, kNbOptions>& Option::All() {
         Option(OptionID::kPrefUseBiosGBA, &g_owned_opts.use_bios_file_gba),
         Option(OptionID::kPrefUseBiosGBC, &g_owned_opts.use_bios_file_gbc),
         Option(OptionID::kPrefVsync, &g_owned_opts.vsync),
+        Option(OptionID::kPrefGBPEnabled, &coreOptions.gbpEnabled, 0, 1),
 
         /// Geometry
         Option(OptionID::kGeomFullScreen, &g_owned_opts.fullscreen),
@@ -598,6 +599,7 @@ const std::array<OptionData, kNbOptions + 1> kAllOptionsData = {
     OptionData{"preferences/useBiosGBC", "BootRomGBC",
                _("Use the specified BIOS file for Game Boy Color")},
     OptionData{"preferences/vsync", "VSync", _("Wait for vertical sync")},
+    OptionData{"preferences/gbpEnabled", "GBPEnabled", _("Enable Game Boy Player")},
 
     /// Geometry
     OptionData{"geometry/fullScreen", "Fullscreen", _("Enter fullscreen mode at startup")},

--- a/src/wx/config/option-id.h
+++ b/src/wx/config/option-id.h
@@ -109,6 +109,7 @@ enum class OptionID {
     kPrefUseBiosGBA,
     kPrefUseBiosGBC,
     kPrefVsync,
+    kPrefGBPEnabled,
 
     /// Geometry
     kGeomFullScreen,

--- a/src/wx/config/option-proxy.h
+++ b/src/wx/config/option-proxy.h
@@ -113,6 +113,7 @@ static constexpr std::array<Option::Type, kNbOptions> kOptionsTypes = {
     /*kPrefUseBiosGBA*/ Option::Type::kBool,
     /*kPrefUseBiosGBC*/ Option::Type::kBool,
     /*kPrefVsync*/ Option::Type::kBool,
+    /*kPrefGBPEnabled*/ Option::Type::kInt,
 
     /// Geometry
     /*kGeomFullScreen*/ Option::Type::kBool,

--- a/src/wx/xrc/MainMenu.xrc
+++ b/src/wx/xrc/MainMenu.xrc
@@ -506,6 +506,10 @@
           <label>_LCD Filter</label>
           <checkable>1</checkable>
         </object>
+        <object class="wxMenuItem" name="GBPEnabled">
+          <label>Enable Game _Boy Player</label>
+          <checkable>1</checkable>
+        </object>
       </object>
       <object class="wxMenu">
         <label translate="0">_Game Boy</label>


### PR DESCRIPTION
Emulate the Game Boy Player's SIO handshake and rumble protocol so that GBP-aware GBA titles can drive controller rumble based off of mGBA's implementation

- Automatically turn off when something else is using the link port to match real GBP behavior
- Use existing rumble implementation for playback