### PR TITLE
Fix GDB remote output buffer bounds

### DIFF
--- a/src/core/gba/gbaRemote.cpp
+++ b/src/core/gba/gbaRemote.cpp
@@ -3663,21 +3663,22 @@ void remoteOutput(const char* s, uint32_t addr)
 
     if (s) {
         char c = *s++;
-        while (c) {
-            snprintf(d, (sizeof(buffer) - (d - buffer)), "%02x", c);
+        while (c && sizeof(buffer) - (d - buffer) >= 3) {
+            snprintf(d, (sizeof(buffer) - (d - buffer)), "%02x", (unsigned char)c);
             d += 2;
             c = *s++;
         }
     } else {
         char c = debuggerReadByte(addr);
         addr++;
-        while (c) {
-            snprintf(d, (sizeof(buffer) - (d - buffer)), "%02x", c);
+        while (c && sizeof(buffer) - (d - buffer) >= 3) {
+            snprintf(d, (sizeof(buffer) - (d - buffer)), "%02x", (unsigned char)c);
             d += 2;
             c = debuggerReadByte(addr);
             addr++;
         }
     }
+    *d = 0;
     remotePutPacket(buffer);
     //  fprintf(stderr, "Output sent %s\n", buffer);
 }


### PR DESCRIPTION
Prevents ROM-controlled debug output from writing past the fixed GDB
packet buffer during an active GDB session.

The output encoder now reserves space for each encoded byte and its
terminator, and encodes input bytes as unsigned values.

Validated with an ASan regression harness.