### PR TITLE
Validate TAMA5 command indices

### DIFF
--- a/src/core/gb/gbMemory.cpp
+++ b/src/core/gb/gbMemory.cpp
@@ -1498,7 +1498,7 @@ void mapperTAMA5RAM(uint16_t address, uint8_t value)
         } break;
         case 1: // 'Commands' Register
         {
-            gbDataTAMA5.mapperCommandNumber = value;
+            gbDataTAMA5.mapperCommandNumber = value & 0x0f;
             gbMemoryMap[0xa][1] = value;
 
             // This should be only a 'is the flashrom ready ?' command.


### PR DESCRIPTION
A TAMA5 ROM can supply a command value larger than the mapper command array. A following mapper write then indexes outside that array.

Mask the command selector to the mapper's four-bit command range before use.