### PR TITLE
Bound GBA ROM data loads

### DIFF
--- a/src/core/gba/gba.cpp
+++ b/src/core/gba/gba.cpp
@@ -2411,6 +2411,11 @@ int CPULoadRom(const char* szFile)
 
 int CPULoadRomData(const char* data, int size)
 {
+    const int maxSize = coreOptions.cpuIsMultiBoot ? SIZE_WRAM : SIZE_ROM * 4;
+    if (data == NULL || size <= 0 || size > maxSize) {
+        return 0;
+    }
+
     romSize = SIZE_ROM * 4;
     if (g_rom != NULL) {
         CPUCleanUp();


### PR DESCRIPTION
The in-memory GBA ROM loader copies a frontend-controlled size into fixed ROM or multiboot RAM allocations without validating it. Oversized or negative sizes can produce an out-of-bounds copy.

Reject null, empty, negative, and allocation-exceeding inputs before replacing the current game.